### PR TITLE
Add Neon branch-per-PR integration testing

### DIFF
--- a/.github/workflows/neon-cleanup.yml
+++ b/.github/workflows/neon-cleanup.yml
@@ -1,0 +1,16 @@
+name: Cleanup Neon Branch
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  delete-neon-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete Neon branch
+        uses: neondatabase/delete-branch-action@v3
+        with:
+          project_id: ${{ vars.NEON_PROJECT_ID }}
+          branch: pr-${{ github.event.number }}
+          api_key: ${{ secrets.NEON_API_KEY }}

--- a/.github/workflows/test-check.yml
+++ b/.github/workflows/test-check.yml
@@ -48,3 +48,33 @@ jobs:
 
       - name: Run unit tests
         run: npm run test:unit
+
+  test-integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Create Neon branch for PR
+        id: neon
+        uses: neondatabase/create-branch-action@v6
+        with:
+          project_id: ${{ vars.NEON_PROJECT_ID }}
+          branch_name: pr-${{ github.event.number }}
+          api_key: ${{ secrets.NEON_API_KEY }}
+
+      - name: Push schema to PR branch
+        run: npx drizzle-kit push --force
+        env:
+          CHAT_SERVICE_DATABASE_URL: ${{ steps.neon.outputs.db_url_pooled }}
+
+      - name: Run integration tests
+        run: npm run test:integration
+        env:
+          CHAT_SERVICE_DATABASE_URL: ${{ steps.neon.outputs.db_url_pooled }}

--- a/README.md
+++ b/README.md
@@ -102,8 +102,16 @@ npm run db:generate
 
 Every PR that touches `src/` must include corresponding tests. CI enforces this:
 
-- **`test-check`** — fails if source files change without new or updated test files
+- **`check-tests`** — fails if source files change without new or updated test files
 - **`run-tests`** — runs `npm run test:unit` on every PR
+- **`test-integration`** — creates an isolated Neon database branch per PR, pushes the schema, and runs `npm run test:integration`
+
+Integration tests use Neon's branch-per-PR pattern: each PR gets a copy-on-write database branch (`pr-<number>`), so concurrent PRs never interfere with each other. Branches are automatically deleted when the PR closes (via `neon-cleanup.yml`).
+
+**CI secrets/variables:**
+- `NEON_API_KEY` (secret) — Neon API key for branch creation/deletion
+- `NEON_PROJECT_ID` (variable) — Neon project ID (`billowing-art-88336019`)
+- `CHAT_SERVICE_DATABASE_URL_DEV` (secret) — dev database connection string
 
 Bug fixes must include a regression test that reproduces the issue. New features need unit tests covering the happy path and edge cases.
 

--- a/tests/integration/db.test.ts
+++ b/tests/integration/db.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { eq } from "drizzle-orm";
+import * as schema from "../../src/db/schema.js";
+
+const connectionString = process.env.CHAT_SERVICE_DATABASE_URL;
+
+describe("database integration", () => {
+  let client: ReturnType<typeof postgres>;
+  let db: ReturnType<typeof drizzle<typeof schema>>;
+
+  beforeAll(async () => {
+    if (!connectionString) {
+      throw new Error("CHAT_SERVICE_DATABASE_URL required for integration tests");
+    }
+    client = postgres(connectionString);
+    db = drizzle(client, { schema });
+  });
+
+  afterAll(async () => {
+    await client?.end();
+  });
+
+  it("should connect and query sessions table", async () => {
+    const rows = await db.select().from(schema.sessions).limit(1);
+    expect(Array.isArray(rows)).toBe(true);
+  });
+
+  it("should create, read, and delete a session", async () => {
+    const [created] = await db
+      .insert(schema.sessions)
+      .values({ orgId: "test-org-integration" })
+      .returning();
+
+    expect(created.id).toBeDefined();
+    expect(created.orgId).toBe("test-org-integration");
+    expect(created.createdAt).toBeInstanceOf(Date);
+
+    const [found] = await db
+      .select()
+      .from(schema.sessions)
+      .where(eq(schema.sessions.id, created.id));
+
+    expect(found).toBeDefined();
+    expect(found.id).toBe(created.id);
+
+    await db.delete(schema.sessions).where(eq(schema.sessions.id, created.id));
+
+    const [gone] = await db
+      .select()
+      .from(schema.sessions)
+      .where(eq(schema.sessions.id, created.id));
+
+    expect(gone).toBeUndefined();
+  });
+
+  it("should create a message linked to a session and cascade delete", async () => {
+    const [session] = await db
+      .insert(schema.sessions)
+      .values({ orgId: "test-org-msg" })
+      .returning();
+
+    const [message] = await db
+      .insert(schema.messages)
+      .values({
+        sessionId: session.id,
+        role: "user",
+        content: "integration test message",
+      })
+      .returning();
+
+    expect(message.id).toBeDefined();
+    expect(message.sessionId).toBe(session.id);
+    expect(message.role).toBe("user");
+    expect(message.content).toBe("integration test message");
+
+    // Cascade delete: removing session should remove its messages
+    await db.delete(schema.sessions).where(eq(schema.sessions.id, session.id));
+
+    const remaining = await db
+      .select()
+      .from(schema.messages)
+      .where(eq(schema.messages.id, message.id));
+
+    expect(remaining).toHaveLength(0);
+  });
+
+  it("should store and retrieve toolCalls and buttons JSONB", async () => {
+    const [session] = await db
+      .insert(schema.sessions)
+      .values({ orgId: "test-org-jsonb" })
+      .returning();
+
+    const toolCalls = [{ name: "search", args: { q: "test" }, result: { hits: 1 } }];
+    const buttons = [{ label: "Try again", value: "Try again" }];
+
+    const [message] = await db
+      .insert(schema.messages)
+      .values({
+        sessionId: session.id,
+        role: "assistant",
+        content: "Here are results",
+        toolCalls,
+        buttons,
+        tokenCount: 42,
+      })
+      .returning();
+
+    expect(message.toolCalls).toEqual(toolCalls);
+    expect(message.buttons).toEqual(buttons);
+    expect(message.tokenCount).toBe(42);
+
+    // Cleanup
+    await db.delete(schema.sessions).where(eq(schema.sessions.id, session.id));
+  });
+});


### PR DESCRIPTION
## Summary

Implements Neon's branch-per-PR pattern for isolated integration testing:

- Each PR creates its own Neon database branch (`pr-<number>`) via GitHub Actions
- Schema auto-pushes to the branch, tests run in isolation, branches auto-delete on PR close
- Prevents concurrent PR test interference (no shared database state)

## What Changed

- Split test job into separate `run-tests` (unit) and `test-integration` (Neon branch) jobs
- Added `.github/workflows/neon-cleanup.yml` to delete branches on PR close
- Updated README with new CI pattern and required secrets/variables

## Setup Required

GitHub secrets and variables already configured:
- `NEON_API_KEY` — Neon API key
- `NEON_PROJECT_ID` — Project ID (billowing-art-88336019)
- `CHAT_SERVICE_DATABASE_URL_DEV` — Dev database (for main-branch CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)