### PR TITLE
fix: switch MCP transport from SSE to Streamable HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,5 +134,5 @@ src/
     schema.ts       # sessions + messages table definitions
   lib/
     gemini.ts       # Gemini AI client, streaming + function calling
-    mcp-client.ts   # MCP server connection + tool execution
+    mcp-client.ts   # MCP server connection via Streamable HTTP transport + tool execution
 ```

--- a/src/lib/mcp-client.ts
+++ b/src/lib/mcp-client.ts
@@ -1,5 +1,5 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { Type, type FunctionDeclaration } from "@google/genai";
 
 const MCP_SERVER_URL = process.env.MCP_SERVER_URL || "https://mcp.mcpfactory.org";
@@ -12,7 +12,7 @@ export interface McpConnection {
 }
 
 export async function connectMcp(apiKey: string): Promise<McpConnection> {
-  const transport = new SSEClientTransport(new URL(`${MCP_SERVER_URL}/sse`), {
+  const transport = new StreamableHTTPClientTransport(new URL(`${MCP_SERVER_URL}/mcp`), {
     requestInit: {
       headers: { "X-API-Key": apiKey },
     },

--- a/tests/unit/mcp-client.test.ts
+++ b/tests/unit/mcp-client.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockConnect,
+  mockListTools,
+  mockCallTool,
+  mockClose,
+  MockStreamableHTTPClientTransport,
+} = vi.hoisted(() => ({
+  mockConnect: vi.fn().mockResolvedValue(undefined),
+  mockListTools: vi.fn().mockResolvedValue({
+    tools: [
+      {
+        name: "test_tool",
+        description: "A test tool",
+        inputSchema: { type: "object", properties: {} },
+      },
+    ],
+  }),
+  mockCallTool: vi.fn().mockResolvedValue({
+    content: [{ type: "text", text: "result" }],
+  }),
+  mockClose: vi.fn().mockResolvedValue(undefined),
+  MockStreamableHTTPClientTransport: vi.fn(),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: vi.fn().mockImplementation(() => ({
+    connect: mockConnect,
+    listTools: mockListTools,
+    callTool: mockCallTool,
+    close: mockClose,
+  })),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
+  StreamableHTTPClientTransport: MockStreamableHTTPClientTransport,
+}));
+
+import { connectMcp } from "../../src/lib/mcp-client.js";
+
+describe("connectMcp", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses StreamableHTTPClientTransport with /mcp endpoint", async () => {
+    await connectMcp("test-api-key");
+
+    expect(MockStreamableHTTPClientTransport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pathname: "/mcp",
+      }),
+      expect.objectContaining({
+        requestInit: {
+          headers: { "X-API-Key": "test-api-key" },
+        },
+      })
+    );
+  });
+
+  it("does not use legacy /sse endpoint", async () => {
+    await connectMcp("test-api-key");
+
+    const url = MockStreamableHTTPClientTransport.mock.calls[0][0] as URL;
+    expect(url.pathname).not.toBe("/sse");
+    expect(url.pathname).toBe("/mcp");
+  });
+
+  it("returns tools mapped to FunctionDeclaration format", async () => {
+    const conn = await connectMcp("test-api-key");
+
+    expect(conn.tools).toHaveLength(1);
+    expect(conn.tools[0]).toEqual({
+      name: "test_tool",
+      description: "A test tool",
+      parameters: { type: "object", properties: {} },
+    });
+  });
+
+  it("callTool delegates to MCP client", async () => {
+    const conn = await connectMcp("test-api-key");
+    const result = await conn.callTool("test_tool", { arg: "value" });
+
+    expect(mockCallTool).toHaveBeenCalledWith({
+      name: "test_tool",
+      arguments: { arg: "value" },
+    });
+    expect(result).toEqual([{ type: "text", text: "result" }]);
+  });
+
+  it("close delegates to MCP client", async () => {
+    const conn = await connectMcp("test-api-key");
+    await conn.close();
+
+    expect(mockClose).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- The MCP server at `mcp.mcpfactory.org` no longer serves the legacy `/sse` endpoint (returns 404), breaking MCP tool connections
- Switched from `SSEClientTransport` to `StreamableHTTPClientTransport` with `/mcp` endpoint, which is the current MCP transport specification
- Added unit tests for the MCP client covering transport setup, tool mapping, and delegation

## Test plan
- [x] New `tests/unit/mcp-client.test.ts` verifies `/mcp` endpoint is used (not `/sse`)
- [x] Tests cover tool mapping, callTool delegation, and close behavior
- [x] Full test suite passes (26/26 tests)
- [ ] Deploy and verify MCP tools connect successfully in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)