### PR TITLE
feat: per-request key resolution, costSource, parentRunId

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ Request body:
     "brandUrl": "https://example.com",
     "objective": "clicks",
     "budgetAmount": 500
-  }
+  },
+  "parentRunId": "optional-parent-run-uuid"
 }
 ```
 
@@ -76,6 +77,7 @@ Request body:
 - `appId` (required) — identifies which app config (system prompt, MCP) to use
 - `sessionId` (optional) — resume an existing session; omit to start a new one
 - `context` (optional) — free-form JSON injected into the system prompt for this request only (not stored)
+- `parentRunId` (optional, uuid) — links this chat run to a parent run in RunsService for hierarchical cost tracking
 
 The response is a stream of SSE events in this order:
 
@@ -135,7 +137,7 @@ Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token st
 
 | Variable | Required | Description |
 |---|---|---|
-| `KEY_SERVICE_API_KEY` | Yes | Service-to-service key for key-service (used to decrypt the Gemini API key at startup and org MCP keys at runtime) |
+| `KEY_SERVICE_API_KEY` | Yes | Service-to-service key for key-service (used to resolve the Gemini API key per-request and org MCP keys at runtime) |
 | `CHAT_SERVICE_DATABASE_URL` | Yes | PostgreSQL connection string |
 | `KEY_SERVICE_URL` | No | Key-service endpoint (default: `https://key.mcpfactory.org`) |
 | `RUNS_SERVICE_URL` | No | RunsService endpoint (default: `https://runs.mcpfactory.org`) |
@@ -207,7 +209,7 @@ src/
   lib/
     gemini.ts       # Gemini AI client, streaming + function calling, buildSystemPrompt helper
     mcp-client.ts   # MCP server connection via Streamable HTTP transport + tool execution
-    key-client.ts   # Key-service client for decrypting app keys (Gemini) and org BYOK keys (MCP)
+    key-client.ts   # Key-service client for resolving Gemini keys (platform or BYOK per org) and org MCP keys
     runs-client.ts  # RunsService HTTP client for run tracking and cost reporting
 scripts/
   generate-openapi.ts  # Generates openapi.json from zod schemas via OpenApiGeneratorV3

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import {
 } from "./lib/gemini.js";
 import { connectMcp, type McpConnection } from "./lib/mcp-client.js";
 import { createRun, updateRunStatus, addRunCosts } from "./lib/runs-client.js";
-import { decryptAppKey, decryptOrgKey } from "./lib/key-client.js";
+import { resolveKey, decryptOrgKey, type ResolvedKey } from "./lib/key-client.js";
 import { ChatRequestSchema, AppConfigRequestSchema } from "./schemas.js";
 import { requireAuth, type AuthLocals } from "./middleware/auth.js";
 import type { Content, Part } from "@google/genai";
@@ -107,7 +107,7 @@ app.post("/chat", requireAuth, async (req, res) => {
       .json({ error: "Invalid request", details: parsed.error.flatten() });
   }
 
-  const { message, sessionId, appId, context } = parsed.data;
+  const { message, sessionId, appId, context, parentRunId } = parsed.data;
 
   // Look up app config
   const [appConfig] = await db
@@ -121,18 +121,19 @@ app.post("/chat", requireAuth, async (req, res) => {
     });
   }
 
