### PR TITLE
fix: flush SSE tokens immediately instead of buffering until newline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
-GEMINI_API_KEY=your-gemini-api-key
 CHAT_SERVICE_DATABASE_URL=postgresql://neondb_owner:xxx@ep-xxx.aws.neon.tech/neondb?sslmode=require
+KEY_SERVICE_URL=https://key.mcpfactory.org
+KEY_SERVICE_API_KEY=your-key-service-api-key
 MCP_SERVER_URL=https://mcp.mcpfactory.org
 RUNS_SERVICE_URL=https://runs.mcpfactory.org
 RUNS_SERVICE_API_KEY=your-runs-service-api-key

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 GEMINI_API_KEY=your-gemini-api-key
 CHAT_SERVICE_DATABASE_URL=postgresql://neondb_owner:xxx@ep-xxx.aws.neon.tech/neondb?sslmode=require
 MCP_SERVER_URL=https://mcp.mcpfactory.org
+RUNS_SERVICE_URL=https://runs.mcpfactory.org
+RUNS_SERVICE_API_KEY=your-runs-service-api-key
 PORT=3002

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm run dev            # starts on port 3002
 
 ## SSE Protocol
 
-`POST /chat` with headers `Content-Type: application/json` and `X-API-Key: <your-key>`.
+`POST /chat` with headers `Content-Type: application/json` and `Authorization: Bearer <your-key>`.
 
 Request body:
 ```json

--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token st
 
 | Variable | Required | Description |
 |---|---|---|
-| `GEMINI_API_KEY` | Yes | Google Gemini API key |
+| `KEY_SERVICE_API_KEY` | Yes | Service-to-service key for key-service (used to decrypt the Gemini API key at startup) |
 | `CHAT_SERVICE_DATABASE_URL` | Yes | PostgreSQL connection string |
+| `KEY_SERVICE_URL` | No | Key-service endpoint (default: `https://key.mcpfactory.org`) |
 | `MCP_SERVER_URL` | No | MCP server endpoint (default: `https://mcp.mcpfactory.org`) |
 | `RUNS_SERVICE_URL` | No | RunsService endpoint (default: `https://runs.mcpfactory.org`) |
 | `RUNS_SERVICE_API_KEY` | No | API key for RunsService (runs tracking disabled if unset) |
@@ -151,6 +152,7 @@ src/
   lib/
     gemini.ts       # Gemini AI client, streaming + function calling
     mcp-client.ts   # MCP server connection via Streamable HTTP transport + tool execution
+    key-client.ts   # Key-service client for decrypting app keys (Gemini API key)
     runs-client.ts  # RunsService HTTP client for run tracking and cost reporting
 scripts/
   generate-openapi.ts  # Generates openapi.json from zod schemas via OpenApiGeneratorV3

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token st
 | `GEMINI_API_KEY` | Yes | Google Gemini API key |
 | `CHAT_SERVICE_DATABASE_URL` | Yes | PostgreSQL connection string |
 | `MCP_SERVER_URL` | No | MCP server endpoint (default: `https://mcp.mcpfactory.org`) |
+| `RUNS_SERVICE_URL` | No | RunsService endpoint (default: `https://runs.mcpfactory.org`) |
+| `RUNS_SERVICE_API_KEY` | No | API key for RunsService (runs tracking disabled if unset) |
 | `PORT` | No | Server port (default: `3002`) |
 
 ## Database
@@ -87,7 +89,7 @@ Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token st
 Uses PostgreSQL via Drizzle ORM. Two tables:
 
 - **sessions** - conversation sessions scoped by `orgId` (from the API key)
-- **messages** - chat messages with role, content, optional `toolCalls` and `buttons` JSONB
+- **messages** - chat messages with role, content, optional `toolCalls`, `buttons` JSONB, and `runId` linking to RunsService
 
 Migrations run automatically on server start. To generate new migrations after schema changes:
 
@@ -149,6 +151,7 @@ src/
   lib/
     gemini.ts       # Gemini AI client, streaming + function calling
     mcp-client.ts   # MCP server connection via Streamable HTTP transport + tool execution
