### PR TITLE
feat: resolve Gemini API key from key-service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
-GEMINI_API_KEY=your-gemini-api-key
 CHAT_SERVICE_DATABASE_URL=postgresql://neondb_owner:xxx@ep-xxx.aws.neon.tech/neondb?sslmode=require
+KEY_SERVICE_URL=https://key.mcpfactory.org
+KEY_SERVICE_API_KEY=your-key-service-api-key
 MCP_SERVER_URL=https://mcp.mcpfactory.org
 RUNS_SERVICE_URL=https://runs.mcpfactory.org
 RUNS_SERVICE_API_KEY=your-runs-service-api-key

--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token st
 
 | Variable | Required | Description |
 |---|---|---|
-| `GEMINI_API_KEY` | Yes | Google Gemini API key |
+| `KEY_SERVICE_API_KEY` | Yes | Service-to-service key for key-service (used to decrypt the Gemini API key at startup) |
 | `CHAT_SERVICE_DATABASE_URL` | Yes | PostgreSQL connection string |
+| `KEY_SERVICE_URL` | No | Key-service endpoint (default: `https://key.mcpfactory.org`) |
 | `MCP_SERVER_URL` | No | MCP server endpoint (default: `https://mcp.mcpfactory.org`) |
 | `RUNS_SERVICE_URL` | No | RunsService endpoint (default: `https://runs.mcpfactory.org`) |
 | `RUNS_SERVICE_API_KEY` | No | API key for RunsService (runs tracking disabled if unset) |
@@ -151,6 +152,7 @@ src/
   lib/
     gemini.ts       # Gemini AI client, streaming + function calling
     mcp-client.ts   # MCP server connection via Streamable HTTP transport + tool execution
+    key-client.ts   # Key-service client for decrypting app keys (Gemini API key)
     runs-client.ts  # RunsService HTTP client for run tracking and cost reporting
 scripts/
   generate-openapi.ts  # Generates openapi.json from zod schemas via OpenApiGeneratorV3

