### PR TITLE
feat: require appId in /chat for key-service

### DIFF
--- a/src/lib/key-client.ts
+++ b/src/lib/key-client.ts
@@ -2,7 +2,7 @@ const KEY_SERVICE_URL =
   process.env.KEY_SERVICE_URL || "https://key.mcpfactory.org";
 const KEY_SERVICE_API_KEY = process.env.KEY_SERVICE_API_KEY;
 
-const APP_ID = "chat";
+const APP_ID = "mcpfactory";
 const CALLER_SERVICE = "chat";
 
 export interface CallerInfo {

--- a/src/lib/key-client.ts
+++ b/src/lib/key-client.ts
@@ -2,7 +2,6 @@ const KEY_SERVICE_URL =
   process.env.KEY_SERVICE_URL || "https://key.mcpfactory.org";
 const KEY_SERVICE_API_KEY = process.env.KEY_SERVICE_API_KEY;
 
-const APP_ID = "mcpfactory";
 const CALLER_SERVICE = "chat";
 
 export interface CallerInfo {
@@ -17,6 +16,7 @@ export interface DecryptedKey {
 
 export async function decryptAppKey(
   provider: string,
+  appId: string,
   caller: CallerInfo,
 ): Promise<DecryptedKey> {
   if (!KEY_SERVICE_API_KEY) {
@@ -25,7 +25,7 @@ export async function decryptAppKey(
     );
   }
 
-  const url = `${KEY_SERVICE_URL}/internal/app-keys/${encodeURIComponent(provider)}/decrypt?appId=${encodeURIComponent(APP_ID)}`;
+  const url = `${KEY_SERVICE_URL}/internal/app-keys/${encodeURIComponent(provider)}/decrypt?appId=${encodeURIComponent(appId)}`;
 
   const res = await fetch(url, {
     method: "GET",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -71,6 +71,7 @@ export const ChatRequestSchema = z
   .object({
     message: z.string().min(1, "message is required"),
     sessionId: z.string().uuid().optional(),
+    appId: z.string().min(1, "appId is required"),
   })
   .openapi("ChatRequest");
 

--- a/tests/unit/key-client.test.ts
+++ b/tests/unit/key-client.test.ts
@@ -26,7 +26,7 @@ describe("decryptAppKey", () => {
     });
 
     const { decryptAppKey } = await loadModule();
-    const result = await decryptAppKey("gemini", {
+    const result = await decryptAppKey("gemini", "mcpfactory", {
       method: "POST",
       path: "/chat",
     });
@@ -55,7 +55,7 @@ describe("decryptAppKey", () => {
 
     const { decryptAppKey } = await loadModule();
     await expect(
-      decryptAppKey("gemini", { method: "POST", path: "/chat" }),
+      decryptAppKey("gemini", "mcpfactory", { method: "POST", path: "/chat" }),
     ).rejects.toThrow(/returned 404/);
   });
 
@@ -68,7 +68,7 @@ describe("decryptAppKey", () => {
 
     const { decryptAppKey } = await loadModule();
     await expect(
-      decryptAppKey("gemini", { method: "POST", path: "/chat" }),
+      decryptAppKey("gemini", "mcpfactory", { method: "POST", path: "/chat" }),
     ).rejects.toThrow(/returned 400/);
   });
 
@@ -81,7 +81,7 @@ describe("decryptAppKey", () => {
 
     const { decryptAppKey } = await loadModule();
     await expect(
-      decryptAppKey("gemini", { method: "POST", path: "/chat" }),
+      decryptAppKey("gemini", "mcpfactory", { method: "POST", path: "/chat" }),
     ).rejects.toThrow(/returned 500/);
   });
 
@@ -92,7 +92,7 @@ describe("decryptAppKey", () => {
 
     const { decryptAppKey } = await loadModule();
     await expect(
-      decryptAppKey("gemini", { method: "POST", path: "/chat" }),
+      decryptAppKey("gemini", "mcpfactory", { method: "POST", path: "/chat" }),
     ).rejects.toThrow("ECONNREFUSED");
   });
 
@@ -101,7 +101,7 @@ describe("decryptAppKey", () => {
 
     const { decryptAppKey } = await loadModule();
     await expect(
-      decryptAppKey("gemini", { method: "POST", path: "/chat" }),
+      decryptAppKey("gemini", "mcpfactory", { method: "POST", path: "/chat" }),
     ).rejects.toThrow(/KEY_SERVICE_API_KEY is required/);
 
     expect(fetch).not.toHaveBeenCalled();
@@ -115,7 +115,7 @@ describe("decryptAppKey", () => {
     });
 
     const { decryptAppKey } = await loadModule();
-    await decryptAppKey("gemini", { method: "POST", path: "/chat" });
+    await decryptAppKey("gemini", "mcpfactory", { method: "POST", path: "/chat" });
 
     expect(fetch).toHaveBeenCalledWith(
       "https://key.mcpfactory.org/internal/app-keys/gemini/decrypt?appId=mcpfactory",

--- a/tests/unit/key-client.test.ts
+++ b/tests/unit/key-client.test.ts
@@ -32,7 +32,7 @@ describe("decryptAppKey", () => {
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://key.test.local/internal/app-keys/gemini/decrypt?appId=chat",
+      "https://key.test.local/internal/app-keys/gemini/decrypt?appId=mcpfactory",
       expect.objectContaining({
         method: "GET",
         headers: {
@@ -118,7 +118,7 @@ describe("decryptAppKey", () => {
     await decryptAppKey("gemini", { method: "POST", path: "/chat" });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://key.mcpfactory.org/internal/app-keys/gemini/decrypt?appId=chat",
+      "https://key.mcpfactory.org/internal/app-keys/gemini/decrypt?appId=mcpfactory",
       expect.anything(),
     );
   });

--- a/tests/unit/schemas.test.ts
+++ b/tests/unit/schemas.test.ts
@@ -3,10 +3,11 @@ import { ChatRequestSchema } from "../../src/schemas.js";
 
 describe("ChatRequestSchema", () => {
   it("accepts valid request with message only", () => {
-    const result = ChatRequestSchema.safeParse({ message: "Hello" });
+    const result = ChatRequestSchema.safeParse({ message: "Hello", appId: "mcpfactory" });
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.message).toBe("Hello");
+      expect(result.data.appId).toBe("mcpfactory");
       expect(result.data.sessionId).toBeUndefined();
     }
   });
@@ -14,13 +15,14 @@ describe("ChatRequestSchema", () => {
   it("accepts valid request with message and sessionId", () => {
     const result = ChatRequestSchema.safeParse({
       message: "Hello",
+      appId: "mcpfactory",
       sessionId: "550e8400-e29b-41d4-a716-446655440000",
     });
     expect(result.success).toBe(true);
   });
 
   it("rejects empty message", () => {
-    const result = ChatRequestSchema.safeParse({ message: "" });
+    const result = ChatRequestSchema.safeParse({ message: "", appId: "mcpfactory" });
     expect(result.success).toBe(false);
   });
 
@@ -29,9 +31,15 @@ describe("ChatRequestSchema", () => {
     expect(result.success).toBe(false);
   });
 
+  it("rejects missing appId", () => {
+    const result = ChatRequestSchema.safeParse({ message: "Hello" });
+    expect(result.success).toBe(false);
+  });
+
   it("rejects non-uuid sessionId", () => {
     const result = ChatRequestSchema.safeParse({
       message: "Hello",
+      appId: "mcpfactory",
       sessionId: "not-a-uuid",
     });
     expect(result.success).toBe(false);
@@ -40,6 +48,7 @@ describe("ChatRequestSchema", () => {
   it("strips extra fields", () => {
     const result = ChatRequestSchema.safeParse({
       message: "Hello",
+      appId: "mcpfactory",
       extra: "field",
     });
     expect(result.success).toBe(true);


### PR DESCRIPTION
## Summary

- `appId` is now a required field in the `/chat` request body
- Gemini API key is resolved per-request via `GET /internal/app-keys/gemini/decrypt?appId={appId}` with caller headers
- Returns 502 if key-service decrypt fails (before SSE starts)
- No more hardcoded appId — the caller (e.g. mcpfactory) provides it

## Test plan

- [x] 63 unit tests pass (including new "rejects missing appId" test)
- [x] TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)