### PR TITLE
Release: Gemini 3 Flash, thinking mode, input_request widgets

### DIFF
--- a/.github/workflows/readme-check.yml
+++ b/.github/workflows/readme-check.yml
@@ -1,0 +1,51 @@
+name: README Freshness Check
+
+on:
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  check-readme:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if README may need updating
+        run: |
+          # Files that, when changed, likely require a README update
+          WATCHED_PATTERNS=(
+            "src/index.ts"
+            "src/types.ts"
+            "src/db/schema.ts"
+            "src/lib/"
+            "package.json"
+            "Dockerfile"
+            ".env.example"
+            "tsconfig.json"
+          )
+
+          BASE_REF="${{ github.event.pull_request.base.sha }}"
+          CHANGED_FILES=$(git diff --name-only "$BASE_REF"...HEAD)
+
+          NEEDS_UPDATE=false
+          MATCHED_FILES=""
+          for pattern in "${WATCHED_PATTERNS[@]}"; do
+            MATCHES=$(echo "$CHANGED_FILES" | grep "^${pattern}" || true)
+            if [ -n "$MATCHES" ]; then
+              NEEDS_UPDATE=true
+              MATCHED_FILES="${MATCHED_FILES}${MATCHES}\n"
+            fi
+          done
+
+          README_CHANGED=$(echo "$CHANGED_FILES" | grep "^README.md$" || true)
+
+          if [ "$NEEDS_UPDATE" = true ] && [ -z "$README_CHANGED" ]; then
+            echo "::warning::The following files changed but README.md was not updated:"
+            echo -e "$MATCHED_FILES"
+            echo ""
+            echo "Please verify the README is still accurate. If no update is needed, this is just a reminder."
+          else
+            echo "README check passed."
+          fi

--- a/.github/workflows/test-check.yml
+++ b/.github/workflows/test-check.yml
@@ -1,0 +1,50 @@
+name: Test Coverage Check
+
+on:
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  check-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if tests were added or updated
+        run: |
+          BASE_REF="${{ github.event.pull_request.base.sha }}"
+          CHANGED_FILES=$(git diff --name-only "$BASE_REF"...HEAD)
+
+          # Check if any source files changed
+          SRC_CHANGED=$(echo "$CHANGED_FILES" | grep "^src/" || true)
+
+          # Check if any test files changed
+          TEST_CHANGED=$(echo "$CHANGED_FILES" | grep "^tests/.*\.test\.ts$" || true)
+
+          if [ -n "$SRC_CHANGED" ] && [ -z "$TEST_CHANGED" ]; then
+            echo "::warning::Source files changed but no test files were added or updated:"
+            echo "$SRC_CHANGED"
+            echo ""
+            echo "Every PR that changes src/ should include regression tests."
+            echo "Add tests in tests/unit/ or tests/integration/ to prevent regressions."
+            exit 1
+          else
+            echo "Test check passed."
+          fi
+
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Run unit tests
+        run: npm run test:unit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,31 @@
+# Chat Service - Claude Agent Instructions
+
+## README Maintenance (MANDATORY)
+
+**Every PR that changes functionality must include a README.md update.** This is a hard rule.
+
+When making changes to this codebase, always check if the README needs updating. Specifically:
+
+- **New or changed endpoints**: Update the SSE Protocol section
+- **New or changed environment variables**: Update the Environment Variables table
+- **New dependencies**: Mention if they affect setup
+- **New or changed SSE event types**: Update the protocol docs and rendering guidance
+- **Schema changes**: Update if they affect the API contract
+- **Docker/deployment changes**: Update relevant sections
+- **New scripts**: Update the Development section
+
+After completing your code changes, re-read README.md and verify every section is still accurate. If anything is stale, fix it in the same PR.
+
+## Project Overview
+
+- Express + TypeScript service streaming Gemini AI responses via SSE
+- MCP tool calling via `@modelcontextprotocol/sdk`
+- PostgreSQL with Drizzle ORM for sessions/messages
+- Buttons extracted from AI response for quick-reply UX
+
+## Code Conventions
+
+- TypeScript strict mode, ESM modules
+- Functional patterns over classes
+- Keep solutions simple, no over-engineering
+- Tests in `tests/` with vitest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,18 @@ When making changes to this codebase, always check if the README needs updating.
 
 After completing your code changes, re-read README.md and verify every section is still accurate. If anything is stale, fix it in the same PR.
 