+    runs-client.ts  # RunsService HTTP client for run tracking and cost reporting
 scripts/
   generate-openapi.ts  # Generates openapi.json from zod schemas via OpenApiGeneratorV3
 ```

--- a/drizzle/0001_deep_richard_fisk.sql
+++ b/drizzle/0001_deep_richard_fisk.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "messages" ADD COLUMN "run_id" uuid;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,142 @@
+{
+  "id": "f3f504df-db03-47cc-87c7-f233a75a7cf7",
+  "prevId": "c1241ff6-8653-4bde-bf07-11e460f87235",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buttons": {
+          "name": "buttons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1770013953733,
       "tag": "0000_legal_naoko",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1770560977671,
+      "tag": "0001_deep_richard_fisk",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -17,6 +17,7 @@ export const messages = pgTable("messages", {
   toolCalls: jsonb("tool_calls").$type<ToolCallRecord[]>(),
   buttons: jsonb("buttons").$type<ButtonRecord[]>(),
   tokenCount: integer("token_count"),
+  runId: uuid("run_id"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,10 +61,11 @@ app.post("/chat", async (req, res) => {
 
   const { message, sessionId } = parsed.data;
 
-  // SSE headers
+  // SSE headers — disable proxy buffering so tokens stream immediately
   res.setHeader("Content-Type", "text/event-stream");
   res.setHeader("Cache-Control", "no-cache");
   res.setHeader("Connection", "keep-alive");
+  res.setHeader("X-Accel-Buffering", "no");
   res.flushHeaders();
 
   const gemini = createGeminiClient({ apiKey: geminiApiKey });
@@ -135,20 +136,37 @@ app.post("/chat", async (req, res) => {
 
     function bufferToken(chunk: string): void {
       fullResponse += chunk;
-      for (const ch of chunk) {
-        lineBuf += ch;
-        if (ch === "\n") {
-          if (BUTTON_RE.test(lineBuf.trimEnd())) {
-            held += lineBuf;
-          } else {
-            if (held) {
-              sendSSE(res, { type: "token", content: held });
-              held = "";
-            }
-            sendSSE(res, { type: "token", content: lineBuf });
+
+      // Split combined buffer + chunk on newlines
+      const combined = lineBuf + chunk;
+      const parts = combined.split("\n");
+      // Last element is the remaining partial line (empty string if chunk ended with \n)
+      const partial = parts.pop()!;
+
+      // Process each complete line (terminated by \n)
+      for (const line of parts) {
+        const fullLine = line + "\n";
+        if (BUTTON_RE.test(line.trimEnd())) {
+          held += fullLine;
+        } else {
+          if (held) {
+            sendSSE(res, { type: "token", content: held });
+            held = "";
           }
-          lineBuf = "";
+          sendSSE(res, { type: "token", content: fullLine });
         }
+      }
+
+      lineBuf = partial;
+
+      // Flush partial line immediately unless it could be the start of a button line
+      if (lineBuf && !/^[-*]\s*\[/.test(lineBuf)) {
+        if (held) {
+          sendSSE(res, { type: "token", content: held });
+          held = "";
+        }
+        sendSSE(res, { type: "token", content: lineBuf });
+        lineBuf = "";
       }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,9 @@ import { dirname, join } from "path";
 import { db } from "./db/index.js";
 import { sessions, messages } from "./db/schema.js";
 import { eq } from "drizzle-orm";
-import { createGeminiClient, REQUEST_USER_INPUT_TOOL } from "./lib/gemini.js";
+import { createGeminiClient, REQUEST_USER_INPUT_TOOL, type UsageMetadata } from "./lib/gemini.js";
 import { connectMcp, type McpConnection } from "./lib/mcp-client.js";
+import { createRun, updateRunStatus, addRunCosts } from "./lib/runs-client.js";
 import { ChatRequestSchema } from "./schemas.js";
 import type { Content, Part } from "@google/genai";
 import type { ButtonRecord, ToolCallRecord } from "./db/schema.js";
@@ -68,7 +69,12 @@ app.post("/chat", async (req, res) => {
   res.setHeader("Connection", "keep-alive");
   res.flushHeaders();
 
+  const gemini = createGeminiClient({ apiKey: GEMINI_API_KEY });
   let mcpConn: McpConnection | null = null;
+  let runId: string | undefined;
+  let chatFailed = false;
+  let totalPromptTokens = 0;
+  let totalOutputTokens = 0;
 
   try {
     // Get or create session
@@ -82,6 +88,15 @@ app.post("/chat", async (req, res) => {
     }
 
     sendSSE(res, { sessionId: currentSessionId });
+
+    // Register run in RunsService
+    const run = await createRun({
+      clerkOrgId: apiKey,
+      appId: "mcpfactory",
+      serviceName: "chat-service",
+      taskName: "chat",
+    });
+    if (run) runId = run.id;
 
     // Load conversation history
     const history = await db.query.messages.findMany({
@@ -111,7 +126,6 @@ app.post("/chat", async (req, res) => {
     });
 
     // Stream response from Gemini
-    const gemini = createGeminiClient({ apiKey: GEMINI_API_KEY });
     let fullResponse = "";
     const toolCalls: ToolCallRecord[] = [];
 
@@ -152,9 +166,19 @@ app.post("/chat", async (req, res) => {
       allTools
     );
 
+    function accumulateUsage(usage?: UsageMetadata) {
+      if (!usage) return;
+      totalPromptTokens += usage.promptTokens;
+      totalOutputTokens += usage.outputTokens;
+    }
+
     for await (const event of stream) {
       if (event.type === "token") {
         bufferToken(event.content);
+      }
+
+      if (event.type === "done") {
+        accumulateUsage(event.usage);
       }
 
       if (event.type === "function_call") {
@@ -222,6 +246,9 @@ app.post("/chat", async (req, res) => {
             if (contEvent.type === "token") {
               bufferToken(contEvent.content);
             }
+            if (contEvent.type === "done") {
+              accumulateUsage(contEvent.usage);
+            }
           }
         } catch (toolErr: unknown) {
           const errDetail = toolErr instanceof Error
@@ -270,10 +297,13 @@ app.post("/chat", async (req, res) => {
       content: cleanedResponse,
       toolCalls: toolCalls.length > 0 ? toolCalls : null,
       buttons: buttons.length > 0 ? buttons : null,
+      tokenCount: totalPromptTokens + totalOutputTokens || null,
+      runId: runId ?? null,
     });
 
     sendSSE(res, "[DONE]");
   } catch (err) {
+    chatFailed = true;
     console.error("Chat error:", err);
     sendSSE(res, {
       type: "token",
@@ -284,6 +314,24 @@ app.post("/chat", async (req, res) => {
     if (mcpConn) {
       mcpConn.close().catch(() => {});
     }
+
+    // Report run status and costs (fire-and-forget)
+    if (runId) {
+      const costModel = gemini.model.replace(/-preview$/, "");
+      const costItems = [
+        ...(totalPromptTokens > 0
+          ? [{ costName: `${costModel}-tokens-input`, quantity: totalPromptTokens }]
+          : []),
+        ...(totalOutputTokens > 0
+          ? [{ costName: `${costModel}-tokens-output`, quantity: totalOutputTokens }]
+          : []),
+      ];
+      Promise.all([
+        updateRunStatus(runId, chatFailed ? "failed" : "completed"),
+        addRunCosts(runId, costItems),
+      ]).catch(() => {});
+    }
+
     res.end();
   }
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,9 +47,10 @@ app.get("/health", (_req, res) => {
 });
 
 app.post("/chat", async (req, res) => {
-  const apiKey = req.headers["x-api-key"] as string | undefined;
+  const authHeader = req.headers["authorization"];
+  const apiKey = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : undefined;
   if (!apiKey) {
-    return res.status(401).json({ error: "X-API-Key header required" });
+    return res.status(401).json({ error: "Authorization: Bearer <key> header required" });
   }
 
   const parsed = ChatRequestSchema.safeParse(req.body);

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -19,14 +19,33 @@ Key behaviors:
 
 Available tools let you search for leads, create campaigns, and manage outreach on behalf of the user.
 
-You have access to mcpfactory_suggest_icp which analyzes a brand's website to suggest who they should target with cold emails. Call this tool when the user wants to create a campaign but hasn't specified their target audience (job titles, industries, or locations). Present the suggestions to the user for confirmation before creating the campaign. The returned person_titles, q_organization_keyword_tags, and organization_locations map directly to target_titles, target_industries, and target_locations in mcpfactory_create_campaign.
+## Campaign tools
+
+- mcpfactory_list_brands: List brands the user has set up.
+- mcpfactory_suggest_icp: Analyze a brand URL to suggest target audience (job titles, industries, locations). The returned person_titles, q_organization_keyword_tags, and organization_locations map directly to target_titles, target_industries, and target_locations in mcpfactory_create_campaign.
+- mcpfactory_create_campaign: Create and start a campaign. Required: name, brand_url, target_titles. Optional: target_industries, target_locations, max_daily_budget_usd, max_weekly_budget_usd, max_monthly_budget_usd, max_total_budget_usd, max_leads, end_date.
+- mcpfactory_list_campaigns: List campaigns, optionally filtered by status (ongoing, stopped, all). Use when the user asks about their campaigns.
+- mcpfactory_campaign_stats: Get campaign performance stats (leads, emails, opens, replies, costs). Use when the user asks how a campaign is doing.
+- mcpfactory_stop_campaign: Stop a running campaign by campaign_id.
+- mcpfactory_resume_campaign: Resume a stopped campaign by campaign_id.
+- mcpfactory_campaign_debug: Get detailed debug info for a campaign (status, runs, errors, pipeline state). Use when troubleshooting.
+
+## Campaign creation flow
 
 IMPORTANT: When the user wants to create a campaign or send cold emails, follow this flow:
 1. FIRST, call mcpfactory_list_brands to check if the user already has brands set up.
 2. If brands exist, present them as button options (e.g. - [https://mybrand.com]) and add a final option - [Use a different URL].
 3. If the user picks an existing brand, proceed with that brand URL.
 4. If no brands exist, or the user picks "Use a different URL", call request_user_input({ input_type: "url", label: "What's your brand URL?", placeholder: "https://yourbrand.com", field: "brand_url" }) to render a URL input widget.
-Never ask for the brand URL in plain text — always use either buttons (for existing brands) or the request_user_input tool (for new URLs).`;
+5. If the user hasn't specified a target audience, call mcpfactory_suggest_icp to get suggestions before creating.
+Never ask for the brand URL in plain text — always use either buttons (for existing brands) or the request_user_input tool (for new URLs).
+
+## Campaign management flow
+
+When the user asks about their campaigns, call mcpfactory_list_campaigns first.
+When they ask about a specific campaign's performance, call mcpfactory_campaign_stats with the campaign_id.
+When they want to stop or resume a campaign, use mcpfactory_stop_campaign or mcpfactory_resume_campaign.
+If something seems wrong with a campaign, use mcpfactory_campaign_debug to investigate.`;
 
 export const REQUEST_USER_INPUT_TOOL: FunctionDeclaration = {
   name: "request_user_input",

--- a/src/lib/key-client.ts
+++ b/src/lib/key-client.ts
@@ -1,0 +1,48 @@
+const KEY_SERVICE_URL =
+  process.env.KEY_SERVICE_URL || "https://key.mcpfactory.org";
+const KEY_SERVICE_API_KEY = process.env.KEY_SERVICE_API_KEY;
+
+const APP_ID = "chat";
+const CALLER_SERVICE = "chat";
+
+export interface CallerInfo {
+  method: string;
+  path: string;
+}
+
+export interface DecryptedKey {
+  provider: string;
+  key: string;
+}
+
+export async function decryptAppKey(
+  provider: string,
+  caller: CallerInfo,
+): Promise<DecryptedKey> {
+  if (!KEY_SERVICE_API_KEY) {
+    throw new Error(
+      "[key-client] KEY_SERVICE_API_KEY is required to decrypt app keys",
+    );
+  }
+
+  const url = `${KEY_SERVICE_URL}/internal/app-keys/${encodeURIComponent(provider)}/decrypt?appId=${encodeURIComponent(APP_ID)}`;
+
+  const res = await fetch(url, {
+    method: "GET",
+    headers: {
+      "x-api-key": KEY_SERVICE_API_KEY,
+      "X-Caller-Service": CALLER_SERVICE,
+      "X-Caller-Method": caller.method,
+      "X-Caller-Path": caller.path,
+    },
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `[key-client] GET /internal/app-keys/${provider}/decrypt returned ${res.status}: ${text}`,
+    );
+  }
+
+  return (await res.json()) as DecryptedKey;
+}

--- a/src/lib/mcp-client.ts
+++ b/src/lib/mcp-client.ts
@@ -14,7 +14,7 @@ export interface McpConnection {
 export async function connectMcp(apiKey: string): Promise<McpConnection> {
   const transport = new StreamableHTTPClientTransport(new URL(`${MCP_SERVER_URL}/mcp`), {
     requestInit: {
-      headers: { "X-API-Key": apiKey },
+      headers: { Authorization: `Bearer ${apiKey}` },
     },
   });
 

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -1,0 +1,83 @@
+const RUNS_SERVICE_URL =
+  process.env.RUNS_SERVICE_URL || "https://runs.mcpfactory.org";
+const RUNS_SERVICE_API_KEY = process.env.RUNS_SERVICE_API_KEY;
+
+export interface RunsRun {
+  id: string;
+  organizationId: string;
+  appId: string;
+  serviceName: string;
+  taskName: string;
+  status: string;
+  startedAt: string;
+  createdAt: string;
+}
+
+export interface CreateRunParams {
+  clerkOrgId: string;
+  clerkUserId?: string;
+  appId: string;
+  serviceName: string;
+  taskName: string;
+  brandId?: string;
+  campaignId?: string;
+  parentRunId?: string;
+}
+
+export interface CostItem {
+  costName: string;
+  quantity: number;
+}
+
+async function runsRequest<T>(
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<T | null> {
+  if (!RUNS_SERVICE_API_KEY) {
+    console.warn("[runs-client] RUNS_SERVICE_API_KEY not set, skipping");
+    return null;
+  }
+  try {
+    const res = await fetch(`${RUNS_SERVICE_URL}${path}`, {
+      method,
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": RUNS_SERVICE_API_KEY,
+      },
+      ...(body ? { body: JSON.stringify(body) } : {}),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      console.warn(
+        `[runs-client] ${method} ${path} returned ${res.status}: ${text}`,
+      );
+      return null;
+    }
+    return (await res.json()) as T;
+  } catch (err) {
+    console.warn(`[runs-client] ${method} ${path} failed:`, err);
+    return null;
+  }
+}
+
+export async function createRun(
+  params: CreateRunParams,
+): Promise<RunsRun | null> {
+  return runsRequest<RunsRun>("POST", "/v1/runs", params);
+}
+
+export async function updateRunStatus(
+  id: string,
+  status: "completed" | "failed",
+): Promise<RunsRun | null> {
+  return runsRequest<RunsRun>("PATCH", `/v1/runs/${id}`, { status });
+}
+
+export async function addRunCosts(
+  id: string,
+  items: CostItem[],
+): Promise<void> {
+  if (items.length === 0) return;
+  await runsRequest("POST", `/v1/runs/${id}/costs`, { items });
+}

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -85,8 +85,8 @@ registry.registerPath({
     "Send a message and receive a streamed AI response via Server-Sent Events (SSE). Supports MCP tool calling and quick-reply buttons.",
   request: {
     headers: z.object({
-      "x-api-key": z.string().openapi({
-        description: "API key used to scope sessions by organization",
+      authorization: z.string().openapi({
+        description: "Bearer token used to scope sessions by organization (format: Bearer <key>)",
       }),
     }),
     body: {
@@ -110,7 +110,7 @@ registry.registerPath({
       },
     },
     401: {
-      description: "Missing X-API-Key header",
+      description: "Missing or invalid Authorization Bearer header",
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
   },

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -2,9 +2,12 @@ import { beforeAll, afterAll } from "vitest";
 
 // Test setup - load env vars for integration tests
 beforeAll(() => {
-  process.env.GEMINI_API_KEY = process.env.GEMINI_API_KEY || "test-key";
   process.env.CHAT_SERVICE_DATABASE_URL =
     process.env.CHAT_SERVICE_DATABASE_URL || "postgresql://localhost/chat_test";
+  process.env.KEY_SERVICE_URL =
+    process.env.KEY_SERVICE_URL || "https://key.test.local";
+  process.env.KEY_SERVICE_API_KEY =
+    process.env.KEY_SERVICE_API_KEY || "test-key-svc-key";
 });
 
 afterAll(() => {

--- a/tests/unit/gemini.test.ts
+++ b/tests/unit/gemini.test.ts
@@ -145,6 +145,34 @@ describe("thoughtSignature preservation", () => {
   });
 });
 
+describe("system prompt references all MCP campaign tools", () => {
+  it("passes system prompt mentioning all campaign MCP tools to Gemini", async () => {
+    const client = createGeminiClient({ apiKey: "test-key" });
+    const gen = client.streamChat([], "hello");
+    for await (const _ of gen) {
+      /* drain */
+    }
+
+    const callArgs = mockGenerateContentStream.mock.calls.at(-1)?.[0];
+    const systemInstruction = callArgs?.config?.systemInstruction as string;
+
+    const expectedTools = [
+      "mcpfactory_list_brands",
+      "mcpfactory_suggest_icp",
+      "mcpfactory_create_campaign",
+      "mcpfactory_list_campaigns",
+      "mcpfactory_campaign_stats",
+      "mcpfactory_stop_campaign",
+      "mcpfactory_resume_campaign",
+      "mcpfactory_campaign_debug",
+    ];
+
+    for (const tool of expectedTools) {
+      expect(systemInstruction).toContain(tool);
+    }
+  });
+});
+
 describe("REQUEST_USER_INPUT_TOOL", () => {
   it("has correct name and required parameters", () => {
     expect(REQUEST_USER_INPUT_TOOL.name).toBe("request_user_input");

--- a/tests/unit/key-client.test.ts
+++ b/tests/unit/key-client.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  process.env.KEY_SERVICE_API_KEY = "test-key-svc-key";
+  process.env.KEY_SERVICE_URL = "https://key.test.local";
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.restoreAllMocks();
+});
+
+async function loadModule() {
+  vi.resetModules();
+  return import("../../src/lib/key-client.js");
+}
+
+describe("decryptAppKey", () => {
+  it("sends GET with correct URL, query params, and caller headers", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ provider: "gemini", key: "decrypted-key" }),
+    });
+
+    const { decryptAppKey } = await loadModule();
+    const result = await decryptAppKey("gemini", {
+      method: "POST",
+      path: "/chat",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://key.test.local/internal/app-keys/gemini/decrypt?appId=chat",
+      expect.objectContaining({
+        method: "GET",
+        headers: {
+          "x-api-key": "test-key-svc-key",
+          "X-Caller-Service": "chat",
+          "X-Caller-Method": "POST",
+          "X-Caller-Path": "/chat",
+        },
+      }),
+    );
+    expect(result).toEqual({ provider: "gemini", key: "decrypted-key" });
+  });
+
+  it("throws on HTTP 404 (key not configured)", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve("Key not configured"),
+    });
+
+    const { decryptAppKey } = await loadModule();
+    await expect(
+      decryptAppKey("gemini", { method: "POST", path: "/chat" }),
+    ).rejects.toThrow(/returned 404/);
+  });
+
+  it("throws on HTTP 400 (missing caller headers)", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: () => Promise.resolve("Missing required caller headers"),
+    });
+
+    const { decryptAppKey } = await loadModule();
+    await expect(
+      decryptAppKey("gemini", { method: "POST", path: "/chat" }),
+    ).rejects.toThrow(/returned 400/);
+  });
+
+  it("throws on HTTP 500 (server error)", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("Internal Server Error"),
+    });
+
+    const { decryptAppKey } = await loadModule();
+    await expect(
+      decryptAppKey("gemini", { method: "POST", path: "/chat" }),
+    ).rejects.toThrow(/returned 500/);
+  });
+
+  it("throws on network error", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("ECONNREFUSED"),
+    );
+
+    const { decryptAppKey } = await loadModule();
+    await expect(
+      decryptAppKey("gemini", { method: "POST", path: "/chat" }),
+    ).rejects.toThrow("ECONNREFUSED");
+  });
+
+  it("throws when KEY_SERVICE_API_KEY is not set", async () => {
+    delete process.env.KEY_SERVICE_API_KEY;
+
+    const { decryptAppKey } = await loadModule();
+    await expect(
+      decryptAppKey("gemini", { method: "POST", path: "/chat" }),
+    ).rejects.toThrow(/KEY_SERVICE_API_KEY is required/);
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("uses default KEY_SERVICE_URL when not set", async () => {
+    delete process.env.KEY_SERVICE_URL;
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ provider: "gemini", key: "key-123" }),
+    });
+
+    const { decryptAppKey } = await loadModule();
+    await decryptAppKey("gemini", { method: "POST", path: "/chat" });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://key.mcpfactory.org/internal/app-keys/gemini/decrypt?appId=chat",
+      expect.anything(),
+    );
+  });
+});

--- a/tests/unit/mcp-client.test.ts
+++ b/tests/unit/mcp-client.test.ts
@@ -53,7 +53,7 @@ describe("connectMcp", () => {
       }),
       expect.objectContaining({
         requestInit: {
-          headers: { "X-API-Key": "test-api-key" },
+          headers: { Authorization: "Bearer test-api-key" },
         },
       })
     );

--- a/tests/unit/runs-client.test.ts
+++ b/tests/unit/runs-client.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  process.env.RUNS_SERVICE_API_KEY = "test-runs-key";
+  process.env.RUNS_SERVICE_URL = "https://runs.test.local";
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.restoreAllMocks();
+});
+
+// Dynamic import so env vars are read fresh
+async function loadModule() {
+  vi.resetModules();
+  return import("../../src/lib/runs-client.js");
+}
+
+describe("createRun", () => {
+  it("sends POST /v1/runs with correct body and headers", async () => {
+    const mockRun = { id: "run-1", status: "running" };
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockRun),
+    });
+
+    const { createRun } = await loadModule();
+    const result = await createRun({
+      clerkOrgId: "org_123",
+      appId: "mcpfactory",
+      serviceName: "chat-service",
+      taskName: "chat",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://runs.test.local/v1/runs",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-API-Key": "test-runs-key",
+        },
+        body: JSON.stringify({
+          clerkOrgId: "org_123",
+          appId: "mcpfactory",
+          serviceName: "chat-service",
+          taskName: "chat",
+        }),
+      }),
+    );
+    expect(result).toEqual(mockRun);
+  });
+
+  it("returns null and logs on HTTP error", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("Internal Server Error"),
+    });
+
+    const { createRun } = await loadModule();
+    const result = await createRun({
+      clerkOrgId: "org_123",
+      appId: "mcpfactory",
+      serviceName: "chat-service",
+      taskName: "chat",
+    });
+
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("returns null and logs on network error", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    (fetch as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("ECONNREFUSED"),
+    );
+
+    const { createRun } = await loadModule();
+    const result = await createRun({
+      clerkOrgId: "org_123",
+      appId: "mcpfactory",
+      serviceName: "chat-service",
+      taskName: "chat",
+    });
+
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});
+
+describe("updateRunStatus", () => {
+  it("sends PATCH /v1/runs/{id} with status", async () => {
+    const mockRun = { id: "run-1", status: "completed" };
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockRun),
+    });
+
+    const { updateRunStatus } = await loadModule();
+    const result = await updateRunStatus("run-1", "completed");
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://runs.test.local/v1/runs/run-1",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ status: "completed" }),
+      }),
+    );
+    expect(result).toEqual(mockRun);
+  });
+
+  it("handles failed status", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: "run-1", status: "failed" }),
+    });
+
+    const { updateRunStatus } = await loadModule();
+    const result = await updateRunStatus("run-1", "failed");
+
+    expect(result?.status).toBe("failed");
+  });
+});
+
+describe("addRunCosts", () => {
+  it("sends POST /v1/runs/{id}/costs with items", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ costs: [] }),
+    });
+
+    const { addRunCosts } = await loadModule();
+    await addRunCosts("run-1", [
+      { costName: "gemini-3-flash-tokens-input", quantity: 100 },
+      { costName: "gemini-3-flash-tokens-output", quantity: 50 },
+    ]);
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://runs.test.local/v1/runs/run-1/costs",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          items: [
+            { costName: "gemini-3-flash-tokens-input", quantity: 100 },
+            { costName: "gemini-3-flash-tokens-output", quantity: 50 },
+          ],
+        }),
+      }),
+    );
+  });
+
+  it("skips request when items array is empty", async () => {
+    const { addRunCosts } = await loadModule();
+    await addRunCosts("run-1", []);
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("handles 422 unknown cost name gracefully", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 422,
+      text: () => Promise.resolve('{"error":"Unknown cost name"}'),
+    });
+
+    const { addRunCosts } = await loadModule();
+    await addRunCosts("run-1", [
+      { costName: "unknown-cost", quantity: 10 },
+    ]);
+
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});
+
+describe("missing RUNS_SERVICE_API_KEY", () => {
+  it("returns null without making requests", async () => {
+    delete process.env.RUNS_SERVICE_API_KEY;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { createRun } = await loadModule();
+    const result = await createRun({
+      clerkOrgId: "org_123",
+      appId: "mcpfactory",
+      serviceName: "chat-service",
+      taskName: "chat",
+    });
+
+    expect(result).toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("RUNS_SERVICE_API_KEY not set"),
+    );
+  });
+});

--- a/tests/unit/streaming.test.ts
+++ b/tests/unit/streaming.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * Inline the bufferToken logic from src/index.ts for unit testing.
+ * This mirrors the actual implementation to verify streaming behavior.
+ */
+const BUTTON_RE = /^[-*]\s*\[.+?\]\s*$/;
+
+function createBufferToken() {
+  const sent: { type: string; content: string }[] = [];
+  let fullResponse = "";
+  let lineBuf = "";
+  let held = "";
+
+  function sendSSE(data: { type: string; content: string }) {
+    sent.push(data);
+  }
+
+  function bufferToken(chunk: string): void {
+    fullResponse += chunk;
+
+    const combined = lineBuf + chunk;
+    const parts = combined.split("\n");
+    const partial = parts.pop()!;
+
+    for (const line of parts) {
+      const fullLine = line + "\n";
+      if (BUTTON_RE.test(line.trimEnd())) {
+        held += fullLine;
+      } else {
+        if (held) {
+          sendSSE({ type: "token", content: held });
+          held = "";
+        }
+        sendSSE({ type: "token", content: fullLine });
+      }
+    }
+
+    lineBuf = partial;
+
+    if (lineBuf && !/^[-*]\s*\[/.test(lineBuf)) {
+      if (held) {
+        sendSSE({ type: "token", content: held });
+        held = "";
+      }
+      sendSSE({ type: "token", content: lineBuf });
+      lineBuf = "";
+    }
+  }
+
+  return { bufferToken, sent, getHeld: () => held, getLineBuf: () => lineBuf, getFullResponse: () => fullResponse };
+}
+
+describe("bufferToken streaming", () => {
+  it("flushes partial lines immediately without waiting for newline", () => {
+    const { bufferToken, sent } = createBufferToken();
+
+    bufferToken("Hello ");
+    expect(sent).toEqual([{ type: "token", content: "Hello " }]);
+
+    bufferToken("world!");
+    expect(sent).toEqual([
+      { type: "token", content: "Hello " },
+      { type: "token", content: "world!" },
+    ]);
+  });
+
+  it("sends complete lines with newline included", () => {
+    const { bufferToken, sent } = createBufferToken();
+
+    bufferToken("Hello world!\n");
+    expect(sent).toEqual([{ type: "token", content: "Hello world!\n" }]);
+  });
+
+  it("handles multi-line chunks correctly", () => {
+    const { bufferToken, sent } = createBufferToken();
+
+    bufferToken("Line one\nLine two\nPartial");
+    expect(sent).toEqual([
+      { type: "token", content: "Line one\n" },
+      { type: "token", content: "Line two\n" },
+      { type: "token", content: "Partial" },
+    ]);
+  });
+
+  it("holds back complete button lines", () => {
+    const { bufferToken, sent, getHeld } = createBufferToken();
+
+    bufferToken("Choose:\n- [Option A]\n- [Option B]\n");
+    expect(sent).toEqual([{ type: "token", content: "Choose:\n" }]);
+    expect(getHeld()).toBe("- [Option A]\n- [Option B]\n");
+  });
+
+  it("holds partial line that looks like a button start", () => {
+    const { bufferToken, sent, getLineBuf } = createBufferToken();
+
+    bufferToken("- [Star");
+    // Should be held in lineBuf, not sent
+    expect(sent).toEqual([]);
+    expect(getLineBuf()).toBe("- [Star");
+  });
+
+  it("completes a button line and holds it", () => {
+    const { bufferToken, sent, getHeld } = createBufferToken();
+
+    bufferToken("- [Star");
+    bufferToken("t campaign]\n");
+    expect(sent).toEqual([]);
+    expect(getHeld()).toBe("- [Start campaign]\n");
+  });
+
+  it("flushes held non-button content when normal text follows", () => {
+    const { bufferToken, sent } = createBufferToken();
+
+    bufferToken("- [Option A]\n");
+    expect(sent).toEqual([]);
+
+    bufferToken("Regular text\n");
+    expect(sent).toEqual([
+      { type: "token", content: "- [Option A]\n" },
+      { type: "token", content: "Regular text\n" },
+    ]);
+  });
+
+  it("handles asterisk button syntax", () => {
+    const { bufferToken, sent, getHeld } = createBufferToken();
+
+    bufferToken("Pick:\n* [Yes]\n* [No]\n");
+    expect(sent).toEqual([{ type: "token", content: "Pick:\n" }]);
+    expect(getHeld()).toBe("* [Yes]\n* [No]\n");
+  });
+
+  it("streams a realistic multi-chunk response", () => {
+    const { bufferToken, sent, getHeld } = createBufferToken();
+
+    // Simulate Gemini sending in chunks (typical behavior)
+    bufferToken("I can help ");
+    bufferToken("you with that! ");
+    bufferToken("Here are your options:\n\n");
+    bufferToken("- [Create a campaign]\n");
+    bufferToken("- [View stats]\n");
+
+    expect(sent).toEqual([
+      { type: "token", content: "I can help " },
+      { type: "token", content: "you with that! " },
+      { type: "token", content: "Here are your options:\n" },
+      { type: "token", content: "\n" },
+    ]);
+    expect(getHeld()).toBe("- [Create a campaign]\n- [View stats]\n");
+  });
+
+  it("accumulates full response regardless of buffering", () => {
+    const { bufferToken, getFullResponse } = createBufferToken();
+
+    bufferToken("Hello ");
+    bufferToken("world!\n");
+    bufferToken("- [Button]\n");
+
+    expect(getFullResponse()).toBe("Hello world!\n- [Button]\n");
+  });
+
+  it("handles empty chunks gracefully", () => {
+    const { bufferToken, sent } = createBufferToken();
+
+    bufferToken("");
+    expect(sent).toEqual([]);
+
+    bufferToken("text");
+    expect(sent).toEqual([{ type: "token", content: "text" }]);
+  });
+
+  it("does not hold regular lines starting with dash", () => {
+    const { bufferToken, sent } = createBufferToken();
+
+    // "- plain item" doesn't match button pattern [...]
+    bufferToken("- plain item\n");
+    expect(sent).toEqual([{ type: "token", content: "- plain item\n" }]);
+  });
+});


### PR DESCRIPTION
## Summary
- **Fixed line-buffering in `bufferToken()`** — tokens were accumulated character-by-character and only sent to the client on `\n`. Long paragraphs arrived all at once instead of streaming incrementally. Now partial lines are flushed immediately, with only potential button lines (`- [...]`) held back for detection.
- **Added `X-Accel-Buffering: no` header** — prevents Railway's reverse proxy from buffering the SSE response.
- **Added 12 unit tests** for the streaming buffer logic covering partial lines, button detection, multi-chunk responses, and edge cases.

## Test plan
- [x] All 12 new streaming tests pass
- [x] Full unit test suite passes (75 tests)
- [ ] Manual verification: deploy and confirm tokens stream incrementally in the chat UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)