### PR TITLE
Migrate OpenAPI from swagger-autogen to zod-to-openapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ data: "[DONE]"
 
 ### OpenAPI Spec
 
-`GET /openapi.json` returns the auto-generated OpenAPI 3.0 specification. Used by the API Registry Service for automatic service discovery.
+`GET /openapi.json` returns the OpenAPI 3.0 specification generated from zod schemas via `@asteasolutions/zod-to-openapi`. Used by the API Registry Service for automatic service discovery.
 
 ## Rendering Buttons on the Frontend
 
@@ -101,7 +101,7 @@ npm run db:generate
 |---|---|
 | `npm run dev` | Start dev server with hot reload |
 | `npm run build` | Compile TypeScript to `dist/` and generate `openapi.json` |
-| `npm run generate:openapi` | Regenerate `openapi.json` from route annotations |
+| `npm run generate:openapi` | Regenerate `openapi.json` from zod schemas |
 | `npm start` | Run compiled server |
 | `npm test` | Run all tests |
 | `npm run test:unit` | Run unit tests only |
@@ -141,7 +141,8 @@ Uses `node:20-alpine`. Requires Node >= 20.
 ```
 src/
   index.ts          # Express server, /chat, /health, and /openapi.json endpoints
-  types.ts          # Request/response TypeScript interfaces
+  types.ts          # SSE event TypeScript interfaces
+  schemas.ts        # Zod schemas, OpenAPI registry, and request/response types
   db/
     index.ts        # Drizzle client init
     schema.ts       # sessions + messages table definitions
@@ -149,5 +150,5 @@ src/
     gemini.ts       # Gemini AI client, streaming + function calling
     mcp-client.ts   # MCP server connection via Streamable HTTP transport + tool execution
 scripts/
-  generate-openapi.ts  # Auto-generates openapi.json from route annotations
+  generate-openapi.ts  # Generates openapi.json from zod schemas via OpenApiGeneratorV3
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,14 @@
       "name": "chat-service",
       "version": "1.0.0",
       "dependencies": {
+        "@asteasolutions/zod-to-openapi": "^8.4.0",
         "@google/genai": "^1.39.0",
         "@modelcontextprotocol/sdk": "^1.25.0",
         "cors": "^2.8.5",
         "drizzle-orm": "^0.38.0",
         "express": "^4.21.0",
         "postgres": "^3.4.0",
-        "swagger-autogen": "^2.23.7"
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
@@ -27,6 +28,18 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@asteasolutions/zod-to-openapi": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@asteasolutions/zod-to-openapi/-/zod-to-openapi-8.4.0.tgz",
+      "integrity": "sha512-Ckp971tmTw4pnv+o7iK85ldBHBKk6gxMaoNyLn3c2Th/fKoTG8G3jdYuOanpdGqwlDB0z01FOjry2d32lfTqrA==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi3-ts": "^4.1.2"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
       }
     },
     "node_modules/@drizzle-team/brocli": {
@@ -1964,18 +1977,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2262,12 +2263,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "license": "MIT"
-    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -2369,15 +2364,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/deepmerge": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/depd": {
@@ -2955,12 +2941,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "license": "ISC"
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3262,17 +3242,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -3353,18 +3322,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
-    },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/jwa": {
       "version": "2.0.1",
@@ -3623,6 +3580,15 @@
         "wrappy": "1"
       }
     },
+    "node_modules/openapi3-ts": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.5.0.tgz",
+      "integrity": "sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.8.0"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -3636,15 +3602,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -4322,61 +4279,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/swagger-autogen": {
-      "version": "2.23.7",
-      "resolved": "https://registry.npmjs.org/swagger-autogen/-/swagger-autogen-2.23.7.tgz",
-      "integrity": "sha512-vr7uRmuV0DCxWc0wokLJAwX3GwQFJ0jwN+AWk0hKxre2EZwusnkGSGdVFd82u7fQLgwSTnbWkxUL7HXuz5LTZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^7.4.1",
-        "deepmerge": "^4.2.2",
-        "glob": "^7.1.7",
-        "json5": "^2.2.3"
-      }
-    },
-    "node_modules/swagger-autogen/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/swagger-autogen/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/swagger-autogen/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/tinybench": {
@@ -5681,6 +5583,21 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -18,13 +18,14 @@
     "db:push": "drizzle-kit push"
   },
   "dependencies": {
+    "@asteasolutions/zod-to-openapi": "^8.4.0",
     "@google/genai": "^1.39.0",
     "@modelcontextprotocol/sdk": "^1.25.0",
     "cors": "^2.8.5",
     "drizzle-orm": "^0.38.0",
     "express": "^4.21.0",
     "postgres": "^3.4.0",
-    "swagger-autogen": "^2.23.7"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -1,4 +1,6 @@
-import swaggerAutogen from "swagger-autogen";
+import { OpenApiGeneratorV3 } from "@asteasolutions/zod-to-openapi";
+import { registry } from "../src/schemas.js";
+import { writeFileSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 
@@ -6,21 +8,20 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const projectRoot = join(__dirname, "..");
 
-const doc = {
+const generator = new OpenApiGeneratorV3(registry.definitions);
+
+const document = generator.generateDocument({
+  openapi: "3.0.0",
   info: {
     title: "Chat Service",
     description:
       "Backend chat service powering Foxy, the MCP Factory AI assistant. Streams Gemini AI responses via SSE with MCP tool calling support.",
     version: "1.0.0",
   },
-  host: process.env.SERVICE_URL || "http://localhost:3002",
-  basePath: "/",
-  schemes: ["https"],
-};
-
-const outputFile = join(projectRoot, "openapi.json");
-const routes = [join(projectRoot, "src/index.ts")];
-
-swaggerAutogen({ openapi: "3.0.0" })(outputFile, routes, doc).then(() => {
-  console.log("openapi.json generated");
+  servers: [
+    { url: process.env.SERVICE_URL || "http://localhost:3002" },
+  ],
 });
+
+writeFileSync(join(projectRoot, "openapi.json"), JSON.stringify(document, null, 2));
+console.log("openapi.json generated");

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,0 +1,95 @@
+import { z } from "zod";
+import {
+  OpenAPIRegistry,
+  extendZodWithOpenApi,
+} from "@asteasolutions/zod-to-openapi";
+
+extendZodWithOpenApi(z);
+
+export const registry = new OpenAPIRegistry();
+
+// --- Shared schemas ---
+
+export const ErrorResponseSchema = z
+  .object({
+    error: z.string(),
+  })
+  .openapi("ErrorResponse");
+
+export const ValidationErrorResponseSchema = z
+  .object({
+    error: z.string(),
+    details: z.record(z.string(), z.unknown()).optional(),
+  })
+  .openapi("ValidationErrorResponse");
+
+// --- Health ---
+
+export const HealthResponseSchema = z
+  .object({
+    status: z.literal("ok"),
+  })
+  .openapi("HealthResponse");
+
+registry.registerPath({
+  method: "get",
+  path: "/health",
+  tags: ["Health"],
+  summary: "Health check",
+  description: "Returns service health status",
+  responses: {
+    200: {
+      description: "Service is healthy",
+      content: { "application/json": { schema: HealthResponseSchema } },
+    },
+  },
+});
+
+// --- Chat ---
+
+export const ChatRequestSchema = z
+  .object({
+    message: z.string().min(1, "message is required"),
+    sessionId: z.string().uuid().optional(),
+  })
+  .openapi("ChatRequest");
+
+export type ChatRequest = z.infer<typeof ChatRequestSchema>;
+
+registry.registerPath({
+  method: "post",
+  path: "/chat",
+  tags: ["Chat"],
+  summary: "Stream AI chat response",
+  description:
+    "Send a message and receive a streamed AI response via Server-Sent Events (SSE). Supports MCP tool calling and quick-reply buttons.",
+  request: {
+    headers: z.object({
+      "x-api-key": z.string().openapi({
+        description: "API key used to scope sessions by organization",
+      }),
+    }),
+    body: {
+      content: { "application/json": { schema: ChatRequestSchema } },
+    },
+  },
+  responses: {
+    200: {
+      description:
+        "SSE stream of chat events (token, tool_call, tool_result, input_request, buttons, [DONE])",
+      content: {
+        "text/event-stream": {
+          schema: z.string(),
+        },
+      },
+    },
+    400: {
+      description: "Missing or empty message",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    401: {
+      description: "Missing X-API-Key header",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});

--- a/tests/unit/openapi.test.ts
+++ b/tests/unit/openapi.test.ts
@@ -50,4 +50,19 @@ describe("openapi.json", () => {
     const spec = JSON.parse(readFileSync(openapiPath, "utf-8"));
     expect(spec.paths["/openapi.json"]).toBeUndefined();
   });
+
+  it("includes component schemas from zod definitions", () => {
+    const spec = JSON.parse(readFileSync(openapiPath, "utf-8"));
+    expect(spec.components?.schemas?.ChatRequest).toBeDefined();
+    expect(spec.components?.schemas?.HealthResponse).toBeDefined();
+    expect(spec.components?.schemas?.ErrorResponse).toBeDefined();
+  });
+
+  it("ChatRequest schema requires message field", () => {
+    const spec = JSON.parse(readFileSync(openapiPath, "utf-8"));
+    const chatReq = spec.components.schemas.ChatRequest;
+    expect(chatReq.required).toContain("message");
+    expect(chatReq.properties.message.type).toBe("string");
+    expect(chatReq.properties.sessionId.type).toBe("string");
+  });
 });

--- a/tests/unit/schemas.test.ts
+++ b/tests/unit/schemas.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { ChatRequestSchema } from "../../src/schemas.js";
+
+describe("ChatRequestSchema", () => {
+  it("accepts valid request with message only", () => {
+    const result = ChatRequestSchema.safeParse({ message: "Hello" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.message).toBe("Hello");
+      expect(result.data.sessionId).toBeUndefined();
+    }
+  });
+
+  it("accepts valid request with message and sessionId", () => {
+    const result = ChatRequestSchema.safeParse({
+      message: "Hello",
+      sessionId: "550e8400-e29b-41d4-a716-446655440000",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects empty message", () => {
+    const result = ChatRequestSchema.safeParse({ message: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing message", () => {
+    const result = ChatRequestSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-uuid sessionId", () => {
+    const result = ChatRequestSchema.safeParse({
+      message: "Hello",
+      sessionId: "not-a-uuid",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("strips extra fields", () => {
+    const result = ChatRequestSchema.safeParse({
+      message: "Hello",
+      extra: "field",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect((result.data as Record<string, unknown>).extra).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Replace `swagger-autogen` + comment annotations with `@asteasolutions/zod-to-openapi` for OpenAPI spec generation
- Zod schemas (`src/schemas.ts`) now serve as single source of truth for TypeScript types, runtime validation (`safeParse`), and OpenAPI docs
- `/chat` handler now uses `ChatRequestSchema.safeParse()` instead of manual `as` casts and `if` checks
- Generated spec is functionally equivalent to the previous one (same paths, schemas, responses)

## Test plan
- [x] `npm run build` compiles and generates `openapi.json` successfully
- [x] Generated spec has correct paths (`/health`, `/chat`), component schemas (`ChatRequest`, `HealthResponse`, `ErrorResponse`)
- [x] New `tests/unit/schemas.test.ts` covers ChatRequest validation (valid input, empty message, invalid UUID, extra fields)
- [x] Existing `tests/unit/openapi.test.ts` extended with component schema assertions
- [ ] CI: `check-tests` and `run-tests` should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)