### PR TITLE
fix: revert auth to x-api-key header

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ All endpoints (except `/health` and `/openapi.json`) require three headers:
 
 | Header | Description |
 |---|---|
-| `Authorization` | `Bearer <chat-service-api-key>` — service-to-service auth |
+| `x-api-key` | Service-to-service API key |
 | `x-org-id` | Internal org UUID from client-service |
 | `x-user-id` | Internal user UUID from client-service |
 
@@ -56,7 +56,7 @@ Response:
 
 ## SSE Protocol
 
-`POST /chat` with headers `Content-Type: application/json`, `Authorization: Bearer <key>`, `x-org-id`, `x-user-id`.
+`POST /chat` with headers `Content-Type: application/json`, `x-api-key`, `x-org-id`, `x-user-id`.
 
 Request body:
 ```json
@@ -200,7 +200,7 @@ src/
   types.ts          # SSE event TypeScript interfaces
   schemas.ts        # Zod schemas, OpenAPI registry, and request/response types
   middleware/
-    auth.ts         # requireAuth middleware (Authorization, x-org-id, x-user-id)
+    auth.ts         # requireAuth middleware (x-api-key, x-org-id, x-user-id)
   db/
     index.ts        # Drizzle client init
     schema.ts       # sessions + messages + app_configs table definitions

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -10,11 +10,9 @@ export function requireAuth(
   res: Response,
   next: NextFunction,
 ): void {
-  const authHeader = req.headers["authorization"];
-  if (!authHeader?.startsWith("Bearer ")) {
-    res
-      .status(401)
-      .json({ error: "Authorization: Bearer <key> header required" });
+  const apiKey = req.headers["x-api-key"];
+  if (!apiKey || typeof apiKey !== "string") {
+    res.status(401).json({ error: "x-api-key header is required" });
     return;
   }
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -99,8 +99,8 @@ registry.registerPath({
   request: {
     params: z.object({ appId: z.string() }),
     headers: z.object({
-      authorization: z.string().openapi({
-        description: "Bearer token for service-to-service auth",
+      "x-api-key": z.string().openapi({
+        description: "Service-to-service API key",
       }),
       "x-org-id": z.string().openapi({
         description: "Internal org UUID from client-service",
@@ -127,7 +127,7 @@ registry.registerPath({
       },
     },
     401: {
-      description: "Missing or invalid Authorization Bearer header",
+      description: "Missing or invalid x-api-key header",
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
   },
@@ -155,8 +155,8 @@ registry.registerPath({
     "Send a message and receive a streamed AI response via Server-Sent Events (SSE). Supports MCP tool calling and quick-reply buttons. Requires app config to be registered first via PUT /apps/{appId}/config.",
   request: {
     headers: z.object({
-      authorization: z.string().openapi({
-        description: "Bearer token for service-to-service auth",
+      "x-api-key": z.string().openapi({
+        description: "Service-to-service API key",
       }),
       "x-org-id": z.string().openapi({
         description: "Internal org UUID from client-service",
@@ -186,7 +186,7 @@ registry.registerPath({
       },
     },
     401: {
-      description: "Missing or invalid Authorization Bearer header",
+      description: "Missing or invalid x-api-key header",
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
     404: {

--- a/tests/unit/auth-middleware.test.ts
+++ b/tests/unit/auth-middleware.test.ts
@@ -14,26 +14,19 @@ function mockReqRes(headers: Record<string, string> = {}) {
 }
 
 describe("requireAuth middleware", () => {
-  it("returns 401 when Authorization header is missing", () => {
+  it("returns 401 when x-api-key header is missing", () => {
     const { req, res, next } = mockReqRes({});
     requireAuth(req, res, next);
     expect(res.status).toHaveBeenCalledWith(401);
     expect(res.json).toHaveBeenCalledWith({
-      error: "Authorization: Bearer <key> header required",
+      error: "x-api-key header is required",
     });
-    expect(next).not.toHaveBeenCalled();
-  });
-
-  it("returns 401 when Authorization header is not Bearer", () => {
-    const { req, res, next } = mockReqRes({ authorization: "Basic abc123" });
-    requireAuth(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(401);
     expect(next).not.toHaveBeenCalled();
   });
 
   it("returns 400 when x-org-id is missing", () => {
     const { req, res, next } = mockReqRes({
-      authorization: "Bearer test-key",
+      "x-api-key": "test-key",
       "x-user-id": "user-123",
     });
     requireAuth(req, res, next);
@@ -46,7 +39,7 @@ describe("requireAuth middleware", () => {
 
   it("returns 400 when x-user-id is missing", () => {
     const { req, res, next } = mockReqRes({
-      authorization: "Bearer test-key",
+      "x-api-key": "test-key",
       "x-org-id": "org-123",
     });
     requireAuth(req, res, next);
@@ -59,7 +52,7 @@ describe("requireAuth middleware", () => {
 
   it("calls next and sets locals when all headers are present", () => {
     const { req, res, next } = mockReqRes({
-      authorization: "Bearer test-key",
+      "x-api-key": "test-key",
       "x-org-id": "org-123",
       "x-user-id": "user-456",
     });


### PR DESCRIPTION
## Summary
- Reverts auth from `Authorization: Bearer` back to `x-api-key` header to align with ecosystem convention
- All microservices in our ecosystem use `x-api-key` for service-to-service auth
- Updates middleware, tests, OpenAPI schemas, and README

## Test plan
- [x] 84 unit tests pass
- [x] TypeScript builds cleanly
- [x] OpenAPI spec regenerated with `x-api-key` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)