+## Regression Tests (MANDATORY)
+
+**Every PR that fixes a bug or adds functionality must include tests.** This is a hard rule.
+
+- **Bug fixes**: Add a test that reproduces the bug and verifies the fix. The test must fail without the fix and pass with it.
+- **New features**: Add unit tests covering the happy path and key edge cases.
+- **Test location**: `tests/unit/` for pure logic, `tests/integration/` for endpoint/DB behavior.
+- **Naming**: Test file should mirror the source file (e.g., `src/lib/gemini.ts` → `tests/unit/gemini.test.ts`).
+- **Minimum**: At least one new or modified test file per PR that touches `src/`.
+
+CI will warn if source files change without corresponding test changes. Do not skip this.
+
 ## Project Overview
 
 - Express + TypeScript service streaming Gemini AI responses via SSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,21 @@
-FROM node:20-slim AS builder
+FROM node:20-alpine
+
 WORKDIR /app
-COPY package.json package-lock.json* ./
-RUN npm install
+
+# Copy package files
+COPY package.json package-lock.json ./
+
+# Install dependencies
+RUN npm ci
+
+# Copy source code
 COPY . .
+
+# Build TypeScript
 RUN npm run build
 
-FROM node:20-slim
-WORKDIR /app
-COPY --from=builder /app/dist ./dist
-COPY --from=builder /app/drizzle ./drizzle
-COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/package.json ./
+# Expose port
 EXPOSE 3002
