### PR TITLE
feat: remove appId, per-request key resolution, costSource, identity headers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
-GEMINI_API_KEY=your-gemini-api-key
 CHAT_SERVICE_DATABASE_URL=postgresql://neondb_owner:xxx@ep-xxx.aws.neon.tech/neondb?sslmode=require
+KEY_SERVICE_URL=https://key.mcpfactory.org
+KEY_SERVICE_API_KEY=your-key-service-api-key
 MCP_SERVER_URL=https://mcp.mcpfactory.org
 RUNS_SERVICE_URL=https://runs.mcpfactory.org
 RUNS_SERVICE_API_KEY=your-runs-service-api-key

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 GEMINI_API_KEY=your-gemini-api-key
 CHAT_SERVICE_DATABASE_URL=postgresql://neondb_owner:xxx@ep-xxx.aws.neon.tech/neondb?sslmode=require
 MCP_SERVER_URL=https://mcp.mcpfactory.org
+RUNS_SERVICE_URL=https://runs.mcpfactory.org
+RUNS_SERVICE_API_KEY=your-runs-service-api-key
 PORT=3002

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm run dev            # starts on port 3002
 
 ## SSE Protocol
 
-`POST /chat` with headers `Content-Type: application/json` and `X-API-Key: <your-key>`.
+`POST /chat` with headers `Content-Type: application/json` and `Authorization: Bearer <your-key>`.
 
 Request body:
 ```json

--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token st
 
 | Variable | Required | Description |
 |---|---|---|
-| `GEMINI_API_KEY` | Yes | Google Gemini API key |
+| `KEY_SERVICE_API_KEY` | Yes | Service-to-service key for key-service (used to decrypt the Gemini API key at startup) |
 | `CHAT_SERVICE_DATABASE_URL` | Yes | PostgreSQL connection string |
+| `KEY_SERVICE_URL` | No | Key-service endpoint (default: `https://key.mcpfactory.org`) |
 | `MCP_SERVER_URL` | No | MCP server endpoint (default: `https://mcp.mcpfactory.org`) |
 | `RUNS_SERVICE_URL` | No | RunsService endpoint (default: `https://runs.mcpfactory.org`) |
 | `RUNS_SERVICE_API_KEY` | No | API key for RunsService (runs tracking disabled if unset) |
@@ -151,6 +152,7 @@ src/
   lib/
     gemini.ts       # Gemini AI client, streaming + function calling
     mcp-client.ts   # MCP server connection via Streamable HTTP transport + tool execution
+    key-client.ts   # Key-service client for decrypting app keys (Gemini API key)
     runs-client.ts  # RunsService HTTP client for run tracking and cost reporting
 scripts/
   generate-openapi.ts  # Generates openapi.json from zod schemas via OpenApiGeneratorV3

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token st
 | `GEMINI_API_KEY` | Yes | Google Gemini API key |
 | `CHAT_SERVICE_DATABASE_URL` | Yes | PostgreSQL connection string |
 | `MCP_SERVER_URL` | No | MCP server endpoint (default: `https://mcp.mcpfactory.org`) |
+| `RUNS_SERVICE_URL` | No | RunsService endpoint (default: `https://runs.mcpfactory.org`) |
+| `RUNS_SERVICE_API_KEY` | No | API key for RunsService (runs tracking disabled if unset) |
 | `PORT` | No | Server port (default: `3002`) |
 
 ## Database
@@ -87,7 +89,7 @@ Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token st
 Uses PostgreSQL via Drizzle ORM. Two tables:
 
 - **sessions** - conversation sessions scoped by `orgId` (from the API key)
-- **messages** - chat messages with role, content, optional `toolCalls` and `buttons` JSONB
+- **messages** - chat messages with role, content, optional `toolCalls`, `buttons` JSONB, and `runId` linking to RunsService
 
 Migrations run automatically on server start. To generate new migrations after schema changes:
 
@@ -149,6 +151,7 @@ src/
   lib/
     gemini.ts       # Gemini AI client, streaming + function calling
     mcp-client.ts   # MCP server connection via Streamable HTTP transport + tool execution
+    runs-client.ts  # RunsService HTTP client for run tracking and cost reporting
 scripts/
   generate-openapi.ts  # Generates openapi.json from zod schemas via OpenApiGeneratorV3
 ```

--- a/README.md
+++ b/README.md
@@ -12,11 +12,15 @@ npm run dev            # starts on port 3002
 
 ## SSE Protocol
 
-`POST /chat` with headers `Content-Type: application/json` and `Authorization: Bearer <your-key>`.
+`POST /chat` with headers:
+- `Content-Type: application/json`
+- `Authorization: Bearer <mcp-auth-key>` (passed through to MCP server)
+- `x-org-id: <org-uuid>` (internal org UUID from client-service)
+- `x-user-id: <user-uuid>` (internal user UUID from client-service)
 
 Request body:
 ```json
-{ "message": "Hello", "sessionId": "optional-uuid" }
+{ "message": "Hello", "sessionId": "optional-uuid", "parentRunId": "optional-uuid" }
 ```
 
 The response is a stream of SSE events in this order:
@@ -77,7 +81,7 @@ Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token st
 
 | Variable | Required | Description |
 |---|---|---|
-| `KEY_SERVICE_API_KEY` | Yes | Service-to-service key for key-service (used to decrypt the Gemini API key at startup) |
+| `KEY_SERVICE_API_KEY` | Yes | Service-to-service key for key-service (used to resolve Gemini API keys per request) |
 | `CHAT_SERVICE_DATABASE_URL` | Yes | PostgreSQL connection string |
 | `KEY_SERVICE_URL` | No | Key-service endpoint (default: `https://key.mcpfactory.org`) |
 | `MCP_SERVER_URL` | No | MCP server endpoint (default: `https://mcp.mcpfactory.org`) |
@@ -89,7 +93,7 @@ Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token st
 
 Uses PostgreSQL via Drizzle ORM. Two tables:
 
-- **sessions** - conversation sessions scoped by `orgId` (from the API key)
+- **sessions** - conversation sessions scoped by `orgId` and `userId` (from identity headers)
 - **messages** - chat messages with role, content, optional `toolCalls`, `buttons` JSONB, and `runId` linking to RunsService
 
 Migrations run automatically on server start. To generate new migrations after schema changes:
@@ -152,8 +156,8 @@ src/
   lib/
     gemini.ts       # Gemini AI client, streaming + function calling
     mcp-client.ts   # MCP server connection via Streamable HTTP transport + tool execution