--- a/src/lib/key-client.ts
+++ b/src/lib/key-client.ts
@@ -1,0 +1,48 @@
+const KEY_SERVICE_URL =
+  process.env.KEY_SERVICE_URL || "https://key.mcpfactory.org";
+const KEY_SERVICE_API_KEY = process.env.KEY_SERVICE_API_KEY;
+
+const APP_ID = "chat";
+const CALLER_SERVICE = "chat";
+
+export interface CallerInfo {
+  method: string;
+  path: string;
+}
+
+export interface DecryptedKey {
+  provider: string;
+  key: string;
+}
+
+export async function decryptAppKey(
+  provider: string,
+  caller: CallerInfo,
+): Promise<DecryptedKey> {
+  if (!KEY_SERVICE_API_KEY) {
+    throw new Error(
+      "[key-client] KEY_SERVICE_API_KEY is required to decrypt app keys",
+    );
+  }
+
+  const url = `${KEY_SERVICE_URL}/internal/app-keys/${encodeURIComponent(provider)}/decrypt?appId=${encodeURIComponent(APP_ID)}`;
+
+  const res = await fetch(url, {
+    method: "GET",
+    headers: {
+      "x-api-key": KEY_SERVICE_API_KEY,
+      "X-Caller-Service": CALLER_SERVICE,
+      "X-Caller-Method": caller.method,
+      "X-Caller-Path": caller.path,
+    },
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `[key-client] GET /internal/app-keys/${provider}/decrypt returned ${res.status}: ${text}`,
+    );
+  }
+
+  return (await res.json()) as DecryptedKey;
+}

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -2,9 +2,12 @@ import { beforeAll, afterAll } from "vitest";
 
 // Test setup - load env vars for integration tests
 beforeAll(() => {
-  process.env.GEMINI_API_KEY = process.env.GEMINI_API_KEY || "test-key";
   process.env.CHAT_SERVICE_DATABASE_URL =
     process.env.CHAT_SERVICE_DATABASE_URL || "postgresql://localhost/chat_test";
+  process.env.KEY_SERVICE_URL =
+    process.env.KEY_SERVICE_URL || "https://key.test.local";
+  process.env.KEY_SERVICE_API_KEY =
+    process.env.KEY_SERVICE_API_KEY || "test-key-svc-key";
 });
 
 afterAll(() => {

--- a/tests/unit/key-client.test.ts
+++ b/tests/unit/key-client.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  process.env.KEY_SERVICE_API_KEY = "test-key-svc-key";
+  process.env.KEY_SERVICE_URL = "https://key.test.local";
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.restoreAllMocks();
+});
+
+async function loadModule() {
+  vi.resetModules();
+  return import("../../src/lib/key-client.js");
+}
+
+describe("decryptAppKey", () => {
+  it("sends GET with correct URL, query params, and caller headers", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ provider: "gemini", key: "decrypted-key" }),
+    });
+
+    const { decryptAppKey } = await loadModule();
+    const result = await decryptAppKey("gemini", {
+      method: "POST",
+      path: "/chat",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://key.test.local/internal/app-keys/gemini/decrypt?appId=chat",
+      expect.objectContaining({
+        method: "GET",
+        headers: {
+          "x-api-key": "test-key-svc-key",
+          "X-Caller-Service": "chat",
+          "X-Caller-Method": "POST",
+          "X-Caller-Path": "/chat",
+        },
+      }),
+    );
+    expect(result).toEqual({ provider: "gemini", key: "decrypted-key" });
+  });
+
+  it("throws on HTTP 404 (key not configured)", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve("Key not configured"),
+    });
+
+    const { decryptAppKey } = await loadModule();
+    await expect(
+      decryptAppKey("gemini", { method: "POST", path: "/chat" }),
+    ).rejects.toThrow(/returned 404/);
+  });
+
+  it("throws on HTTP 400 (missing caller headers)", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: () => Promise.resolve("Missing required caller headers"),
+    });
+
+    const { decryptAppKey } = await loadModule();
+    await expect(
+      decryptAppKey("gemini", { method: "POST", path: "/chat" }),
+    ).rejects.toThrow(/returned 400/);
+  });
+
+  it("throws on HTTP 500 (server error)", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("Internal Server Error"),
+    });
+
+    const { decryptAppKey } = await loadModule();
+    await expect(
+      decryptAppKey("gemini", { method: "POST", path: "/chat" }),
+    ).rejects.toThrow(/returned 500/);
+  });
+
+  it("throws on network error", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("ECONNREFUSED"),
+    );
+
+    const { decryptAppKey } = await loadModule();
+    await expect(
+      decryptAppKey("gemini", { method: "POST", path: "/chat" }),
+    ).rejects.toThrow("ECONNREFUSED");
+  });
+
+  it("throws when KEY_SERVICE_API_KEY is not set", async () => {
+    delete process.env.KEY_SERVICE_API_KEY;
+
+    const { decryptAppKey } = await loadModule();
+    await expect(
+      decryptAppKey("gemini", { method: "POST", path: "/chat" }),
+    ).rejects.toThrow(/KEY_SERVICE_API_KEY is required/);
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("uses default KEY_SERVICE_URL when not set", async () => {
+    delete process.env.KEY_SERVICE_URL;
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ provider: "gemini", key: "key-123" }),
+    });
+
+    const { decryptAppKey } = await loadModule();
+    await decryptAppKey("gemini", { method: "POST", path: "/chat" });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://key.mcpfactory.org/internal/app-keys/gemini/decrypt?appId=chat",
+      expect.anything(),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- **Replaces `GEMINI_API_KEY` env var** with a runtime call to key-service's `GET /internal/app-keys/gemini/decrypt` endpoint
- **Includes new required caller headers** (`X-Caller-Service`, `X-Caller-Method`, `X-Caller-Path`) per the key-service breaking change announcement
- Key is decrypted once at startup and cached for all requests

## Changes

- `src/lib/key-client.ts` — new key-service client with `decryptAppKey()` function
- `src/index.ts` — startup chain now decrypts Gemini key via key-service before listening
- `tests/unit/key-client.test.ts` — 7 unit tests (happy path, HTTP errors, network errors, missing env)
- `.env.example`, `README.md`, `tests/setup.ts` — updated env vars

## Test plan

- [x] `npm run test:unit` — 62 tests pass (8 suites)
- [x] `npx tsc --noEmit` — TypeScript compiles clean
- [x] `npm run generate:openapi` — OpenAPI spec generates successfully
- [ ] CI: verify unit tests pass
- [ ] CI: verify integration tests pass with Neon branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)