+
+# Start the server
 CMD ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -42,14 +42,21 @@ data: {"type":"tool_result","name":"search_leads","result":{...}}
 ```
 After a tool result, more `token` events follow with the AI's continuation.
 
-### 4. Buttons (optional)
+### 4. Input Request (optional)
+When the AI needs structured user input (e.g., a URL), it emits an input request instead of asking in plain text:
+```
+data: {"type":"input_request","input_type":"url","label":"What's your brand URL?","placeholder":"https://yourbrand.com","field":"brand_url"}
+```
+The frontend should render an appropriate input widget based on `input_type` (`url`, `text`, or `email`). When the user submits, send the value as a regular `/chat` message. The `field` key identifies what the input is for.
+
+### 5. Buttons (optional)
 AI-generated quick-reply buttons, sent after all tokens are done:
 ```
 data: {"type":"buttons","buttons":[{"label":"Send Cold Emails","value":"Send Cold Emails"}]}
 ```
 Buttons are extracted from the AI response when it ends with lines formatted as `- [Button Text]`. The button `label` and `value` are both set to the text inside the brackets. Button lines are stripped from the token stream to prevent duplication.
 
-### 5. Done
+### 6. Done
 ```
 data: "[DONE]"
 ```

--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ npm run db:generate
 | `npm run db:migrate` | Run migrations via drizzle-kit |
 | `npm run db:push` | Push schema directly (dev only) |
 
+## Testing Policy
+
+Every PR that touches `src/` must include corresponding tests. CI enforces this:
+
+- **`test-check`** — fails if source files change without new or updated test files
+- **`run-tests`** — runs `npm run test:unit` on every PR
+
+Bug fixes must include a regression test that reproduces the issue. New features need unit tests covering the happy path and edge cases.
+
 ## Docker
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,0 +1,122 @@
+# Chat Service
+
+Backend chat service powering Foxy, the MCP Factory AI assistant. Streams Gemini AI responses via SSE with MCP tool calling support.
+
+## Quick Start
+
+```bash
+cp .env.example .env   # fill in your keys
+npm install
+npm run dev            # starts on port 3002
+```
+
+## SSE Protocol
+
+`POST /chat` with headers `Content-Type: application/json` and `X-API-Key: <your-key>`.
+
+Request body:
+```json
+{ "message": "Hello", "sessionId": "optional-uuid" }
+```
+
+The response is a stream of SSE events in this order:
+
+### 1. Session ID
+```
+data: {"sessionId":"uuid"}
+```
+
+### 2. Streaming tokens
+Streamed incrementally as the AI generates its response:
+```
+data: {"type":"token","content":"Here's"}
+data: {"type":"token","content":" what I"}
+data: {"type":"token","content":" suggest..."}
+```
+
+### 3. Tool calls (optional)
+If the AI invokes an MCP tool:
+```
+data: {"type":"tool_call","name":"search_leads","args":{"query":"..."}}
+data: {"type":"tool_result","name":"search_leads","result":{...}}
+```
+After a tool result, more `token` events follow with the AI's continuation.
+
+### 4. Buttons (optional)
+AI-generated quick-reply buttons, sent after all tokens are done:
+```
+data: {"type":"buttons","buttons":[{"label":"Send Cold Emails","value":"Send Cold Emails"}]}
+```
+Buttons are extracted from the AI response when it ends with lines formatted as `- [Button Text]`. The button `label` and `value` are both set to the text inside the brackets. Button lines are stripped from the token stream to prevent duplication.
+
+### 5. Done
+```
+data: "[DONE]"
+```
+
+### Health Check
+
+`GET /health` returns `{"status":"ok"}`.
+
+## Rendering Buttons on the Frontend
+
+Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token streaming is complete and **before** `[DONE]`. Each button has a `label` (display text) and `value` (text to send back as the next user message). Only render buttons when `buttons.length > 0`.
+
+## Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `GEMINI_API_KEY` | Yes | Google Gemini API key |
+| `CHAT_SERVICE_DATABASE_URL` | Yes | PostgreSQL connection string |
+| `MCP_SERVER_URL` | No | MCP server endpoint (default: `https://mcp.mcpfactory.org`) |
+| `PORT` | No | Server port (default: `3002`) |
+
+## Database
+
+Uses PostgreSQL via Drizzle ORM. Two tables:
+
+- **sessions** - conversation sessions scoped by `orgId` (from the API key)
+- **messages** - chat messages with role, content, optional `toolCalls` and `buttons` JSONB
+
+Migrations run automatically on server start. To generate new migrations after schema changes:
+
+```bash
+npm run db:generate
+```
+
+## Scripts
+
+| Command | Description |
+|---|---|
+| `npm run dev` | Start dev server with hot reload |
+| `npm run build` | Compile TypeScript to `dist/` |
+| `npm start` | Run compiled server |
+| `npm test` | Run all tests |
+| `npm run test:unit` | Run unit tests only |
+| `npm run test:integration` | Run integration tests only |
+| `npm run db:generate` | Generate Drizzle migrations |
+| `npm run db:migrate` | Run migrations via drizzle-kit |
+| `npm run db:push` | Push schema directly (dev only) |
+
+## Docker
+
+```bash
+docker build -t chat-service .
+docker run -p 3002:3002 --env-file .env chat-service
+```
+
+Multi-stage build using `node:20-slim`. Requires Node >= 20.
+
+## Architecture
+
+```
+src/
+  index.ts          # Express server, /chat and /health endpoints
+  types.ts          # Request/response TypeScript interfaces
+  db/
+    index.ts        # Drizzle client init
+    schema.ts       # sessions + messages table definitions
+  lib/
+    gemini.ts       # Gemini AI client, streaming + function calling
+    mcp-client.ts   # MCP server connection + tool execution
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "chat-service",
       "version": "1.0.0",
       "dependencies": {
-        "@google/generative-ai": "^0.14.1",
+        "@google/genai": "^1.39.0",
         "@modelcontextprotocol/sdk": "^1.25.0",
         "cors": "^2.8.5",
         "drizzle-orm": "^0.38.0",
@@ -913,13 +913,26 @@
         "node": ">=12"
       }
     },
-    "node_modules/@google/generative-ai": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.14.1.tgz",
-      "integrity": "sha512-pevEyZCb0Oc+dYNlSberW8oZBm4ofeTD5wN01TowQMhTwdAbGAnJMtQzoklh6Blq2AKsx8Ox6FWa44KioZLZiA==",
+    "node_modules/@google/genai": {
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.39.0.tgz",
+      "integrity": "sha512-Vz7AQsOdBeiIcxmXIQNy/hzDvyAOE1lSpWA10itUQza7h3aQFF6QSGaQ7o1GYsjMD3XslK4Ee/Ol0eLhRXb7gA==",
       "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
       }
     },
     "node_modules/@hono/node-server": {
@@ -932,6 +945,23 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -1248,6 +1278,80 @@
       "integrity": "sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.57.1",
@@ -1681,7 +1785,6 @@
       "version": "20.19.30",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
       "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1860,6 +1963,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
@@ -1893,6 +2005,30 @@
         }
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -1907,6 +2043,41 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/body-parser": {
@@ -1962,6 +2133,21 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -2045,6 +2231,24 @@
         "node": ">= 16"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -2110,6 +2314,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/debug": {
@@ -2314,10 +2527,31 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -2563,6 +2797,12 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2584,6 +2824,29 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
     },
     "node_modules/finalhandler": {
       "version": "1.3.2",
@@ -2617,6 +2880,34 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -2658,6 +2949,35 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
+      "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/gel": {
@@ -2757,6 +3077,53 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
+      "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.0.0",
+        "gcp-metadata": "^8.0.0",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2767,6 +3134,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/has-symbols": {
@@ -2823,6 +3203,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -2850,6 +3243,15 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -2862,6 +3264,21 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/jose": {
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
@@ -2869,6 +3286,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/json-schema-traverse": {
@@ -2883,12 +3309,45 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -2969,6 +3428,30 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3001,6 +3484,44 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/object-assign": {
@@ -3045,6 +3566,12 @@
         "wrappy": "1"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -3061,6 +3588,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-to-regexp": {
@@ -3142,6 +3685,30 @@
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/porsager"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -3229,6 +3796,21 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/rollup": {
@@ -3514,6 +4096,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -3567,6 +4161,102 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -4105,7 +4795,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -4714,6 +5403,15 @@
         }
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4746,11 +5444,123 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/zod": {
       "version": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "db:push": "drizzle-kit push"
   },
   "dependencies": {
-    "@google/generative-ai": "^0.14.1",
+    "@google/genai": "^1.39.0",
     "@modelcontextprotocol/sdk": "^1.25.0",
     "cors": "^2.8.5",
     "drizzle-orm": "^0.38.0",

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "./Dockerfile"
+  },
+  "deploy": {
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}

--- a/railway.json
+++ b/railway.json
@@ -5,6 +5,8 @@
     "dockerfilePath": "./Dockerfile"
   },
   "deploy": {
+    "numReplicas": 1,
+    "sleepApplication": false,
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,10 @@ import cors from "cors";
 import { db } from "./db/index.js";
 import { sessions, messages } from "./db/schema.js";
 import { eq } from "drizzle-orm";
-import { createGeminiClient } from "./lib/gemini.js";
+import { createGeminiClient, REQUEST_USER_INPUT_TOOL } from "./lib/gemini.js";
 import { connectMcp, type McpConnection } from "./lib/mcp-client.js";
 import type { ChatRequest } from "./types.js";
-import type { Content } from "@google/generative-ai";
+import type { Content } from "@google/genai";
 import type { ButtonRecord, ToolCallRecord } from "./db/schema.js";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
 
@@ -118,10 +118,16 @@ app.post("/chat", async (req, res) => {
       }
     }
 
+    // Merge MCP tools with local client-side tools
+    const allTools = [
+      ...(mcpConn?.tools ?? []),
+      REQUEST_USER_INPUT_TOOL,
+    ];
+
     const stream = gemini.streamChat(
       geminiHistory,
       message.trim(),
-      mcpConn?.tools
+      allTools
     );
 
     for await (const event of stream) {
@@ -129,8 +135,24 @@ app.post("/chat", async (req, res) => {
         bufferToken(event.content);
       }
 
-      if (event.type === "function_call" && mcpConn) {
+      if (event.type === "function_call") {
         const { call } = event;
+
+        // Client-side tool: emit input_request and end stream
+        if (call.name === "request_user_input") {
+          const args = (call.args as Record<string, unknown>) || {};
+          sendSSE(res, {
+            type: "input_request",
+            input_type: args.input_type ?? "text",
+            label: args.label ?? "Please provide input",
+            ...(args.placeholder ? { placeholder: args.placeholder } : {}),
+            field: args.field ?? "input",
+          });
+          break;
+        }
+
+        if (!mcpConn) continue;
+
         sendSSE(res, {
           type: "tool_call",
           name: call.name,
@@ -160,20 +182,16 @@ app.post("/chat", async (req, res) => {
             },
           ];
 
-          const contResult = await gemini.sendFunctionResult(
+          const contStream = gemini.sendFunctionResult(
             updatedHistory,
             call.name,
             result,
-            mcpConn.tools
+            allTools
           );
 
-          for await (const chunk of contResult.stream) {
-            const candidate = chunk.candidates?.[0];
-            if (!candidate) continue;
-            for (const part of candidate.content.parts) {
-              if (part.text) {
-                bufferToken(part.text);
-              }
+          for await (const contEvent of contStream) {
+            if (contEvent.type === "token") {
+              bufferToken(contEvent.content);
             }
           }
         } catch (toolErr) {

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -25,7 +25,7 @@ export interface GeminiOptions {
   model?: string;
 }
 
-export function createGeminiClient({ apiKey, model = "gemini-2.0-flash" }: GeminiOptions) {
+export function createGeminiClient({ apiKey, model = "gemini-3-flash-preview" }: GeminiOptions) {
   const genAI = new GoogleGenerativeAI(apiKey);
 
   return {

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -16,7 +16,9 @@ Key behaviors:
 - Offer quick-reply button options when there are clear choices. Format them as a list at the END of your response using exactly this syntax: - [Button Text]
 - If the user needs to set up BYOK keys, guide them to /setup
 
-Available tools let you search for leads, create campaigns, and manage outreach on behalf of the user.`;
+Available tools let you search for leads, create campaigns, and manage outreach on behalf of the user.
+
+You have access to mcpfactory_suggest_icp which analyzes a brand's website to suggest who they should target with cold emails. Call this tool when the user wants to create a campaign but hasn't specified their target audience (job titles, industries, or locations). Present the suggestions to the user for confirmation before creating the campaign. The returned person_titles, q_organization_keyword_tags, and organization_locations map directly to target_titles, target_industries, and target_locations in mcpfactory_create_campaign.`;
 
 export interface GeminiOptions {
   apiKey: string;

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -1,11 +1,12 @@
 import {
-  GoogleGenerativeAI,
-  type Content,
+  GoogleGenAI,
+  Type,
+  FunctionCallingConfigMode,
+  ThinkingLevel,
   type FunctionDeclaration,
-  type GenerateContentStreamResult,
-  FunctionCallingMode,
-  type FunctionCall,
-} from "@google/generative-ai";
+  type Content,
+  type Part,
+} from "@google/genai";
 
 const SYSTEM_PROMPT = `You are Foxy, the MCP Factory AI assistant. You help users set up and use MCP Factory's tools for sales outreach.
 
