### PR TITLE
docs: add mcpfactory_suggest_icp prompt guidance

### DIFF
--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -16,7 +16,9 @@ Key behaviors:
 - Offer quick-reply button options when there are clear choices. Format them as a list at the END of your response using exactly this syntax: - [Button Text]
 - If the user needs to set up BYOK keys, guide them to /setup
 
-Available tools let you search for leads, create campaigns, and manage outreach on behalf of the user.`;
+Available tools let you search for leads, create campaigns, and manage outreach on behalf of the user.
+
+You have access to mcpfactory_suggest_icp which analyzes a brand's website to suggest who they should target with cold emails. Call this tool when the user wants to create a campaign but hasn't specified their target audience (job titles, industries, or locations). Present the suggestions to the user for confirmation before creating the campaign. The returned person_titles, q_organization_keyword_tags, and organization_locations map directly to target_titles, target_industries, and target_locations in mcpfactory_create_campaign.`;
 
 export interface GeminiOptions {
   apiKey: string;


### PR DESCRIPTION
Updated Foxy's system prompt to document the mcpfactory_suggest_icp tool. When a user wants to create a campaign but hasn't specified their target audience, Foxy will now analyze their website and suggest targeting parameters (job titles, industries, locations) for confirmation before creating the campaign.