-    key-client.ts   # Key-service client for decrypting app keys (Gemini API key)
-    runs-client.ts  # RunsService HTTP client for run tracking and cost reporting
+    key-client.ts   # Key-service client for per-request key resolution (supports BYOK per org)
+    runs-client.ts  # RunsService HTTP client for run tracking and cost reporting (with costSource)
 scripts/
   generate-openapi.ts  # Generates openapi.json from zod schemas via OpenApiGeneratorV3
 ```

--- a/drizzle/0001_deep_richard_fisk.sql
+++ b/drizzle/0001_deep_richard_fisk.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "messages" ADD COLUMN "run_id" uuid;

--- a/drizzle/0002_yummy_doctor_doom.sql
+++ b/drizzle/0002_yummy_doctor_doom.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "sessions" ADD COLUMN "user_id" text;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,142 @@
+{
+  "id": "f3f504df-db03-47cc-87c7-f233a75a7cf7",
+  "prevId": "c1241ff6-8653-4bde-bf07-11e460f87235",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buttons": {
+          "name": "buttons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,148 @@
+{
+  "id": "e22ced71-8160-4027-b5bd-238801b8cae6",
+  "prevId": "f3f504df-db03-47cc-87c7-f233a75a7cf7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buttons": {
+          "name": "buttons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1770013953733,
       "tag": "0000_legal_naoko",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1770560977671,
+      "tag": "0001_deep_richard_fisk",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1770560977671,
       "tag": "0001_deep_richard_fisk",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1772452052522,
+      "tag": "0002_yummy_doctor_doom",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -17,6 +17,7 @@ export const messages = pgTable("messages", {
   toolCalls: jsonb("tool_calls").$type<ToolCallRecord[]>(),
   buttons: jsonb("buttons").$type<ButtonRecord[]>(),
   tokenCount: integer("token_count"),
+  runId: uuid("run_id"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -3,6 +3,7 @@ import { pgTable, uuid, text, timestamp, jsonb, integer } from "drizzle-orm/pg-c
 export const sessions = pgTable("sessions", {
   id: uuid("id").primaryKey().defaultRandom(),
   orgId: text("org_id").notNull(),
+  userId: text("user_id"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,9 @@ import { dirname, join } from "path";
 import { db } from "./db/index.js";
 import { sessions, messages } from "./db/schema.js";
 import { eq } from "drizzle-orm";
-import { createGeminiClient, REQUEST_USER_INPUT_TOOL } from "./lib/gemini.js";
+import { createGeminiClient, REQUEST_USER_INPUT_TOOL, type UsageMetadata } from "./lib/gemini.js";
 import { connectMcp, type McpConnection } from "./lib/mcp-client.js";
+import { createRun, updateRunStatus, addRunCosts } from "./lib/runs-client.js";
 import { ChatRequestSchema } from "./schemas.js";
 import type { Content, Part } from "@google/genai";
 import type { ButtonRecord, ToolCallRecord } from "./db/schema.js";
@@ -68,7 +69,12 @@ app.post("/chat", async (req, res) => {
   res.setHeader("Connection", "keep-alive");
   res.flushHeaders();
 
+  const gemini = createGeminiClient({ apiKey: GEMINI_API_KEY });
   let mcpConn: McpConnection | null = null;
+  let runId: string | undefined;
+  let chatFailed = false;
+  let totalPromptTokens = 0;
+  let totalOutputTokens = 0;
 
   try {
     // Get or create session
@@ -82,6 +88,15 @@ app.post("/chat", async (req, res) => {
     }
 
     sendSSE(res, { sessionId: currentSessionId });
+
+    // Register run in RunsService
+    const run = await createRun({
+      clerkOrgId: apiKey,
+      appId: "mcpfactory",
+      serviceName: "chat-service",
+      taskName: "chat",
+    });
+    if (run) runId = run.id;
 
     // Load conversation history
     const history = await db.query.messages.findMany({
@@ -111,7 +126,6 @@ app.post("/chat", async (req, res) => {
     });
 
     // Stream response from Gemini
-    const gemini = createGeminiClient({ apiKey: GEMINI_API_KEY });
     let fullResponse = "";
     const toolCalls: ToolCallRecord[] = [];
 
@@ -152,9 +166,19 @@ app.post("/chat", async (req, res) => {
       allTools
     );
 
+    function accumulateUsage(usage?: UsageMetadata) {
+      if (!usage) return;
+      totalPromptTokens += usage.promptTokens;
+      totalOutputTokens += usage.outputTokens;
+    }
+
     for await (const event of stream) {
       if (event.type === "token") {
         bufferToken(event.content);
+      }
+
+      if (event.type === "done") {
+        accumulateUsage(event.usage);
       }
 
       if (event.type === "function_call") {
@@ -222,6 +246,9 @@ app.post("/chat", async (req, res) => {
             if (contEvent.type === "token") {
               bufferToken(contEvent.content);
             }
+            if (contEvent.type === "done") {
+              accumulateUsage(contEvent.usage);
+            }
           }
         } catch (toolErr: unknown) {
           const errDetail = toolErr instanceof Error
@@ -270,10 +297,13 @@ app.post("/chat", async (req, res) => {
       content: cleanedResponse,
       toolCalls: toolCalls.length > 0 ? toolCalls : null,
       buttons: buttons.length > 0 ? buttons : null,
+      tokenCount: totalPromptTokens + totalOutputTokens || null,
+      runId: runId ?? null,
     });
 
     sendSSE(res, "[DONE]");
   } catch (err) {
+    chatFailed = true;
     console.error("Chat error:", err);
     sendSSE(res, {
       type: "token",
@@ -284,6 +314,24 @@ app.post("/chat", async (req, res) => {
     if (mcpConn) {
       mcpConn.close().catch(() => {});
     }
+
+    // Report run status and costs (fire-and-forget)
+    if (runId) {
+      const costModel = gemini.model.replace(/-preview$/, "");
+      const costItems = [
+        ...(totalPromptTokens > 0
+          ? [{ costName: `${costModel}-tokens-input`, quantity: totalPromptTokens }]
+          : []),
+        ...(totalOutputTokens > 0
+          ? [{ costName: `${costModel}-tokens-output`, quantity: totalOutputTokens }]
+          : []),
+      ];
+      Promise.all([
+        updateRunStatus(runId, chatFailed ? "failed" : "completed"),
+        addRunCosts(runId, costItems),
+      ]).catch(() => {});
+    }
+
     res.end();
   }
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,9 +47,10 @@ app.get("/health", (_req, res) => {
 });
 
 app.post("/chat", async (req, res) => {
-  const apiKey = req.headers["x-api-key"] as string | undefined;
+  const authHeader = req.headers["authorization"];
+  const apiKey = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : undefined;
   if (!apiKey) {
-    return res.status(401).json({ error: "X-API-Key header required" });
+    return res.status(401).json({ error: "Authorization: Bearer <key> header required" });
   }
 
   const parsed = ChatRequestSchema.safeParse(req.body);

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { eq } from "drizzle-orm";
 import { createGeminiClient, REQUEST_USER_INPUT_TOOL, type UsageMetadata } from "./lib/gemini.js";
 import { connectMcp, type McpConnection } from "./lib/mcp-client.js";
 import { createRun, updateRunStatus, addRunCosts } from "./lib/runs-client.js";
-import { decryptAppKey } from "./lib/key-client.js";
+import { resolveKey, type ResolvedKey } from "./lib/key-client.js";
 import { ChatRequestSchema } from "./schemas.js";
 import type { Content, Part } from "@google/genai";
 import type { ButtonRecord, ToolCallRecord } from "./db/schema.js";
@@ -24,8 +24,6 @@ app.use(cors());
 app.use(express.json());
 
 const PORT = parseInt(process.env.PORT || "3002", 10);
-
-let geminiApiKey: string;
 
 function sendSSE(res: express.Response, data: unknown) {
   res.write(`data: ${JSON.stringify(data)}\n\n`);
@@ -46,9 +44,20 @@ app.get("/health", (_req, res) => {
 });
 
 app.post("/chat", async (req, res) => {
+  // Identity headers (required)
+  const orgId = req.headers["x-org-id"];
+  const userId = req.headers["x-user-id"];
+  if (typeof orgId !== "string" || !orgId) {
+    return res.status(401).json({ error: "x-org-id header is required" });
+  }
+  if (typeof userId !== "string" || !userId) {
+    return res.status(401).json({ error: "x-user-id header is required" });
+  }
+
+  // Bearer token (still required for MCP auth pass-through)
   const authHeader = req.headers["authorization"];
-  const apiKey = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : undefined;
-  if (!apiKey) {
+  const bearerToken = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : undefined;
+  if (!bearerToken) {
     return res.status(401).json({ error: "Authorization: Bearer <key> header required" });
   }
 
@@ -59,7 +68,21 @@ app.post("/chat", async (req, res) => {
       .json({ error: "Invalid request", details: parsed.error.flatten() });
   }
 
-  const { message, sessionId } = parsed.data;
+  const { message, sessionId, parentRunId } = parsed.data;
+
+  // Resolve Gemini key per-request (supports BYOK per org)
+  let resolvedKey: ResolvedKey;
+  try {
+    resolvedKey = await resolveKey({
+      provider: "gemini",
+      orgId,
+      userId,
+      caller: { method: "POST", path: "/chat" },
+    });
+  } catch (err) {
+    console.error("Key resolution failed:", err);
+    return res.status(502).json({ error: "Failed to resolve API key" });
+  }
 
   // SSE headers
   res.setHeader("Content-Type", "text/event-stream");
@@ -67,7 +90,7 @@ app.post("/chat", async (req, res) => {
   res.setHeader("Connection", "keep-alive");
   res.flushHeaders();
 
-  const gemini = createGeminiClient({ apiKey: geminiApiKey });
+  const gemini = createGeminiClient({ apiKey: resolvedKey.key });
   let mcpConn: McpConnection | null = null;
   let runId: string | undefined;
   let chatFailed = false;
@@ -80,7 +103,7 @@ app.post("/chat", async (req, res) => {
     if (!currentSessionId) {
       const [session] = await db
         .insert(sessions)
-        .values({ orgId: apiKey })
+        .values({ orgId, userId })
         .returning();
       currentSessionId = session.id;
     }
@@ -89,10 +112,12 @@ app.post("/chat", async (req, res) => {
 
     // Register run in RunsService
     const run = await createRun({
-      clerkOrgId: apiKey,
-      appId: "mcpfactory",
+      orgId,
+      userId,
+      appId: "chat",
       serviceName: "chat-service",
       taskName: "chat",
+      ...(parentRunId ? { parentRunId } : {}),
     });
     if (run) runId = run.id;
 
@@ -111,7 +136,7 @@ app.post("/chat", async (req, res) => {
 
     // Connect to MCP to get available tools
     try {
-      mcpConn = await connectMcp(apiKey);
+      mcpConn = await connectMcp(bearerToken);
     } catch (err) {
       console.warn("MCP connection failed, proceeding without tools:", err);
     }
@@ -316,12 +341,13 @@ app.post("/chat", async (req, res) => {
     // Report run status and costs (fire-and-forget)
     if (runId) {
       const costModel = gemini.model.replace(/-preview$/, "");
+      const costSource = resolvedKey.keySource;
       const costItems = [
         ...(totalPromptTokens > 0
-          ? [{ costName: `${costModel}-tokens-input`, quantity: totalPromptTokens }]
+          ? [{ costName: `${costModel}-tokens-input`, costSource, quantity: totalPromptTokens }]
           : []),
         ...(totalOutputTokens > 0
-          ? [{ costName: `${costModel}-tokens-output`, quantity: totalOutputTokens }]
+          ? [{ costName: `${costModel}-tokens-output`, costSource, quantity: totalOutputTokens }]
           : []),
       ];
       Promise.all([
@@ -368,14 +394,8 @@ function stripButtons(text: string): string {
 // Only start server if not in test environment
 if (process.env.NODE_ENV !== "test") {
   migrate(db, { migrationsFolder: "./drizzle" })
-    .then(async () => {
+    .then(() => {
       console.log("Migrations complete");
-      const decrypted = await decryptAppKey("gemini", {
-        method: "POST",
-        path: "/chat",
-      });
-      geminiApiKey = decrypted.key;
-      console.log("Gemini API key resolved via key-service");
       app.listen(Number(PORT), "::", () => {
         console.log(`Service running on port ${PORT}`);
       });

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -19,14 +19,33 @@ Key behaviors:
 
 Available tools let you search for leads, create campaigns, and manage outreach on behalf of the user.
 
-You have access to mcpfactory_suggest_icp which analyzes a brand's website to suggest who they should target with cold emails. Call this tool when the user wants to create a campaign but hasn't specified their target audience (job titles, industries, or locations). Present the suggestions to the user for confirmation before creating the campaign. The returned person_titles, q_organization_keyword_tags, and organization_locations map directly to target_titles, target_industries, and target_locations in mcpfactory_create_campaign.
+## Campaign tools
+
+- mcpfactory_list_brands: List brands the user has set up.
+- mcpfactory_suggest_icp: Analyze a brand URL to suggest target audience (job titles, industries, locations). The returned person_titles, q_organization_keyword_tags, and organization_locations map directly to target_titles, target_industries, and target_locations in mcpfactory_create_campaign.
+- mcpfactory_create_campaign: Create and start a campaign. Required: name, brand_url, target_titles. Optional: target_industries, target_locations, max_daily_budget_usd, max_weekly_budget_usd, max_monthly_budget_usd, max_total_budget_usd, max_leads, end_date.
+- mcpfactory_list_campaigns: List campaigns, optionally filtered by status (ongoing, stopped, all). Use when the user asks about their campaigns.
+- mcpfactory_campaign_stats: Get campaign performance stats (leads, emails, opens, replies, costs). Use when the user asks how a campaign is doing.
+- mcpfactory_stop_campaign: Stop a running campaign by campaign_id.
+- mcpfactory_resume_campaign: Resume a stopped campaign by campaign_id.
+- mcpfactory_campaign_debug: Get detailed debug info for a campaign (status, runs, errors, pipeline state). Use when troubleshooting.
+
+## Campaign creation flow
 
 IMPORTANT: When the user wants to create a campaign or send cold emails, follow this flow:
 1. FIRST, call mcpfactory_list_brands to check if the user already has brands set up.
 2. If brands exist, present them as button options (e.g. - [https://mybrand.com]) and add a final option - [Use a different URL].
 3. If the user picks an existing brand, proceed with that brand URL.
 4. If no brands exist, or the user picks "Use a different URL", call request_user_input({ input_type: "url", label: "What's your brand URL?", placeholder: "https://yourbrand.com", field: "brand_url" }) to render a URL input widget.
-Never ask for the brand URL in plain text — always use either buttons (for existing brands) or the request_user_input tool (for new URLs).`;
+5. If the user hasn't specified a target audience, call mcpfactory_suggest_icp to get suggestions before creating.
+Never ask for the brand URL in plain text — always use either buttons (for existing brands) or the request_user_input tool (for new URLs).
+
+## Campaign management flow
+
+When the user asks about their campaigns, call mcpfactory_list_campaigns first.
+When they ask about a specific campaign's performance, call mcpfactory_campaign_stats with the campaign_id.
+When they want to stop or resume a campaign, use mcpfactory_stop_campaign or mcpfactory_resume_campaign.
+If something seems wrong with a campaign, use mcpfactory_campaign_debug to investigate.`;
 
 export const REQUEST_USER_INPUT_TOOL: FunctionDeclaration = {
   name: "request_user_input",

--- a/src/lib/key-client.ts
+++ b/src/lib/key-client.ts
@@ -1,0 +1,48 @@
+const KEY_SERVICE_URL =
+  process.env.KEY_SERVICE_URL || "https://key.mcpfactory.org";
+const KEY_SERVICE_API_KEY = process.env.KEY_SERVICE_API_KEY;
+
+const APP_ID = "chat";
+const CALLER_SERVICE = "chat";
+
+export interface CallerInfo {
+  method: string;
+  path: string;
+}
+
+export interface DecryptedKey {
+  provider: string;
+  key: string;
+}
+
+export async function decryptAppKey(
+  provider: string,
+  caller: CallerInfo,
+): Promise<DecryptedKey> {
+  if (!KEY_SERVICE_API_KEY) {
+    throw new Error(
+      "[key-client] KEY_SERVICE_API_KEY is required to decrypt app keys",
+    );
+  }
+
+  const url = `${KEY_SERVICE_URL}/internal/app-keys/${encodeURIComponent(provider)}/decrypt?appId=${encodeURIComponent(APP_ID)}`;
+
+  const res = await fetch(url, {
+    method: "GET",
+    headers: {
+      "x-api-key": KEY_SERVICE_API_KEY,
+      "X-Caller-Service": CALLER_SERVICE,
+      "X-Caller-Method": caller.method,
+      "X-Caller-Path": caller.path,
+    },
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `[key-client] GET /internal/app-keys/${provider}/decrypt returned ${res.status}: ${text}`,
+    );
+  }
+
+  return (await res.json()) as DecryptedKey;
+}

--- a/src/lib/key-client.ts
+++ b/src/lib/key-client.ts
@@ -1,8 +1,6 @@
 const KEY_SERVICE_URL =
   process.env.KEY_SERVICE_URL || "https://key.mcpfactory.org";
 const KEY_SERVICE_API_KEY = process.env.KEY_SERVICE_API_KEY;
-
-const APP_ID = "chat";
 const CALLER_SERVICE = "chat";
 
 export interface CallerInfo {
@@ -10,22 +8,31 @@ export interface CallerInfo {
   path: string;
 }
 
-export interface DecryptedKey {
+export interface KeyResolutionParams {
   provider: string;
-  key: string;
+  orgId: string;
+  userId: string;
+  caller: CallerInfo;
 }
 
-export async function decryptAppKey(
-  provider: string,
-  caller: CallerInfo,
-): Promise<DecryptedKey> {
+export interface ResolvedKey {
+  provider: string;
+  key: string;
+  keySource: "org" | "platform";
+}
+
+export async function resolveKey(
+  params: KeyResolutionParams,
+): Promise<ResolvedKey> {
   if (!KEY_SERVICE_API_KEY) {
     throw new Error(
-      "[key-client] KEY_SERVICE_API_KEY is required to decrypt app keys",
+      "[key-client] KEY_SERVICE_API_KEY is required to resolve keys",
     );
   }
 
-  const url = `${KEY_SERVICE_URL}/internal/app-keys/${encodeURIComponent(provider)}/decrypt?appId=${encodeURIComponent(APP_ID)}`;
+  const { provider, orgId, userId, caller } = params;
+  const qs = new URLSearchParams({ orgId, userId });
+  const url = `${KEY_SERVICE_URL}/keys/${encodeURIComponent(provider)}/decrypt?${qs}`;
 
   const res = await fetch(url, {
     method: "GET",
@@ -40,9 +47,9 @@ export async function decryptAppKey(
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `[key-client] GET /internal/app-keys/${provider}/decrypt returned ${res.status}: ${text}`,
+      `[key-client] GET /keys/${provider}/decrypt returned ${res.status}: ${text}`,
     );
   }
 
-  return (await res.json()) as DecryptedKey;
+  return (await res.json()) as ResolvedKey;
 }

--- a/src/lib/mcp-client.ts
+++ b/src/lib/mcp-client.ts
@@ -14,7 +14,7 @@ export interface McpConnection {
 export async function connectMcp(apiKey: string): Promise<McpConnection> {
   const transport = new StreamableHTTPClientTransport(new URL(`${MCP_SERVER_URL}/mcp`), {
     requestInit: {
-      headers: { "X-API-Key": apiKey },
+      headers: { Authorization: `Bearer ${apiKey}` },
     },
   });
 

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -1,0 +1,83 @@
+const RUNS_SERVICE_URL =
+  process.env.RUNS_SERVICE_URL || "https://runs.mcpfactory.org";
+const RUNS_SERVICE_API_KEY = process.env.RUNS_SERVICE_API_KEY;
+
+export interface RunsRun {
+  id: string;
+  organizationId: string;
+  appId: string;
+  serviceName: string;
+  taskName: string;
+  status: string;
+  startedAt: string;
+  createdAt: string;
+}
+
+export interface CreateRunParams {
+  clerkOrgId: string;
+  clerkUserId?: string;
+  appId: string;
+  serviceName: string;
+  taskName: string;
+  brandId?: string;
+  campaignId?: string;
+  parentRunId?: string;
+}
+
+export interface CostItem {
+  costName: string;
+  quantity: number;
+}
+
+async function runsRequest<T>(
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<T | null> {
+  if (!RUNS_SERVICE_API_KEY) {
+    console.warn("[runs-client] RUNS_SERVICE_API_KEY not set, skipping");
+    return null;
+  }
+  try {
+    const res = await fetch(`${RUNS_SERVICE_URL}${path}`, {
+      method,
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": RUNS_SERVICE_API_KEY,
+      },
+      ...(body ? { body: JSON.stringify(body) } : {}),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      console.warn(
+        `[runs-client] ${method} ${path} returned ${res.status}: ${text}`,
+      );
+      return null;
+    }
+    return (await res.json()) as T;
+  } catch (err) {
+    console.warn(`[runs-client] ${method} ${path} failed:`, err);
+    return null;
+  }
+}
+
+export async function createRun(
+  params: CreateRunParams,
+): Promise<RunsRun | null> {
+  return runsRequest<RunsRun>("POST", "/v1/runs", params);
+}
+
+export async function updateRunStatus(
+  id: string,
+  status: "completed" | "failed",
+): Promise<RunsRun | null> {
+  return runsRequest<RunsRun>("PATCH", `/v1/runs/${id}`, { status });
+}
+
+export async function addRunCosts(
+  id: string,
+  items: CostItem[],
+): Promise<void> {
+  if (items.length === 0) return;
+  await runsRequest("POST", `/v1/runs/${id}/costs`, { items });
+}

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -5,7 +5,6 @@ const RUNS_SERVICE_API_KEY = process.env.RUNS_SERVICE_API_KEY;
 export interface RunsRun {
   id: string;
   organizationId: string;
-  appId: string;
   serviceName: string;
   taskName: string;
   status: string;
@@ -14,18 +13,17 @@ export interface RunsRun {
 }
 
 export interface CreateRunParams {
-  clerkOrgId: string;
-  clerkUserId?: string;
+  orgId: string;
+  userId?: string;
   appId: string;
   serviceName: string;
   taskName: string;
-  brandId?: string;
-  campaignId?: string;
   parentRunId?: string;
 }
 
 export interface CostItem {
   costName: string;
+  costSource: "platform" | "org";
   quantity: number;
 }
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -85,8 +85,8 @@ registry.registerPath({
     "Send a message and receive a streamed AI response via Server-Sent Events (SSE). Supports MCP tool calling and quick-reply buttons.",
   request: {
     headers: z.object({
-      "x-api-key": z.string().openapi({
-        description: "API key used to scope sessions by organization",
+      authorization: z.string().openapi({
+        description: "Bearer token used to scope sessions by organization (format: Bearer <key>)",
       }),
     }),
     body: {
@@ -110,7 +110,7 @@ registry.registerPath({
       },
     },
     401: {
-      description: "Missing X-API-Key header",
+      description: "Missing or invalid Authorization Bearer header",
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
   },

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -71,6 +71,7 @@ export const ChatRequestSchema = z
   .object({
     message: z.string().min(1, "message is required"),
     sessionId: z.string().uuid().optional(),
+    parentRunId: z.string().uuid().optional(),
   })
   .openapi("ChatRequest");
 
@@ -86,7 +87,13 @@ registry.registerPath({
   request: {
     headers: z.object({
       authorization: z.string().openapi({
-        description: "Bearer token used to scope sessions by organization (format: Bearer <key>)",
+        description: "Bearer token for MCP server authentication (format: Bearer <key>)",
+      }),
+      "x-org-id": z.string().openapi({
+        description: "Internal organization UUID (from client-service)",
+      }),
+      "x-user-id": z.string().openapi({
+        description: "Internal user UUID (from client-service)",
       }),
     }),
     body: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import type { ButtonRecord, ToolCallRecord } from "./db/schema.js";
 export interface ChatRequest {
   message: string;
   sessionId?: string;
+  parentRunId?: string;
 }
 
 export interface SSETokenEvent {

--- a/tests/integration/db.test.ts
+++ b/tests/integration/db.test.ts
@@ -30,11 +30,12 @@ describe("database integration", () => {
   it("should create, read, and delete a session", async () => {
     const [created] = await db
       .insert(schema.sessions)
-      .values({ orgId: "test-org-integration" })
+      .values({ orgId: "test-org-integration", userId: "test-user-integration" })
       .returning();
 
     expect(created.id).toBeDefined();
     expect(created.orgId).toBe("test-org-integration");
+    expect(created.userId).toBe("test-user-integration");
     expect(created.createdAt).toBeInstanceOf(Date);
 
     const [found] = await db
@@ -58,7 +59,7 @@ describe("database integration", () => {
   it("should create a message linked to a session and cascade delete", async () => {
     const [session] = await db
       .insert(schema.sessions)
-      .values({ orgId: "test-org-msg" })
+      .values({ orgId: "test-org-msg", userId: "test-user-msg" })
       .returning();
 
     const [message] = await db
@@ -89,7 +90,7 @@ describe("database integration", () => {
   it("should store and retrieve toolCalls and buttons JSONB", async () => {
     const [session] = await db
       .insert(schema.sessions)
-      .values({ orgId: "test-org-jsonb" })
+      .values({ orgId: "test-org-jsonb", userId: "test-user-jsonb" })
       .returning();
 
     const toolCalls = [{ name: "search", args: { q: "test" }, result: { hits: 1 } }];

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -2,9 +2,12 @@ import { beforeAll, afterAll } from "vitest";
 
 // Test setup - load env vars for integration tests
 beforeAll(() => {
-  process.env.GEMINI_API_KEY = process.env.GEMINI_API_KEY || "test-key";
   process.env.CHAT_SERVICE_DATABASE_URL =
     process.env.CHAT_SERVICE_DATABASE_URL || "postgresql://localhost/chat_test";
+  process.env.KEY_SERVICE_URL =
+    process.env.KEY_SERVICE_URL || "https://key.test.local";
+  process.env.KEY_SERVICE_API_KEY =
+    process.env.KEY_SERVICE_API_KEY || "test-key-svc-key";
 });
 
 afterAll(() => {

--- a/tests/unit/gemini.test.ts
+++ b/tests/unit/gemini.test.ts
@@ -145,6 +145,34 @@ describe("thoughtSignature preservation", () => {
   });
 });
 
+describe("system prompt references all MCP campaign tools", () => {
+  it("passes system prompt mentioning all campaign MCP tools to Gemini", async () => {
+    const client = createGeminiClient({ apiKey: "test-key" });
+    const gen = client.streamChat([], "hello");
+    for await (const _ of gen) {
+      /* drain */
+    }
+
+    const callArgs = mockGenerateContentStream.mock.calls.at(-1)?.[0];
+    const systemInstruction = callArgs?.config?.systemInstruction as string;
+
+    const expectedTools = [
+      "mcpfactory_list_brands",
+      "mcpfactory_suggest_icp",
+      "mcpfactory_create_campaign",
+      "mcpfactory_list_campaigns",
+      "mcpfactory_campaign_stats",
+      "mcpfactory_stop_campaign",
+      "mcpfactory_resume_campaign",
+      "mcpfactory_campaign_debug",
+    ];
+
+    for (const tool of expectedTools) {
+      expect(systemInstruction).toContain(tool);
+    }
+  });
+});
+
 describe("REQUEST_USER_INPUT_TOOL", () => {
   it("has correct name and required parameters", () => {
     expect(REQUEST_USER_INPUT_TOOL.name).toBe("request_user_input");

--- a/tests/unit/key-client.test.ts
+++ b/tests/unit/key-client.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  process.env.KEY_SERVICE_API_KEY = "test-key-svc-key";
+  process.env.KEY_SERVICE_URL = "https://key.test.local";
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.restoreAllMocks();
+});
+
+async function loadModule() {
+  vi.resetModules();
+  return import("../../src/lib/key-client.js");
+}
+
+describe("decryptAppKey", () => {
+  it("sends GET with correct URL, query params, and caller headers", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ provider: "gemini", key: "decrypted-key" }),
+    });
+
+    const { decryptAppKey } = await loadModule();
+    const result = await decryptAppKey("gemini", {
+      method: "POST",
+      path: "/chat",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://key.test.local/internal/app-keys/gemini/decrypt?appId=chat",
+      expect.objectContaining({
+        method: "GET",
+        headers: {
+          "x-api-key": "test-key-svc-key",
+          "X-Caller-Service": "chat",
+          "X-Caller-Method": "POST",
+          "X-Caller-Path": "/chat",
+        },
+      }),
+    );
+    expect(result).toEqual({ provider: "gemini", key: "decrypted-key" });
+  });
+
+  it("throws on HTTP 404 (key not configured)", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve("Key not configured"),
+    });
+
+    const { decryptAppKey } = await loadModule();
+    await expect(
+      decryptAppKey("gemini", { method: "POST", path: "/chat" }),
+    ).rejects.toThrow(/returned 404/);
+  });
+
+  it("throws on HTTP 400 (missing caller headers)", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: () => Promise.resolve("Missing required caller headers"),
+    });
+
+    const { decryptAppKey } = await loadModule();
+    await expect(
+      decryptAppKey("gemini", { method: "POST", path: "/chat" }),
+    ).rejects.toThrow(/returned 400/);
+  });
+
+  it("throws on HTTP 500 (server error)", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("Internal Server Error"),
+    });
+
+    const { decryptAppKey } = await loadModule();
+    await expect(
+      decryptAppKey("gemini", { method: "POST", path: "/chat" }),
+    ).rejects.toThrow(/returned 500/);
+  });
+
+  it("throws on network error", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("ECONNREFUSED"),
+    );
+
+    const { decryptAppKey } = await loadModule();
+    await expect(
+      decryptAppKey("gemini", { method: "POST", path: "/chat" }),
+    ).rejects.toThrow("ECONNREFUSED");
+  });
+
+  it("throws when KEY_SERVICE_API_KEY is not set", async () => {
+    delete process.env.KEY_SERVICE_API_KEY;
+
+    const { decryptAppKey } = await loadModule();
+    await expect(
+      decryptAppKey("gemini", { method: "POST", path: "/chat" }),
+    ).rejects.toThrow(/KEY_SERVICE_API_KEY is required/);
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("uses default KEY_SERVICE_URL when not set", async () => {
+    delete process.env.KEY_SERVICE_URL;
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ provider: "gemini", key: "key-123" }),
+    });
+
+    const { decryptAppKey } = await loadModule();
+    await decryptAppKey("gemini", { method: "POST", path: "/chat" });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://key.mcpfactory.org/internal/app-keys/gemini/decrypt?appId=chat",
+      expect.anything(),
+    );
+  });
+});

--- a/tests/unit/key-client.test.ts
+++ b/tests/unit/key-client.test.ts
@@ -18,21 +18,28 @@ async function loadModule() {
   return import("../../src/lib/key-client.js");
 }
 
-describe("decryptAppKey", () => {
+describe("resolveKey", () => {
   it("sends GET with correct URL, query params, and caller headers", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ provider: "gemini", key: "decrypted-key" }),
+      json: () =>
+        Promise.resolve({
+          provider: "gemini",
+          key: "decrypted-key",
+          keySource: "platform",
+        }),
     });
 
-    const { decryptAppKey } = await loadModule();
-    const result = await decryptAppKey("gemini", {
-      method: "POST",
-      path: "/chat",
+    const { resolveKey } = await loadModule();
+    const result = await resolveKey({
+      provider: "gemini",
+      orgId: "org-uuid-1",
+      userId: "user-uuid-1",
+      caller: { method: "POST", path: "/chat" },
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://key.test.local/internal/app-keys/gemini/decrypt?appId=chat",
+      "https://key.test.local/keys/gemini/decrypt?orgId=org-uuid-1&userId=user-uuid-1",
       expect.objectContaining({
         method: "GET",
         headers: {
@@ -43,7 +50,33 @@ describe("decryptAppKey", () => {
         },
       }),
     );
-    expect(result).toEqual({ provider: "gemini", key: "decrypted-key" });
+    expect(result).toEqual({
+      provider: "gemini",
+      key: "decrypted-key",
+      keySource: "platform",
+    });
+  });
+
+  it("returns keySource 'org' for BYOK keys", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          provider: "gemini",
+          key: "user-own-key",
+          keySource: "org",
+        }),
+    });
+
+    const { resolveKey } = await loadModule();
+    const result = await resolveKey({
+      provider: "gemini",
+      orgId: "org-uuid-1",
+      userId: "user-uuid-1",
+      caller: { method: "POST", path: "/chat" },
+    });
+
+    expect(result.keySource).toBe("org");
   });
 
   it("throws on HTTP 404 (key not configured)", async () => {
@@ -53,9 +86,14 @@ describe("decryptAppKey", () => {
       text: () => Promise.resolve("Key not configured"),
     });
 
-    const { decryptAppKey } = await loadModule();
+    const { resolveKey } = await loadModule();
     await expect(
-      decryptAppKey("gemini", { method: "POST", path: "/chat" }),
+      resolveKey({
+        provider: "gemini",
+        orgId: "org-1",
+        userId: "user-1",
+        caller: { method: "POST", path: "/chat" },
+      }),
     ).rejects.toThrow(/returned 404/);
   });
 
@@ -66,9 +104,14 @@ describe("decryptAppKey", () => {
       text: () => Promise.resolve("Missing required caller headers"),
     });
 
-    const { decryptAppKey } = await loadModule();
+    const { resolveKey } = await loadModule();
     await expect(
-      decryptAppKey("gemini", { method: "POST", path: "/chat" }),
+      resolveKey({
+        provider: "gemini",
+        orgId: "org-1",
+        userId: "user-1",
+        caller: { method: "POST", path: "/chat" },
+      }),
     ).rejects.toThrow(/returned 400/);
   });
 
@@ -79,9 +122,14 @@ describe("decryptAppKey", () => {
       text: () => Promise.resolve("Internal Server Error"),
     });
 
-    const { decryptAppKey } = await loadModule();
+    const { resolveKey } = await loadModule();
     await expect(
-      decryptAppKey("gemini", { method: "POST", path: "/chat" }),
+      resolveKey({
+        provider: "gemini",
+        orgId: "org-1",
+        userId: "user-1",
+        caller: { method: "POST", path: "/chat" },
+      }),
     ).rejects.toThrow(/returned 500/);
   });
 
@@ -90,18 +138,28 @@ describe("decryptAppKey", () => {
       new Error("ECONNREFUSED"),
     );
 
-    const { decryptAppKey } = await loadModule();
+    const { resolveKey } = await loadModule();
     await expect(
-      decryptAppKey("gemini", { method: "POST", path: "/chat" }),
+      resolveKey({
+        provider: "gemini",
+        orgId: "org-1",
+        userId: "user-1",
+        caller: { method: "POST", path: "/chat" },
+      }),
     ).rejects.toThrow("ECONNREFUSED");
   });
 
   it("throws when KEY_SERVICE_API_KEY is not set", async () => {
     delete process.env.KEY_SERVICE_API_KEY;
 
-    const { decryptAppKey } = await loadModule();
+    const { resolveKey } = await loadModule();
     await expect(
-      decryptAppKey("gemini", { method: "POST", path: "/chat" }),
+      resolveKey({
+        provider: "gemini",
+        orgId: "org-1",
+        userId: "user-1",
+        caller: { method: "POST", path: "/chat" },
+      }),
     ).rejects.toThrow(/KEY_SERVICE_API_KEY is required/);
 
     expect(fetch).not.toHaveBeenCalled();
@@ -111,14 +169,26 @@ describe("decryptAppKey", () => {
     delete process.env.KEY_SERVICE_URL;
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ provider: "gemini", key: "key-123" }),
+      json: () =>
+        Promise.resolve({
+          provider: "gemini",
+          key: "key-123",
+          keySource: "platform",
+        }),
     });
 
-    const { decryptAppKey } = await loadModule();
-    await decryptAppKey("gemini", { method: "POST", path: "/chat" });
+    const { resolveKey } = await loadModule();
+    await resolveKey({
+      provider: "gemini",
+      orgId: "org-1",
+      userId: "user-1",
+      caller: { method: "POST", path: "/chat" },
+    });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://key.mcpfactory.org/internal/app-keys/gemini/decrypt?appId=chat",
+      expect.stringContaining(
+        "https://key.mcpfactory.org/keys/gemini/decrypt",
+      ),
       expect.anything(),
     );
   });

--- a/tests/unit/mcp-client.test.ts
+++ b/tests/unit/mcp-client.test.ts
@@ -53,7 +53,7 @@ describe("connectMcp", () => {
       }),
       expect.objectContaining({
         requestInit: {
-          headers: { "X-API-Key": "test-api-key" },
+          headers: { Authorization: "Bearer test-api-key" },
         },
       })
     );

--- a/tests/unit/runs-client.test.ts
+++ b/tests/unit/runs-client.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  process.env.RUNS_SERVICE_API_KEY = "test-runs-key";
+  process.env.RUNS_SERVICE_URL = "https://runs.test.local";
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.restoreAllMocks();
+});
+
+// Dynamic import so env vars are read fresh
+async function loadModule() {
+  vi.resetModules();
+  return import("../../src/lib/runs-client.js");
+}
+
+describe("createRun", () => {
+  it("sends POST /v1/runs with correct body and headers", async () => {
+    const mockRun = { id: "run-1", status: "running" };
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockRun),
+    });
+
+    const { createRun } = await loadModule();
+    const result = await createRun({
+      clerkOrgId: "org_123",
+      appId: "mcpfactory",
+      serviceName: "chat-service",
+      taskName: "chat",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://runs.test.local/v1/runs",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-API-Key": "test-runs-key",
+        },
+        body: JSON.stringify({
+          clerkOrgId: "org_123",
+          appId: "mcpfactory",
+          serviceName: "chat-service",
+          taskName: "chat",
+        }),
+      }),
+    );
+    expect(result).toEqual(mockRun);
+  });
+
+  it("returns null and logs on HTTP error", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("Internal Server Error"),
+    });
+
+    const { createRun } = await loadModule();
+    const result = await createRun({
+      clerkOrgId: "org_123",
+      appId: "mcpfactory",
+      serviceName: "chat-service",
+      taskName: "chat",
+    });
+
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("returns null and logs on network error", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    (fetch as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("ECONNREFUSED"),
+    );
+
+    const { createRun } = await loadModule();
+    const result = await createRun({
+      clerkOrgId: "org_123",
+      appId: "mcpfactory",
+      serviceName: "chat-service",
+      taskName: "chat",
+    });
+
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});
+
+describe("updateRunStatus", () => {
+  it("sends PATCH /v1/runs/{id} with status", async () => {
+    const mockRun = { id: "run-1", status: "completed" };
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockRun),
+    });
+
+    const { updateRunStatus } = await loadModule();
+    const result = await updateRunStatus("run-1", "completed");
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://runs.test.local/v1/runs/run-1",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ status: "completed" }),
+      }),
+    );
+    expect(result).toEqual(mockRun);
+  });
+
+  it("handles failed status", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: "run-1", status: "failed" }),
+    });
+
+    const { updateRunStatus } = await loadModule();
+    const result = await updateRunStatus("run-1", "failed");
+
+    expect(result?.status).toBe("failed");
+  });
+});
+
+describe("addRunCosts", () => {
+  it("sends POST /v1/runs/{id}/costs with items", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ costs: [] }),
+    });
+
+    const { addRunCosts } = await loadModule();
+    await addRunCosts("run-1", [
+      { costName: "gemini-3-flash-tokens-input", quantity: 100 },
+      { costName: "gemini-3-flash-tokens-output", quantity: 50 },
+    ]);
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://runs.test.local/v1/runs/run-1/costs",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          items: [
+            { costName: "gemini-3-flash-tokens-input", quantity: 100 },
+            { costName: "gemini-3-flash-tokens-output", quantity: 50 },
+          ],
+        }),
+      }),
+    );
+  });
+
+  it("skips request when items array is empty", async () => {
+    const { addRunCosts } = await loadModule();
+    await addRunCosts("run-1", []);
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("handles 422 unknown cost name gracefully", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 422,
+      text: () => Promise.resolve('{"error":"Unknown cost name"}'),
+    });
+
+    const { addRunCosts } = await loadModule();
+    await addRunCosts("run-1", [
+      { costName: "unknown-cost", quantity: 10 },
+    ]);
+
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});
+
+describe("missing RUNS_SERVICE_API_KEY", () => {
+  it("returns null without making requests", async () => {
+    delete process.env.RUNS_SERVICE_API_KEY;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { createRun } = await loadModule();
+    const result = await createRun({
+      clerkOrgId: "org_123",
+      appId: "mcpfactory",
+      serviceName: "chat-service",
+      taskName: "chat",
+    });
+
+    expect(result).toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("RUNS_SERVICE_API_KEY not set"),
+    );
+  });
+});

--- a/tests/unit/runs-client.test.ts
+++ b/tests/unit/runs-client.test.ts
@@ -29,8 +29,8 @@ describe("createRun", () => {
 
     const { createRun } = await loadModule();
     const result = await createRun({
-      clerkOrgId: "org_123",
-      appId: "mcpfactory",
+      orgId: "org_123",
+      appId: "chat",
       serviceName: "chat-service",
       taskName: "chat",
     });
@@ -44,14 +44,46 @@ describe("createRun", () => {
           "X-API-Key": "test-runs-key",
         },
         body: JSON.stringify({
-          clerkOrgId: "org_123",
-          appId: "mcpfactory",
+          orgId: "org_123",
+          appId: "chat",
           serviceName: "chat-service",
           taskName: "chat",
         }),
       }),
     );
     expect(result).toEqual(mockRun);
+  });
+
+  it("passes parentRunId when provided", async () => {
+    const mockRun = { id: "run-1", status: "running" };
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockRun),
+    });
+
+    const { createRun } = await loadModule();
+    await createRun({
+      orgId: "org_123",
+      userId: "user_456",
+      appId: "chat",
+      serviceName: "chat-service",
+      taskName: "chat",
+      parentRunId: "parent-run-id",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: JSON.stringify({
+          orgId: "org_123",
+          userId: "user_456",
+          appId: "chat",
+          serviceName: "chat-service",
+          taskName: "chat",
+          parentRunId: "parent-run-id",
+        }),
+      }),
+    );
   });
 
   it("returns null and logs on HTTP error", async () => {
@@ -64,8 +96,8 @@ describe("createRun", () => {
 
     const { createRun } = await loadModule();
     const result = await createRun({
-      clerkOrgId: "org_123",
-      appId: "mcpfactory",
+      orgId: "org_123",
+      appId: "chat",
       serviceName: "chat-service",
       taskName: "chat",
     });
@@ -82,8 +114,8 @@ describe("createRun", () => {
 
     const { createRun } = await loadModule();
     const result = await createRun({
-      clerkOrgId: "org_123",
-      appId: "mcpfactory",
+      orgId: "org_123",
+      appId: "chat",
       serviceName: "chat-service",
       taskName: "chat",
     });
@@ -128,7 +160,7 @@ describe("updateRunStatus", () => {
 });
 
 describe("addRunCosts", () => {
-  it("sends POST /v1/runs/{id}/costs with items", async () => {
+  it("sends POST /v1/runs/{id}/costs with items including costSource", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ costs: [] }),
@@ -136,8 +168,8 @@ describe("addRunCosts", () => {
 
     const { addRunCosts } = await loadModule();
     await addRunCosts("run-1", [
-      { costName: "gemini-3-flash-tokens-input", quantity: 100 },
-      { costName: "gemini-3-flash-tokens-output", quantity: 50 },
+      { costName: "gemini-3-flash-tokens-input", costSource: "platform", quantity: 100 },
+      { costName: "gemini-3-flash-tokens-output", costSource: "platform", quantity: 50 },
     ]);
 
     expect(fetch).toHaveBeenCalledWith(
@@ -146,8 +178,31 @@ describe("addRunCosts", () => {
         method: "POST",
         body: JSON.stringify({
           items: [
-            { costName: "gemini-3-flash-tokens-input", quantity: 100 },
-            { costName: "gemini-3-flash-tokens-output", quantity: 50 },
+            { costName: "gemini-3-flash-tokens-input", costSource: "platform", quantity: 100 },
+            { costName: "gemini-3-flash-tokens-output", costSource: "platform", quantity: 50 },
+          ],
+        }),
+      }),
+    );
+  });
+
+  it("sends costSource 'org' for BYOK costs", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ costs: [] }),
+    });
+
+    const { addRunCosts } = await loadModule();
+    await addRunCosts("run-1", [
+      { costName: "gemini-3-flash-tokens-input", costSource: "org", quantity: 100 },
+    ]);
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: JSON.stringify({
+          items: [
+            { costName: "gemini-3-flash-tokens-input", costSource: "org", quantity: 100 },
           ],
         }),
       }),
@@ -171,7 +226,7 @@ describe("addRunCosts", () => {
 
     const { addRunCosts } = await loadModule();
     await addRunCosts("run-1", [
-      { costName: "unknown-cost", quantity: 10 },
+      { costName: "unknown-cost", costSource: "platform", quantity: 10 },
     ]);
 
     expect(warnSpy).toHaveBeenCalled();
@@ -185,8 +240,8 @@ describe("missing RUNS_SERVICE_API_KEY", () => {
 
     const { createRun } = await loadModule();
     const result = await createRun({
-      clerkOrgId: "org_123",
-      appId: "mcpfactory",
+      orgId: "org_123",
+      appId: "chat",
       serviceName: "chat-service",
       taskName: "chat",
     });

--- a/tests/unit/schemas.test.ts
+++ b/tests/unit/schemas.test.ts
@@ -37,6 +37,27 @@ describe("ChatRequestSchema", () => {
     expect(result.success).toBe(false);
   });
 
+  it("accepts valid request with parentRunId", () => {
+    const result = ChatRequestSchema.safeParse({
+      message: "Hello",
+      parentRunId: "550e8400-e29b-41d4-a716-446655440000",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.parentRunId).toBe(
+        "550e8400-e29b-41d4-a716-446655440000",
+      );
+    }
+  });
+
+  it("rejects non-uuid parentRunId", () => {
+    const result = ChatRequestSchema.safeParse({
+      message: "Hello",
+      parentRunId: "not-a-uuid",
+    });
+    expect(result.success).toBe(false);
+  });
+
   it("strips extra fields", () => {
     const result = ChatRequestSchema.safeParse({
       message: "Hello",

--- a/tests/unit/types.test.ts
+++ b/tests/unit/types.test.ts
@@ -13,6 +13,11 @@ describe("types", () => {
     expect(req.sessionId).toBe("abc-123");
   });
 
+  it("ChatRequest with parentRunId", () => {
+    const req: ChatRequest = { message: "hi", parentRunId: "run-123" };
+    expect(req.parentRunId).toBe("run-123");
+  });
+
   it("SSETokenEvent shape", () => {
     const event: SSETokenEvent = { type: "token", content: "Hello" };
     expect(event.type).toBe("token");


### PR DESCRIPTION
## Summary

- **Remove appId from key resolution**: Switch from `GET /internal/app-keys/{provider}/decrypt?appId=chat` to `GET /keys/{provider}/decrypt?orgId=...&userId=...` — new key-service contract
- **Per-request key resolution**: Move Gemini key resolution from startup cache to per-request, enabling BYOK (Bring Your Own Key) per org. Key-service response now includes `keySource` ("platform" | "org")
- **Add costSource to runs-service costs**: Every cost item now includes `costSource` derived from key-service's `keySource` response — required by runs-service
- **Require x-org-id and x-user-id headers**: Identity comes from client-service headers instead of the Bearer token. Bearer token retained for MCP server auth pass-through
- **Accept parentRunId in request body**: Forwarded to runs-service for hierarchical run tracking
- **Add userId column to sessions table**: Migration 0002 adds nullable `user_id` to sessions (backward-compatible with existing rows)
- **Rename clerkOrgId → orgId in runs-client**: Match runs-service's actual field names; remove unused `brandId`/`campaignId` fields

## Test plan

- [x] All 68 unit tests pass (`npm run test:unit`)
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] OpenAPI spec regenerated with new headers and parentRunId
- [ ] Integration tests (CI will run against Neon branch)
- [ ] Deploy and verify key resolution works with new key-service endpoint
- [ ] Verify costSource flows correctly to runs-service

🤖 Generated with [Claude Code](https://claude.com/claude-code)