### PR TITLE
Merge dev to main: OpenAPI + MCP transport + testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ node_modules/
 dist/
 .env
 *.tgz
+openapi.json
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ data: "[DONE]"
 
 `GET /health` returns `{"status":"ok"}`.
 
+### OpenAPI Spec
+
+`GET /openapi.json` returns the auto-generated OpenAPI 3.0 specification. Used by the API Registry Service for automatic service discovery.
+
 ## Rendering Buttons on the Frontend
 
 Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token streaming is complete and **before** `[DONE]`. Each button has a `label` (display text) and `value` (text to send back as the next user message). Only render buttons when `buttons.length > 0`.
@@ -96,7 +100,8 @@ npm run db:generate
 | Command | Description |
 |---|---|
 | `npm run dev` | Start dev server with hot reload |
-| `npm run build` | Compile TypeScript to `dist/` |
+| `npm run build` | Compile TypeScript to `dist/` and generate `openapi.json` |
+| `npm run generate:openapi` | Regenerate `openapi.json` from route annotations |
 | `npm start` | Run compiled server |
 | `npm test` | Run all tests |
 | `npm run test:unit` | Run unit tests only |
@@ -135,7 +140,7 @@ Uses `node:20-alpine`. Requires Node >= 20.
 
 ```
 src/
-  index.ts          # Express server, /chat and /health endpoints
+  index.ts          # Express server, /chat, /health, and /openapi.json endpoints
   types.ts          # Request/response TypeScript interfaces
   db/
     index.ts        # Drizzle client init
@@ -143,4 +148,6 @@ src/
   lib/
     gemini.ts       # Gemini AI client, streaming + function calling
     mcp-client.ts   # MCP server connection via Streamable HTTP transport + tool execution
+scripts/
+  generate-openapi.ts  # Auto-generates openapi.json from route annotations
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "cors": "^2.8.5",
         "drizzle-orm": "^0.38.0",
         "express": "^4.21.0",
-        "postgres": "^3.4.0"
+        "postgres": "^3.4.0",
+        "swagger-autogen": "^2.23.7"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
@@ -1963,6 +1964,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2249,6 +2262,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -2350,6 +2369,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/depd": {
@@ -2927,6 +2955,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3228,6 +3262,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -3308,6 +3353,18 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/jwa": {
       "version": "2.0.1",
@@ -3579,6 +3636,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -4256,6 +4322,61 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/swagger-autogen": {
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/swagger-autogen/-/swagger-autogen-2.23.7.tgz",
+      "integrity": "sha512-vr7uRmuV0DCxWc0wokLJAwX3GwQFJ0jwN+AWk0hKxre2EZwusnkGSGdVFd82u7fQLgwSTnbWkxUL7HXuz5LTZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^7.4.1",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.7",
+        "json5": "^2.2.3"
+      }
+    },
+    "node_modules/swagger-autogen/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/swagger-autogen/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/swagger-autogen/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "dist/index.js",
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "build": "tsc",
+    "build": "tsc && npm run generate:openapi",
+    "generate:openapi": "tsx scripts/generate-openapi.ts",
     "start": "node dist/index.js",
     "test": "vitest run",
     "test:unit": "vitest run tests/unit",
@@ -22,7 +23,8 @@
     "cors": "^2.8.5",
     "drizzle-orm": "^0.38.0",
     "express": "^4.21.0",
-    "postgres": "^3.4.0"
+    "postgres": "^3.4.0",
+    "swagger-autogen": "^2.23.7"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -1,0 +1,26 @@
+import swaggerAutogen from "swagger-autogen";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const projectRoot = join(__dirname, "..");
+
+const doc = {
+  info: {
+    title: "Chat Service",
+    description:
+      "Backend chat service powering Foxy, the MCP Factory AI assistant. Streams Gemini AI responses via SSE with MCP tool calling support.",
+    version: "1.0.0",
+  },
+  host: process.env.SERVICE_URL || "http://localhost:3002",
+  basePath: "/",
+  schemes: ["https"],
+};
+
+const outputFile = join(projectRoot, "openapi.json");
+const routes = [join(projectRoot, "src/index.ts")];
+
+swaggerAutogen({ openapi: "3.0.0" })(outputFile, routes, doc).then(() => {
+  console.log("openapi.json generated");
+});

--- a/tests/unit/openapi.test.ts
+++ b/tests/unit/openapi.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { execSync } from "child_process";
+import { readFileSync, existsSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const projectRoot = join(__dirname, "..", "..");
+const openapiPath = join(projectRoot, "openapi.json");
+
+beforeAll(() => {
+  execSync("npx tsx scripts/generate-openapi.ts", { cwd: projectRoot });
+});
+
+describe("openapi.json", () => {
+  it("openapi.json is generated", () => {
+    expect(existsSync(openapiPath)).toBe(true);
+  });
+
+  it("is valid OpenAPI 3.0", () => {
+    const spec = JSON.parse(readFileSync(openapiPath, "utf-8"));
+    expect(spec.openapi).toBe("3.0.0");
+  });
+
+  it("has correct service info", () => {
+    const spec = JSON.parse(readFileSync(openapiPath, "utf-8"));
+    expect(spec.info.title).toBe("Chat Service");
+    expect(spec.info.version).toBe("1.0.0");
+  });
+
+  it("documents GET /health", () => {
+    const spec = JSON.parse(readFileSync(openapiPath, "utf-8"));
+    expect(spec.paths["/health"]).toBeDefined();
+    expect(spec.paths["/health"].get).toBeDefined();
+    expect(spec.paths["/health"].get.responses["200"]).toBeDefined();
+  });
+
+  it("documents POST /chat with request body and responses", () => {
+    const spec = JSON.parse(readFileSync(openapiPath, "utf-8"));
+    const chat = spec.paths["/chat"]?.post;
+    expect(chat).toBeDefined();
+    expect(chat.requestBody.content["application/json"]).toBeDefined();
+    expect(chat.responses["200"]).toBeDefined();
+    expect(chat.responses["401"]).toBeDefined();
+    expect(chat.responses["400"]).toBeDefined();
+  });
+
+  it("does not expose /openapi.json as a documented path", () => {
+    const spec = JSON.parse(readFileSync(openapiPath, "utf-8"));
+    expect(spec.paths["/openapi.json"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- **Add OpenAPI documentation endpoint** (#18) — `/openapi.json` for API Registry discovery
- **Switch MCP transport from legacy SSE to Streamable HTTP** (#14)
- **Add Neon branch-per-PR integration testing** (#15)
- **Update Docker base image docs to node:20-alpine** (#13)

## Test plan
- [ ] Verify `/openapi.json` returns valid OpenAPI 3.0 spec
- [ ] Verify `/health` and `/chat` endpoints still work
- [ ] Verify MCP tool calling works with Streamable HTTP transport

🤖 Generated with [Claude Code](https://claude.com/claude-code)