### PR TITLE
Migrate auth from X-API-Key to Authorization Bearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm run dev            # starts on port 3002
 
 ## SSE Protocol
 
-`POST /chat` with headers `Content-Type: application/json` and `X-API-Key: <your-key>`.
+`POST /chat` with headers `Content-Type: application/json` and `Authorization: Bearer <your-key>`.
 
 Request body:
 ```json

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,9 +47,10 @@ app.get("/health", (_req, res) => {
 });
 
 app.post("/chat", async (req, res) => {
-  const apiKey = req.headers["x-api-key"] as string | undefined;
+  const authHeader = req.headers["authorization"];
+  const apiKey = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : undefined;
   if (!apiKey) {
-    return res.status(401).json({ error: "X-API-Key header required" });
+    return res.status(401).json({ error: "Authorization: Bearer <key> header required" });
   }
 
   const parsed = ChatRequestSchema.safeParse(req.body);

--- a/src/lib/mcp-client.ts
+++ b/src/lib/mcp-client.ts
@@ -14,7 +14,7 @@ export interface McpConnection {
 export async function connectMcp(apiKey: string): Promise<McpConnection> {
   const transport = new StreamableHTTPClientTransport(new URL(`${MCP_SERVER_URL}/mcp`), {
     requestInit: {
-      headers: { "X-API-Key": apiKey },
+      headers: { Authorization: `Bearer ${apiKey}` },
     },
   });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -85,8 +85,8 @@ registry.registerPath({
     "Send a message and receive a streamed AI response via Server-Sent Events (SSE). Supports MCP tool calling and quick-reply buttons.",
   request: {
     headers: z.object({
-      "x-api-key": z.string().openapi({
-        description: "API key used to scope sessions by organization",
+      authorization: z.string().openapi({
+        description: "Bearer token used to scope sessions by organization (format: Bearer <key>)",
       }),
     }),
     body: {
@@ -110,7 +110,7 @@ registry.registerPath({
       },
     },
     401: {
-      description: "Missing X-API-Key header",
+      description: "Missing or invalid Authorization Bearer header",
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
   },

--- a/tests/unit/mcp-client.test.ts
+++ b/tests/unit/mcp-client.test.ts
@@ -53,7 +53,7 @@ describe("connectMcp", () => {
       }),
       expect.objectContaining({
         requestInit: {
-          headers: { "X-API-Key": "test-api-key" },
+          headers: { Authorization: "Bearer test-api-key" },
         },
       })
     );


### PR DESCRIPTION
## Summary

Updated the chat service and MCP client to use standard Bearer token authentication instead of custom X-API-Key header. This aligns the runtime implementation with the API Registry's OpenAPI spec (bearerAuth — type: http, scheme: bearer).

## Changes

- Chat endpoint now reads `Authorization: Bearer <key>` header
- MCP client sends Bearer token to MCP server  
- OpenAPI spec updated to reflect new header
- Tests and README updated
- All unit tests pass

## Migration Note

Consumers currently using `X-API-Key` (like the chat UI) will need to switch to `Authorization: Bearer <key>`.