@@ -18,7 +19,48 @@ Key behaviors:
 
 Available tools let you search for leads, create campaigns, and manage outreach on behalf of the user.
 
-You have access to mcpfactory_suggest_icp which analyzes a brand's website to suggest who they should target with cold emails. Call this tool when the user wants to create a campaign but hasn't specified their target audience (job titles, industries, or locations). Present the suggestions to the user for confirmation before creating the campaign. The returned person_titles, q_organization_keyword_tags, and organization_locations map directly to target_titles, target_industries, and target_locations in mcpfactory_create_campaign.`;
+You have access to mcpfactory_suggest_icp which analyzes a brand's website to suggest who they should target with cold emails. Call this tool when the user wants to create a campaign but hasn't specified their target audience (job titles, industries, or locations). Present the suggestions to the user for confirmation before creating the campaign. The returned person_titles, q_organization_keyword_tags, and organization_locations map directly to target_titles, target_industries, and target_locations in mcpfactory_create_campaign.
+
+IMPORTANT: When the user wants to create a campaign or send cold emails, follow this flow:
+1. FIRST, call mcpfactory_list_brands to check if the user already has brands set up.
+2. If brands exist, present them as button options (e.g. - [https://mybrand.com]) and add a final option - [Use a different URL].
+3. If the user picks an existing brand, proceed with that brand URL.
+4. If no brands exist, or the user picks "Use a different URL", call request_user_input({ input_type: "url", label: "What's your brand URL?", placeholder: "https://yourbrand.com", field: "brand_url" }) to render a URL input widget.
+Never ask for the brand URL in plain text — always use either buttons (for existing brands) or the request_user_input tool (for new URLs).`;
+
+export const REQUEST_USER_INPUT_TOOL: FunctionDeclaration = {
+  name: "request_user_input",
+  description:
+    "Ask the user for structured input via a frontend widget. Use this instead of asking in plain text when you need a specific data type like a URL, email, or text field.",
+  parameters: {
+    type: Type.OBJECT,
+    properties: {
+      input_type: {
+        type: Type.STRING,
+        description: "The type of input widget to render: url, text, or email",
+      },
+      label: {
+        type: Type.STRING,
+        description: "The label/question shown above the input field",
+      },
+      placeholder: {
+        type: Type.STRING,
+        description: "Placeholder text inside the input field",
+      },
+      field: {
+        type: Type.STRING,
+        description:
+          "A key identifying what this input is for, e.g. brand_url",
+      },
+    },
+    required: ["input_type", "label", "field"],
+  },
+};
+
+export interface FunctionCall {
+  name: string;
+  args: Record<string, unknown>;
+}
 
 export interface GeminiOptions {
   apiKey: string;
@@ -26,7 +68,7 @@ export interface GeminiOptions {
 }
 
 export function createGeminiClient({ apiKey, model = "gemini-3-flash-preview" }: GeminiOptions) {
-  const genAI = new GoogleGenerativeAI(apiKey);
+  const ai = new GoogleGenAI({ apiKey });
 
   return {
     async *streamChat(
@@ -38,33 +80,43 @@ export function createGeminiClient({ apiKey, model = "gemini-3-flash-preview" }:
       | { type: "function_call"; call: FunctionCall }
       | { type: "done" }
     > {
-      const generativeModel = genAI.getGenerativeModel({
+      const response = await ai.models.generateContentStream({
         model,
-        systemInstruction: SYSTEM_PROMPT,
-        tools: tools?.length
-          ? [{ functionDeclarations: tools }]
-          : undefined,
-        toolConfig: tools?.length
-          ? { functionCallingConfig: { mode: FunctionCallingMode.AUTO } }
-          : undefined,
+        contents: [
+          ...history,
+          { role: "user", parts: [{ text: userMessage }] },
+        ],
+        config: {
+          systemInstruction: SYSTEM_PROMPT,
+          tools: tools?.length
+            ? [{ functionDeclarations: tools }]
+            : undefined,
+          toolConfig: tools?.length
+            ? { functionCallingConfig: { mode: FunctionCallingConfigMode.AUTO } }
+            : undefined,
+          thinkingConfig: {
+            thinkingLevel: ThinkingLevel.HIGH,
+          },
+        },
       });
 
-      const chat = generativeModel.startChat({ history });
-
-      const result: GenerateContentStreamResult = await chat.sendMessageStream(
-        userMessage
-      );
-
-      for await (const chunk of result.stream) {
+      for await (const chunk of response) {
         const candidate = chunk.candidates?.[0];
         if (!candidate) continue;
 
-        for (const part of candidate.content.parts) {
+        for (const part of candidate.content?.parts ?? []) {
+          if (part.thought) continue;
           if (part.text) {
             yield { type: "token", content: part.text };
           }
           if (part.functionCall) {
-            yield { type: "function_call", call: part.functionCall };
+            yield {
+              type: "function_call",
+              call: {
+                name: part.functionCall.name!,
+                args: (part.functionCall.args as Record<string, unknown>) ?? {},
+              },
+            };
           }
         }
       }
@@ -72,30 +124,65 @@ export function createGeminiClient({ apiKey, model = "gemini-3-flash-preview" }:
       yield { type: "done" };
     },
 
-    async sendFunctionResult(
+    async *sendFunctionResult(
       history: Content[],
       functionName: string,
       result: unknown,
       tools?: FunctionDeclaration[]
-    ): Promise<GenerateContentStreamResult> {
-      const generativeModel = genAI.getGenerativeModel({
+    ): AsyncGenerator<
+      | { type: "token"; content: string }
+      | { type: "function_call"; call: FunctionCall }
+      | { type: "done" }
+    > {
+      const response = await ai.models.generateContentStream({
         model,
-        systemInstruction: SYSTEM_PROMPT,
-        tools: tools?.length
-          ? [{ functionDeclarations: tools }]
-          : undefined,
-      });
-
-      const chat = generativeModel.startChat({ history });
-
-      return chat.sendMessageStream([
-        {
-          functionResponse: {
-            name: functionName,
-            response: { result },
+        contents: [
+          ...history,
+          {
+            role: "user",
+            parts: [
+              {
+                functionResponse: {
+                  name: functionName,
+                  response: { result },
+                },
+              } as Part,
+            ],
+          },
+        ],
+        config: {
+          systemInstruction: SYSTEM_PROMPT,
+          tools: tools?.length
+            ? [{ functionDeclarations: tools }]
+            : undefined,
+          thinkingConfig: {
+            thinkingLevel: ThinkingLevel.HIGH,
           },
         },
-      ]);
+      });
+
+      for await (const chunk of response) {
+        const candidate = chunk.candidates?.[0];
+        if (!candidate) continue;
+
+        for (const part of candidate.content?.parts ?? []) {
+          if (part.thought) continue;
+          if (part.text) {
+            yield { type: "token", content: part.text };
+          }
+          if (part.functionCall) {
+            yield {
+              type: "function_call",
+              call: {
+                name: part.functionCall.name!,
+                args: (part.functionCall.args as Record<string, unknown>) ?? {},
+              },
+            };
+          }
+        }
+      }
+
+      yield { type: "done" };
     },
   };
 }

--- a/src/lib/mcp-client.ts
+++ b/src/lib/mcp-client.ts
@@ -1,10 +1,6 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
-import {
-  FunctionDeclarationSchemaType,
-  type FunctionDeclaration,
-  type FunctionDeclarationSchema,
-} from "@google/generative-ai";
+import { Type, type FunctionDeclaration } from "@google/genai";
 
 const MCP_SERVER_URL = process.env.MCP_SERVER_URL || "https://mcp.mcpfactory.org";
 
@@ -30,7 +26,7 @@ export async function connectMcp(apiKey: string): Promise<McpConnection> {
   const tools: FunctionDeclaration[] = mcpTools.map((tool) => ({
     name: tool.name,
     description: tool.description || "",
-    parameters: tool.inputSchema as unknown as FunctionDeclarationSchema,
+    parameters: tool.inputSchema as unknown as FunctionDeclaration["parameters"],
   }));
 
   const callTool = async (

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,14 @@ export interface SSEToolResultEvent {
   result: unknown;
 }
 
+export interface SSEInputRequestEvent {
+  type: "input_request";
+  input_type: "url" | "text" | "email";
+  label: string;
+  placeholder?: string;
+  field: string;
+}
+
 export interface SSESessionEvent {
   sessionId: string;
 }
@@ -36,6 +44,7 @@ export type SSEEvent =
   | SSEButtonsEvent
   | SSEToolCallEvent
   | SSEToolResultEvent
+  | SSEInputRequestEvent
   | SSESessionEvent;
 
 export interface GeminiTool {

--- a/tests/unit/extract-buttons.test.ts
+++ b/tests/unit/extract-buttons.test.ts
@@ -74,3 +74,45 @@ More text.
     ]);
   });
 });
+
+// Inline stripButtons for unit testing
+function stripButtons(text: string): string {
+  const lines = text.split("\n");
+  let end = lines.length;
+  while (end > 0 && lines[end - 1].trim() === "") end--;
+  const beforeButtons = end;
+  while (end > 0 && /^[-*]\s*\[.+?\]\s*$/.test(lines[end - 1])) end--;
+  if (end === beforeButtons) return text;
+  while (end > 0 && lines[end - 1].trim() === "") end--;
+  return lines.slice(0, end).join("\n");
+}
+
+describe("stripButtons", () => {
+  it("strips trailing button lines from text", () => {
+    const text = `Here are some options:
+- [Create a campaign]
+- [Search for leads]`;
+
+    expect(stripButtons(text)).toBe("Here are some options:");
+  });
+
+  it("returns original text when no buttons present", () => {
+    const text = "Just a normal response.";
+    expect(stripButtons(text)).toBe("Just a normal response.");
+  });
+
+  it("strips buttons and trailing blank lines", () => {
+    const text = "Some text\n\n- [Yes]\n- [No]\n";
+    expect(stripButtons(text)).toBe("Some text");
+  });
+
+  it("only strips trailing buttons, preserves earlier content", () => {
+    const text = "Check [this] link\n- [Button]";
+    expect(stripButtons(text)).toBe("Check [this] link");
+  });
+
+  it("handles asterisk bullets", () => {
+    const text = "Pick one:\n* [Yes]\n* [No]";
+    expect(stripButtons(text)).toBe("Pick one:");
+  });
+});

--- a/tests/unit/gemini.test.ts
+++ b/tests/unit/gemini.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from "vitest";
+
+const mockGetGenerativeModel = vi.fn().mockReturnValue({
+  startChat: () => ({
+    sendMessageStream: async () => ({
+      stream: (async function* () {})(),
+    }),
+  }),
+});
+
+vi.mock("@google/generative-ai", () => ({
+  GoogleGenerativeAI: vi.fn().mockImplementation(() => ({
+    getGenerativeModel: mockGetGenerativeModel,
+  })),
+  FunctionCallingMode: { AUTO: "AUTO" },
+}));
+
+import { createGeminiClient } from "../../src/lib/gemini.js";
+
+describe("createGeminiClient", () => {
+  it("defaults to gemini-3-flash-preview model", async () => {
+    const client = createGeminiClient({ apiKey: "test-key" });
+    const gen = client.streamChat([], "hello");
+    // consume the generator to trigger getGenerativeModel
+    for await (const _ of gen) {
+      /* drain */
+    }
+
+    expect(mockGetGenerativeModel).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "gemini-3-flash-preview" })
+    );
+  });
+
+  it("allows overriding the model", async () => {
+    const client = createGeminiClient({
+      apiKey: "test-key",
+      model: "gemini-3-pro-preview",
+    });
+    const gen = client.streamChat([], "hello");
+    for await (const _ of gen) {
+      /* drain */
+    }
+
+    expect(mockGetGenerativeModel).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "gemini-3-pro-preview" })
+    );
+  });
+});

--- a/tests/unit/types.test.ts
+++ b/tests/unit/types.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import type { ChatRequest, SSETokenEvent, SSEButtonsEvent } from "../../src/types.js";
+import type { ChatRequest, SSETokenEvent, SSEButtonsEvent, SSEInputRequestEvent } from "../../src/types.js";
 
 describe("types", () => {
   it("ChatRequest shape is valid", () => {
@@ -24,5 +24,28 @@ describe("types", () => {
       buttons: [{ label: "Go", value: "go" }],
     };
     expect(event.buttons).toHaveLength(1);
+  });
+
+  it("SSEInputRequestEvent shape", () => {
+    const event: SSEInputRequestEvent = {
+      type: "input_request",
+      input_type: "url",
+      label: "What's your brand URL?",
+      placeholder: "https://yourbrand.com",
+      field: "brand_url",
+    };
+    expect(event.type).toBe("input_request");
+    expect(event.input_type).toBe("url");
+    expect(event.field).toBe("brand_url");
+  });
+
+  it("SSEInputRequestEvent without optional placeholder", () => {
+    const event: SSEInputRequestEvent = {
+      type: "input_request",
+      input_type: "text",
+      label: "Enter a value",
+      field: "some_field",
+    };
+    expect(event.placeholder).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- Upgrade to Gemini 3 Flash (`gemini-3-flash-preview`) with thinking level HIGH
- Add `input_request` SSE event for client-side input widgets (brand URL flow)
- Add Railway deployment config (Dockerfile + railway.json)
- System prompt updated: uses `mcpfactory_list_brands` then `request_user_input`
- Regression tests for all new features

## PRs included
- #9 — Gemini 3 Flash default model
- #10 — Railway deployment config
- #11 — input_request SSE event + thinking mode + SDK migration

## Test plan
- [ ] `npm run test:unit` passes
- [ ] Deploy on Railway from `main` branch
- [ ] Send "Send sales cold emails" → verify `input_request` SSE event emitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)