### PR TITLE
upgrade: use Gemini 3 Flash as default model

### DIFF
--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -25,7 +25,7 @@ export interface GeminiOptions {
   model?: string;
 }
 
-export function createGeminiClient({ apiKey, model = "gemini-2.0-flash" }: GeminiOptions) {
+export function createGeminiClient({ apiKey, model = "gemini-3-flash-preview" }: GeminiOptions) {
   const genAI = new GoogleGenerativeAI(apiKey);
 
   return {

--- a/tests/unit/gemini.test.ts
+++ b/tests/unit/gemini.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from "vitest";
+
+const mockGetGenerativeModel = vi.fn().mockReturnValue({
+  startChat: () => ({
+    sendMessageStream: async () => ({
+      stream: (async function* () {})(),
+    }),
+  }),
+});
+
+vi.mock("@google/generative-ai", () => ({
+  GoogleGenerativeAI: vi.fn().mockImplementation(() => ({
+    getGenerativeModel: mockGetGenerativeModel,
+  })),
+  FunctionCallingMode: { AUTO: "AUTO" },
+}));
+
+import { createGeminiClient } from "../../src/lib/gemini.js";
+
+describe("createGeminiClient", () => {
+  it("defaults to gemini-3-flash-preview model", async () => {
+    const client = createGeminiClient({ apiKey: "test-key" });
+    const gen = client.streamChat([], "hello");
+    // consume the generator to trigger getGenerativeModel
+    for await (const _ of gen) {
+      /* drain */
+    }
+
+    expect(mockGetGenerativeModel).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "gemini-3-flash-preview" })
+    );
+  });
+
+  it("allows overriding the model", async () => {
+    const client = createGeminiClient({
+      apiKey: "test-key",
+      model: "gemini-3-pro-preview",
+    });
+    const gen = client.streamChat([], "hello");
+    for await (const _ of gen) {
+      /* drain */
+    }
+
+    expect(mockGetGenerativeModel).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "gemini-3-pro-preview" })
+    );
+  });
+});


### PR DESCRIPTION
Replace gemini-2.0-flash with gemini-3-flash-preview for better reasoning and agentic capabilities. Gemini 3 Flash offers frontier-level performance at faster inference speeds.