-  // Resolve Gemini API key for this app
-  let geminiKey: string;
+  // Resolve Gemini API key per-request (supports BYOK per org)
+  let resolvedKey: ResolvedKey;
   try {
-    const decrypted = await decryptAppKey("gemini", appId, {
-      method: "POST",
-      path: "/chat",
+    resolvedKey = await resolveKey({
+      provider: "gemini",
+      orgId,
+      userId,
+      caller: { method: "POST", path: "/chat" },
     });
-    geminiKey = decrypted.key;
   } catch (err) {
-    console.error(`Failed to resolve Gemini key for appId="${appId}":`, err);
-    return res.status(500).json({
-      error: `Failed to resolve Gemini API key for appId="${appId}". Ensure the key is registered in key-service.`,
+    console.error(`Failed to resolve Gemini key for org="${orgId}":`, err);
+    return res.status(502).json({
+      error: `Failed to resolve Gemini API key. Ensure the key is configured in key-service.`,
     });
   }
 
@@ -145,7 +146,7 @@ app.post("/chat", requireAuth, async (req, res) => {
 
   // Build system prompt with optional context
   const systemPrompt = buildSystemPrompt(appConfig.systemPrompt, context);
-  const gemini = createGeminiClient({ apiKey: geminiKey, systemPrompt });
+  const gemini = createGeminiClient({ apiKey: resolvedKey.key, systemPrompt });
 
   let mcpConn: McpConnection | null = null;
   let runId: string | undefined;
@@ -188,6 +189,7 @@ app.post("/chat", requireAuth, async (req, res) => {
       appId,
       serviceName: "chat-service",
       taskName: "chat",
+      ...(parentRunId ? { parentRunId } : {}),
     });
     if (run) runId = run.id;
 
@@ -447,12 +449,15 @@ app.post("/chat", requireAuth, async (req, res) => {
     // Report run status and costs (fire-and-forget)
     if (runId) {
       const costModel = gemini.model.replace(/-preview$/, "");
+      const costSource: "platform" | "org" =
+        resolvedKey.keySource === "org" ? "org" : "platform";
       const costItems = [
         ...(totalPromptTokens > 0
           ? [
               {
                 costName: `${costModel}-tokens-input`,
                 quantity: totalPromptTokens,
+                costSource,
               },
             ]
           : []),
@@ -461,6 +466,7 @@ app.post("/chat", requireAuth, async (req, res) => {
               {
                 costName: `${costModel}-tokens-output`,
                 quantity: totalOutputTokens,
+                costSource,
               },
             ]
           : []),

--- a/src/lib/key-client.ts
+++ b/src/lib/key-client.ts
@@ -14,18 +14,31 @@ export interface DecryptedKey {
   key: string;
 }
 
-export async function decryptAppKey(
-  provider: string,
-  appId: string,
-  caller: CallerInfo,
-): Promise<DecryptedKey> {
+export interface KeyResolutionParams {
+  provider: string;
+  orgId: string;
+  userId: string;
+  caller: CallerInfo;
+}
+
+export interface ResolvedKey {
+  provider: string;
+  key: string;
+  keySource: "org" | "platform";
+}
+
+export async function resolveKey(
+  params: KeyResolutionParams,
+): Promise<ResolvedKey> {
   if (!KEY_SERVICE_API_KEY) {
     throw new Error(
-      "[key-client] KEY_SERVICE_API_KEY is required to decrypt app keys",
+      "[key-client] KEY_SERVICE_API_KEY is required to resolve keys",
     );
   }
 
-  const url = `${KEY_SERVICE_URL}/internal/app-keys/${encodeURIComponent(provider)}/decrypt?appId=${encodeURIComponent(appId)}`;
+  const { provider, orgId, userId, caller } = params;
+  const qs = new URLSearchParams({ orgId, userId });
+  const url = `${KEY_SERVICE_URL}/keys/${encodeURIComponent(provider)}/decrypt?${qs}`;
 
   const res = await fetch(url, {
     method: "GET",
@@ -40,11 +53,11 @@ export async function decryptAppKey(
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `[key-client] GET /internal/app-keys/${provider}/decrypt returned ${res.status}: ${text}`,
+      `[key-client] GET /keys/${provider}/decrypt returned ${res.status}: ${text}`,
     );
   }
 
-  return (await res.json()) as DecryptedKey;
+  return (await res.json()) as ResolvedKey;
 }
 
 export async function decryptOrgKey(

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -19,14 +19,13 @@ export interface CreateRunParams {
   appId: string;
   serviceName: string;
   taskName: string;
-  brandId?: string;
-  campaignId?: string;
   parentRunId?: string;
 }
 
 export interface CostItem {
   costName: string;
   quantity: number;
+  costSource: "platform" | "org";
 }
 
 async function runsRequest<T>(

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -141,6 +141,7 @@ export const ChatRequestSchema = z
     sessionId: z.string().uuid().optional(),
     appId: z.string().min(1, "appId is required"),
     context: z.record(z.string(), z.unknown()).optional(),
+    parentRunId: z.string().uuid().optional(),
   })
   .openapi("ChatRequest");
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export interface ChatRequest {
   sessionId?: string;
   appId: string;
   context?: Record<string, unknown>;
+  parentRunId?: string;
 }
 
 export interface SSETokenEvent {

--- a/tests/unit/key-client.test.ts
+++ b/tests/unit/key-client.test.ts
@@ -18,22 +18,28 @@ async function loadModule() {
   return import("../../src/lib/key-client.js");
 }
 
-describe("decryptAppKey", () => {
+describe("resolveKey", () => {
   it("sends GET with correct URL, query params, and caller headers", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: () =>
-        Promise.resolve({ provider: "gemini", key: "decrypted-key" }),
+        Promise.resolve({
+          provider: "gemini",
+          key: "resolved-key",
+          keySource: "platform",
+        }),
     });
 
-    const { decryptAppKey } = await loadModule();
-    const result = await decryptAppKey("gemini", "chat", {
-      method: "POST",
-      path: "/chat",
+    const { resolveKey } = await loadModule();
+    const result = await resolveKey({
+      provider: "gemini",
+      orgId: "org-uuid-123",
+      userId: "user-uuid-456",
+      caller: { method: "POST", path: "/chat" },
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://key.test.local/internal/app-keys/gemini/decrypt?appId=chat",
+      "https://key.test.local/keys/gemini/decrypt?orgId=org-uuid-123&userId=user-uuid-456",
       expect.objectContaining({
         method: "GET",
         headers: {
@@ -44,7 +50,33 @@ describe("decryptAppKey", () => {
         },
       }),
     );
-    expect(result).toEqual({ provider: "gemini", key: "decrypted-key" });
+    expect(result).toEqual({
+      provider: "gemini",
+      key: "resolved-key",
+      keySource: "platform",
+    });
+  });
+
+  it("returns keySource 'org' for BYOK keys", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          provider: "gemini",
+          key: "user-own-key",
+          keySource: "org",
+        }),
+    });
+
+    const { resolveKey } = await loadModule();
+    const result = await resolveKey({
+      provider: "gemini",
+      orgId: "org-byok",
+      userId: "user-byok",
+      caller: { method: "POST", path: "/chat" },
+    });
+
+    expect(result.keySource).toBe("org");
   });
 
   it("throws on HTTP 404 (key not configured)", async () => {
@@ -54,9 +86,14 @@ describe("decryptAppKey", () => {
       text: () => Promise.resolve("Key not configured"),
     });
 
-    const { decryptAppKey } = await loadModule();
+    const { resolveKey } = await loadModule();
     await expect(
-      decryptAppKey("gemini", "chat", { method: "POST", path: "/chat" }),
+      resolveKey({
+        provider: "gemini",
+        orgId: "org-123",
+        userId: "user-123",
+        caller: { method: "POST", path: "/chat" },
+      }),
     ).rejects.toThrow(/returned 404/);
   });
 
@@ -67,9 +104,14 @@ describe("decryptAppKey", () => {
       text: () => Promise.resolve("Missing required caller headers"),
     });
 
-    const { decryptAppKey } = await loadModule();
+    const { resolveKey } = await loadModule();
     await expect(
-      decryptAppKey("gemini", "chat", { method: "POST", path: "/chat" }),
+      resolveKey({
+        provider: "gemini",
+        orgId: "org-123",
+        userId: "user-123",
+        caller: { method: "POST", path: "/chat" },
+      }),
     ).rejects.toThrow(/returned 400/);
   });
 
@@ -80,9 +122,14 @@ describe("decryptAppKey", () => {
       text: () => Promise.resolve("Internal Server Error"),
     });
 
-    const { decryptAppKey } = await loadModule();
+    const { resolveKey } = await loadModule();
     await expect(
-      decryptAppKey("gemini", "chat", { method: "POST", path: "/chat" }),
+      resolveKey({
+        provider: "gemini",
+        orgId: "org-123",
+        userId: "user-123",
+        caller: { method: "POST", path: "/chat" },
+      }),
     ).rejects.toThrow(/returned 500/);
   });
 
@@ -91,18 +138,28 @@ describe("decryptAppKey", () => {
       new Error("ECONNREFUSED"),
     );
 
-    const { decryptAppKey } = await loadModule();
+    const { resolveKey } = await loadModule();
     await expect(
-      decryptAppKey("gemini", "chat", { method: "POST", path: "/chat" }),
+      resolveKey({
+        provider: "gemini",
+        orgId: "org-123",
+        userId: "user-123",
+        caller: { method: "POST", path: "/chat" },
+      }),
     ).rejects.toThrow("ECONNREFUSED");
   });
 
   it("throws when KEY_SERVICE_API_KEY is not set", async () => {
     delete process.env.KEY_SERVICE_API_KEY;
 
-    const { decryptAppKey } = await loadModule();
+    const { resolveKey } = await loadModule();
     await expect(
-      decryptAppKey("gemini", "chat", { method: "POST", path: "/chat" }),
+      resolveKey({
+        provider: "gemini",
+        orgId: "org-123",
+        userId: "user-123",
+        caller: { method: "POST", path: "/chat" },
+      }),
     ).rejects.toThrow(/KEY_SERVICE_API_KEY is required/);
 
     expect(fetch).not.toHaveBeenCalled();
@@ -112,14 +169,24 @@ describe("decryptAppKey", () => {
     delete process.env.KEY_SERVICE_URL;
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ provider: "gemini", key: "key-123" }),
+      json: () =>
+        Promise.resolve({
+          provider: "gemini",
+          key: "key-123",
+          keySource: "platform",
+        }),
     });
 
-    const { decryptAppKey } = await loadModule();
-    await decryptAppKey("gemini", "chat", { method: "POST", path: "/chat" });
+    const { resolveKey } = await loadModule();
+    await resolveKey({
+      provider: "gemini",
+      orgId: "org-123",
+      userId: "user-123",
+      caller: { method: "POST", path: "/chat" },
+    });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://key.mcpfactory.org/internal/app-keys/gemini/decrypt?appId=chat",
+      "https://key.mcpfactory.org/keys/gemini/decrypt?orgId=org-123&userId=user-123",
       expect.anything(),
     );
   });

--- a/tests/unit/runs-client.test.ts
+++ b/tests/unit/runs-client.test.ts
@@ -56,6 +56,38 @@ describe("createRun", () => {
     expect(result).toEqual(mockRun);
   });
 
+  it("forwards parentRunId when provided", async () => {
+    const mockRun = { id: "run-2", status: "running" };
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockRun),
+    });
+
+    const { createRun } = await loadModule();
+    await createRun({
+      orgId: "org-uuid-123",
+      userId: "user-uuid-456",
+      appId: "sales-cold-emails",
+      serviceName: "chat-service",
+      taskName: "chat",
+      parentRunId: "parent-run-uuid",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://runs.test.local/v1/runs",
+      expect.objectContaining({
+        body: JSON.stringify({
+          orgId: "org-uuid-123",
+          userId: "user-uuid-456",
+          appId: "sales-cold-emails",
+          serviceName: "chat-service",
+          taskName: "chat",
+          parentRunId: "parent-run-uuid",
+        }),
+      }),
+    );
+  });
+
   it("returns null and logs on HTTP error", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
@@ -138,8 +170,8 @@ describe("addRunCosts", () => {
 
     const { addRunCosts } = await loadModule();
     await addRunCosts("run-1", [
-      { costName: "gemini-3-flash-tokens-input", quantity: 100 },
-      { costName: "gemini-3-flash-tokens-output", quantity: 50 },
+      { costName: "gemini-3-flash-tokens-input", quantity: 100, costSource: "platform" },
+      { costName: "gemini-3-flash-tokens-output", quantity: 50, costSource: "platform" },
     ]);
 
     expect(fetch).toHaveBeenCalledWith(
@@ -148,8 +180,8 @@ describe("addRunCosts", () => {
         method: "POST",
         body: JSON.stringify({
           items: [
-            { costName: "gemini-3-flash-tokens-input", quantity: 100 },
-            { costName: "gemini-3-flash-tokens-output", quantity: 50 },
+            { costName: "gemini-3-flash-tokens-input", quantity: 100, costSource: "platform" },
+            { costName: "gemini-3-flash-tokens-output", quantity: 50, costSource: "platform" },
           ],
         }),
       }),
@@ -173,7 +205,7 @@ describe("addRunCosts", () => {
 
     const { addRunCosts } = await loadModule();
     await addRunCosts("run-1", [
-      { costName: "unknown-cost", quantity: 10 },
+      { costName: "unknown-cost", quantity: 10, costSource: "platform" as const },
     ]);
 
     expect(warnSpy).toHaveBeenCalled();

--- a/tests/unit/schemas.test.ts
+++ b/tests/unit/schemas.test.ts
@@ -80,6 +80,40 @@ describe("ChatRequestSchema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts valid parentRunId (uuid)", () => {
+    const result = ChatRequestSchema.safeParse({
+      message: "Hello",
+      appId: "my-app",
+      parentRunId: "550e8400-e29b-41d4-a716-446655440000",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.parentRunId).toBe(
+        "550e8400-e29b-41d4-a716-446655440000",
+      );
+    }
+  });
+
+  it("rejects non-uuid parentRunId", () => {
+    const result = ChatRequestSchema.safeParse({
+      message: "Hello",
+      appId: "my-app",
+      parentRunId: "not-a-uuid",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts request without parentRunId", () => {
+    const result = ChatRequestSchema.safeParse({
+      message: "Hello",
+      appId: "my-app",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.parentRunId).toBeUndefined();
+    }
+  });
+
   it("strips extra fields", () => {
     const result = ChatRequestSchema.safeParse({
       message: "Hello",


### PR DESCRIPTION
## Summary
- **resolveKey**: Replace `decryptAppKey` with `resolveKey` in key-client — calls `GET /keys/{provider}/decrypt?orgId=...&userId=...` per-request, supporting both platform and BYOK (org) keys. Returns `keySource: "platform" | "org"`.
- **costSource**: Add `costSource` field to `CostItem` so runs-service can distinguish platform vs org key usage for billing.
- **parentRunId**: Add optional `parentRunId` (uuid) to `ChatRequest` schema, forwarded to `createRun` for hierarchical run tracking.

## Test plan
- [x] Updated key-client.test.ts for new `resolveKey` API (URL, query params, keySource values, error cases)
- [x] Updated runs-client.test.ts for `costSource` in cost items and `parentRunId` in createRun
- [x] Added schemas.test.ts tests for `parentRunId` validation (valid uuid, non-uuid, omitted)
- [x] All 101 unit tests pass
- [x] Build + OpenAPI generation succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)