### PR TITLE
feat: require x-run-id header and propagate parentRunId to runs-service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
-GEMINI_API_KEY=your-gemini-api-key
 CHAT_SERVICE_DATABASE_URL=postgresql://neondb_owner:xxx@ep-xxx.aws.neon.tech/neondb?sslmode=require
+KEY_SERVICE_URL=https://key.mcpfactory.org
+KEY_SERVICE_API_KEY=your-key-service-api-key
 MCP_SERVER_URL=https://mcp.mcpfactory.org
 RUNS_SERVICE_URL=https://runs.mcpfactory.org
 RUNS_SERVICE_API_KEY=your-runs-service-api-key

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 GEMINI_API_KEY=your-gemini-api-key
 CHAT_SERVICE_DATABASE_URL=postgresql://neondb_owner:xxx@ep-xxx.aws.neon.tech/neondb?sslmode=require
 MCP_SERVER_URL=https://mcp.mcpfactory.org
+RUNS_SERVICE_URL=https://runs.mcpfactory.org
+RUNS_SERVICE_API_KEY=your-runs-service-api-key
 PORT=3002

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm run dev            # starts on port 3002
 
 ## SSE Protocol
 
-`POST /chat` with headers `Content-Type: application/json` and `X-API-Key: <your-key>`.
+`POST /chat` with headers `Content-Type: application/json` and `Authorization: Bearer <your-key>`.
 
 Request body:
 ```json

--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token st
 
 | Variable | Required | Description |
 |---|---|---|
-| `GEMINI_API_KEY` | Yes | Google Gemini API key |
+| `KEY_SERVICE_API_KEY` | Yes | Service-to-service key for key-service (used to decrypt the Gemini API key at startup) |
 | `CHAT_SERVICE_DATABASE_URL` | Yes | PostgreSQL connection string |
+| `KEY_SERVICE_URL` | No | Key-service endpoint (default: `https://key.mcpfactory.org`) |
 | `MCP_SERVER_URL` | No | MCP server endpoint (default: `https://mcp.mcpfactory.org`) |
 | `RUNS_SERVICE_URL` | No | RunsService endpoint (default: `https://runs.mcpfactory.org`) |
 | `RUNS_SERVICE_API_KEY` | No | API key for RunsService (runs tracking disabled if unset) |
@@ -151,6 +152,7 @@ src/
   lib/
     gemini.ts       # Gemini AI client, streaming + function calling
     mcp-client.ts   # MCP server connection via Streamable HTTP transport + tool execution
+    key-client.ts   # Key-service client for decrypting app keys (Gemini API key)
     runs-client.ts  # RunsService HTTP client for run tracking and cost reporting
 scripts/
   generate-openapi.ts  # Generates openapi.json from zod schemas via OpenApiGeneratorV3

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token st
 | `GEMINI_API_KEY` | Yes | Google Gemini API key |
 | `CHAT_SERVICE_DATABASE_URL` | Yes | PostgreSQL connection string |
 | `MCP_SERVER_URL` | No | MCP server endpoint (default: `https://mcp.mcpfactory.org`) |
+| `RUNS_SERVICE_URL` | No | RunsService endpoint (default: `https://runs.mcpfactory.org`) |
+| `RUNS_SERVICE_API_KEY` | No | API key for RunsService (runs tracking disabled if unset) |
 | `PORT` | No | Server port (default: `3002`) |
 
 ## Database
@@ -87,7 +89,7 @@ Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token st
 Uses PostgreSQL via Drizzle ORM. Two tables:
 
 - **sessions** - conversation sessions scoped by `orgId` (from the API key)
-- **messages** - chat messages with role, content, optional `toolCalls` and `buttons` JSONB
+- **messages** - chat messages with role, content, optional `toolCalls`, `buttons` JSONB, and `runId` linking to RunsService
 
 Migrations run automatically on server start. To generate new migrations after schema changes:
 
@@ -149,6 +151,7 @@ src/
   lib/
     gemini.ts       # Gemini AI client, streaming + function calling
     mcp-client.ts   # MCP server connection via Streamable HTTP transport + tool execution
+    runs-client.ts  # RunsService HTTP client for run tracking and cost reporting
 scripts/
   generate-openapi.ts  # Generates openapi.json from zod schemas via OpenApiGeneratorV3
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,15 @@ npm run dev            # starts on port 3002
 
 ## SSE Protocol
 
-`POST /chat` with headers `Content-Type: application/json` and `Authorization: Bearer <your-key>`.
+`POST /chat` with the following headers:
+
+| Header | Required | Description |
+|---|---|---|
+| `Content-Type` | Yes | `application/json` |
+| `Authorization` | Yes | `Bearer <your-key>` |
+| `x-org-id` | Yes | Internal org UUID (from client-service) |
+| `x-user-id` | Yes | Internal user UUID (from client-service) |
+| `x-run-id` | Yes | Caller's run ID (used as `parentRunId` when creating this service's own run in runs-service) |
 
 Request body:
 ```json
@@ -89,7 +97,7 @@ Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token st
 
 Uses PostgreSQL via Drizzle ORM. Two tables:
 
-- **sessions** - conversation sessions scoped by `orgId` (from the API key)
+- **sessions** - conversation sessions scoped by `orgId` (from the `x-org-id` header)
 - **messages** - chat messages with role, content, optional `toolCalls`, `buttons` JSONB, and `runId` linking to RunsService
 
 Migrations run automatically on server start. To generate new migrations after schema changes:

--- a/drizzle/0001_deep_richard_fisk.sql
+++ b/drizzle/0001_deep_richard_fisk.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "messages" ADD COLUMN "run_id" uuid;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,142 @@
+{
+  "id": "f3f504df-db03-47cc-87c7-f233a75a7cf7",
+  "prevId": "c1241ff6-8653-4bde-bf07-11e460f87235",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buttons": {
+          "name": "buttons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1770013953733,
       "tag": "0000_legal_naoko",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1770560977671,
+      "tag": "0001_deep_richard_fisk",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,9 @@
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
         "@types/node": "^20.0.0",
+        "@types/supertest": "^7.2.0",
         "drizzle-kit": "^0.30.0",
+        "supertest": "^7.2.2",
         "tsx": "^4.0.0",
         "typescript": "^5.5.0",
         "vitest": "^2.0.0"
@@ -1286,6 +1288,29 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
     "node_modules/@petamoriken/float16": {
       "version": "3.9.3",
       "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.3.tgz",
@@ -1738,6 +1763,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/cors": {
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
@@ -1785,6 +1817,13 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1849,6 +1888,30 @@
       "dependencies": {
         "@types/mime": "^1",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.0.tgz",
+      "integrity": "sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -2049,6 +2112,13 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2058,6 +2128,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -2263,6 +2340,29 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -2297,6 +2397,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -2366,6 +2473,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -2383,6 +2500,17 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/drizzle-kit": {
@@ -2627,6 +2755,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.19.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.12.tgz",
@@ -2823,6 +2967,13 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -2911,6 +3062,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -2921,6 +3089,24 @@
       },
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -3168,6 +3354,22 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -4279,6 +4481,65 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
       }
     },
     "node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/node": "^20.0.0",
+    "@types/supertest": "^7.2.0",
     "drizzle-kit": "^0.30.0",
+    "supertest": "^7.2.2",
     "tsx": "^4.0.0",
     "typescript": "^5.5.0",
     "vitest": "^2.0.0"

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -17,6 +17,7 @@ export const messages = pgTable("messages", {
   toolCalls: jsonb("tool_calls").$type<ToolCallRecord[]>(),
   buttons: jsonb("buttons").$type<ButtonRecord[]>(),
   tokenCount: integer("token_count"),
+  runId: uuid("run_id"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,9 @@ import { dirname, join } from "path";
 import { db } from "./db/index.js";
 import { sessions, messages } from "./db/schema.js";
 import { eq } from "drizzle-orm";
-import { createGeminiClient, REQUEST_USER_INPUT_TOOL } from "./lib/gemini.js";
+import { createGeminiClient, REQUEST_USER_INPUT_TOOL, type UsageMetadata } from "./lib/gemini.js";
 import { connectMcp, type McpConnection } from "./lib/mcp-client.js";
+import { createRun, updateRunStatus, addRunCosts } from "./lib/runs-client.js";
 import { ChatRequestSchema } from "./schemas.js";
 import type { Content, Part } from "@google/genai";
 import type { ButtonRecord, ToolCallRecord } from "./db/schema.js";
@@ -68,7 +69,12 @@ app.post("/chat", async (req, res) => {
   res.setHeader("Connection", "keep-alive");
   res.flushHeaders();
 
+  const gemini = createGeminiClient({ apiKey: GEMINI_API_KEY });
   let mcpConn: McpConnection | null = null;
+  let runId: string | undefined;
+  let chatFailed = false;
+  let totalPromptTokens = 0;
+  let totalOutputTokens = 0;
 
   try {
     // Get or create session
@@ -82,6 +88,15 @@ app.post("/chat", async (req, res) => {
     }
 
     sendSSE(res, { sessionId: currentSessionId });
+
+    // Register run in RunsService
+    const run = await createRun({
+      clerkOrgId: apiKey,
+      appId: "mcpfactory",
+      serviceName: "chat-service",
+      taskName: "chat",
+    });
+    if (run) runId = run.id;
 
     // Load conversation history
     const history = await db.query.messages.findMany({
@@ -111,7 +126,6 @@ app.post("/chat", async (req, res) => {
     });
 
     // Stream response from Gemini
-    const gemini = createGeminiClient({ apiKey: GEMINI_API_KEY });
     let fullResponse = "";
     const toolCalls: ToolCallRecord[] = [];
 
@@ -152,9 +166,19 @@ app.post("/chat", async (req, res) => {
       allTools
     );
 
+    function accumulateUsage(usage?: UsageMetadata) {
+      if (!usage) return;
+      totalPromptTokens += usage.promptTokens;
+      totalOutputTokens += usage.outputTokens;
+    }
+
     for await (const event of stream) {
       if (event.type === "token") {
         bufferToken(event.content);
+      }
+
+      if (event.type === "done") {
+        accumulateUsage(event.usage);
       }
 
       if (event.type === "function_call") {
@@ -222,6 +246,9 @@ app.post("/chat", async (req, res) => {
             if (contEvent.type === "token") {
               bufferToken(contEvent.content);
             }
+            if (contEvent.type === "done") {
+              accumulateUsage(contEvent.usage);
+            }
           }
         } catch (toolErr: unknown) {
           const errDetail = toolErr instanceof Error
@@ -270,10 +297,13 @@ app.post("/chat", async (req, res) => {
       content: cleanedResponse,
       toolCalls: toolCalls.length > 0 ? toolCalls : null,
       buttons: buttons.length > 0 ? buttons : null,
+      tokenCount: totalPromptTokens + totalOutputTokens || null,
+      runId: runId ?? null,
     });
 
     sendSSE(res, "[DONE]");
   } catch (err) {
+    chatFailed = true;
     console.error("Chat error:", err);
     sendSSE(res, {
       type: "token",
@@ -284,6 +314,24 @@ app.post("/chat", async (req, res) => {
     if (mcpConn) {
       mcpConn.close().catch(() => {});
     }
+
+    // Report run status and costs (fire-and-forget)
+    if (runId) {
+      const costModel = gemini.model.replace(/-preview$/, "");
+      const costItems = [
+        ...(totalPromptTokens > 0
+          ? [{ costName: `${costModel}-tokens-input`, quantity: totalPromptTokens }]
+          : []),
+        ...(totalOutputTokens > 0
+          ? [{ costName: `${costModel}-tokens-output`, quantity: totalOutputTokens }]
+          : []),
+      ];
+      Promise.all([
+        updateRunStatus(runId, chatFailed ? "failed" : "completed"),
+        addRunCosts(runId, costItems),
+      ]).catch(() => {});
+    }
+
     res.end();
   }
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,9 +47,10 @@ app.get("/health", (_req, res) => {
 });
 
 app.post("/chat", async (req, res) => {
-  const apiKey = req.headers["x-api-key"] as string | undefined;
+  const authHeader = req.headers["authorization"];
+  const apiKey = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : undefined;
   if (!apiKey) {
-    return res.status(401).json({ error: "X-API-Key header required" });
+    return res.status(401).json({ error: "Authorization: Bearer <key> header required" });
   }
 
   const parsed = ChatRequestSchema.safeParse(req.body);

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,22 @@ app.post("/chat", async (req, res) => {
     return res.status(401).json({ error: "Authorization: Bearer <key> header required" });
   }
 
+  // Required inter-service headers
+  const orgId = req.headers["x-org-id"] as string | undefined;
+  const userId = req.headers["x-user-id"] as string | undefined;
+  const callerRunId = req.headers["x-run-id"] as string | undefined;
+
+  const missingHeaders = [
+    ...(!orgId ? ["x-org-id"] : []),
+    ...(!userId ? ["x-user-id"] : []),
+    ...(!callerRunId ? ["x-run-id"] : []),
+  ];
+  if (missingHeaders.length > 0) {
+    return res.status(400).json({
+      error: `Missing required headers: ${missingHeaders.join(", ")}`,
+    });
+  }
+
   const parsed = ChatRequestSchema.safeParse(req.body);
   if (!parsed.success) {
     return res
@@ -80,19 +96,21 @@ app.post("/chat", async (req, res) => {
     if (!currentSessionId) {
       const [session] = await db
         .insert(sessions)
-        .values({ orgId: apiKey })
+        .values({ orgId })
         .returning();
       currentSessionId = session.id;
     }
 
     sendSSE(res, { sessionId: currentSessionId });
 
-    // Register run in RunsService
+    // Register run in RunsService (caller's runId becomes our parentRunId)
     const run = await createRun({
-      clerkOrgId: apiKey,
+      clerkOrgId: orgId,
+      clerkUserId: userId,
       appId: "mcpfactory",
       serviceName: "chat-service",
       taskName: "chat",
+      parentRunId: callerRunId,
     });
     if (run) runId = run.id;
 

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -19,14 +19,33 @@ Key behaviors:
 
 Available tools let you search for leads, create campaigns, and manage outreach on behalf of the user.
 
-You have access to mcpfactory_suggest_icp which analyzes a brand's website to suggest who they should target with cold emails. Call this tool when the user wants to create a campaign but hasn't specified their target audience (job titles, industries, or locations). Present the suggestions to the user for confirmation before creating the campaign. The returned person_titles, q_organization_keyword_tags, and organization_locations map directly to target_titles, target_industries, and target_locations in mcpfactory_create_campaign.
+## Campaign tools
+
+- mcpfactory_list_brands: List brands the user has set up.
+- mcpfactory_suggest_icp: Analyze a brand URL to suggest target audience (job titles, industries, locations). The returned person_titles, q_organization_keyword_tags, and organization_locations map directly to target_titles, target_industries, and target_locations in mcpfactory_create_campaign.
+- mcpfactory_create_campaign: Create and start a campaign. Required: name, brand_url, target_titles. Optional: target_industries, target_locations, max_daily_budget_usd, max_weekly_budget_usd, max_monthly_budget_usd, max_total_budget_usd, max_leads, end_date.
+- mcpfactory_list_campaigns: List campaigns, optionally filtered by status (ongoing, stopped, all). Use when the user asks about their campaigns.
+- mcpfactory_campaign_stats: Get campaign performance stats (leads, emails, opens, replies, costs). Use when the user asks how a campaign is doing.
+- mcpfactory_stop_campaign: Stop a running campaign by campaign_id.
+- mcpfactory_resume_campaign: Resume a stopped campaign by campaign_id.
+- mcpfactory_campaign_debug: Get detailed debug info for a campaign (status, runs, errors, pipeline state). Use when troubleshooting.
+
+## Campaign creation flow
 
 IMPORTANT: When the user wants to create a campaign or send cold emails, follow this flow:
 1. FIRST, call mcpfactory_list_brands to check if the user already has brands set up.
 2. If brands exist, present them as button options (e.g. - [https://mybrand.com]) and add a final option - [Use a different URL].
 3. If the user picks an existing brand, proceed with that brand URL.
 4. If no brands exist, or the user picks "Use a different URL", call request_user_input({ input_type: "url", label: "What's your brand URL?", placeholder: "https://yourbrand.com", field: "brand_url" }) to render a URL input widget.
-Never ask for the brand URL in plain text — always use either buttons (for existing brands) or the request_user_input tool (for new URLs).`;
+5. If the user hasn't specified a target audience, call mcpfactory_suggest_icp to get suggestions before creating.
+Never ask for the brand URL in plain text — always use either buttons (for existing brands) or the request_user_input tool (for new URLs).
+
+## Campaign management flow
+
+When the user asks about their campaigns, call mcpfactory_list_campaigns first.
+When they ask about a specific campaign's performance, call mcpfactory_campaign_stats with the campaign_id.
+When they want to stop or resume a campaign, use mcpfactory_stop_campaign or mcpfactory_resume_campaign.
+If something seems wrong with a campaign, use mcpfactory_campaign_debug to investigate.`;
 
 export const REQUEST_USER_INPUT_TOOL: FunctionDeclaration = {
   name: "request_user_input",

--- a/src/lib/key-client.ts
+++ b/src/lib/key-client.ts
@@ -1,0 +1,48 @@
+const KEY_SERVICE_URL =
+  process.env.KEY_SERVICE_URL || "https://key.mcpfactory.org";
+const KEY_SERVICE_API_KEY = process.env.KEY_SERVICE_API_KEY;
+
+const APP_ID = "chat";
+const CALLER_SERVICE = "chat";
+
+export interface CallerInfo {
+  method: string;
+  path: string;
+}
+
+export interface DecryptedKey {
+  provider: string;
+  key: string;
+}
+
+export async function decryptAppKey(
+  provider: string,
+  caller: CallerInfo,
+): Promise<DecryptedKey> {
+  if (!KEY_SERVICE_API_KEY) {
+    throw new Error(
+      "[key-client] KEY_SERVICE_API_KEY is required to decrypt app keys",
+    );
+  }
+
+  const url = `${KEY_SERVICE_URL}/internal/app-keys/${encodeURIComponent(provider)}/decrypt?appId=${encodeURIComponent(APP_ID)}`;
+
+  const res = await fetch(url, {
+    method: "GET",
+    headers: {
+      "x-api-key": KEY_SERVICE_API_KEY,
+      "X-Caller-Service": CALLER_SERVICE,
+      "X-Caller-Method": caller.method,
+      "X-Caller-Path": caller.path,
+    },
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `[key-client] GET /internal/app-keys/${provider}/decrypt returned ${res.status}: ${text}`,
+    );
+  }
+
+  return (await res.json()) as DecryptedKey;
+}

--- a/src/lib/mcp-client.ts
+++ b/src/lib/mcp-client.ts
@@ -14,7 +14,7 @@ export interface McpConnection {
 export async function connectMcp(apiKey: string): Promise<McpConnection> {
   const transport = new StreamableHTTPClientTransport(new URL(`${MCP_SERVER_URL}/mcp`), {
     requestInit: {
-      headers: { "X-API-Key": apiKey },
+      headers: { Authorization: `Bearer ${apiKey}` },
     },
   });
 

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -1,0 +1,83 @@
+const RUNS_SERVICE_URL =
+  process.env.RUNS_SERVICE_URL || "https://runs.mcpfactory.org";
+const RUNS_SERVICE_API_KEY = process.env.RUNS_SERVICE_API_KEY;
+
+export interface RunsRun {
+  id: string;
+  organizationId: string;
+  appId: string;
+  serviceName: string;
+  taskName: string;
+  status: string;
+  startedAt: string;
+  createdAt: string;
+}
+
+export interface CreateRunParams {
+  clerkOrgId: string;
+  clerkUserId?: string;
+  appId: string;
+  serviceName: string;
+  taskName: string;
+  brandId?: string;
+  campaignId?: string;
+  parentRunId?: string;
+}
+
+export interface CostItem {
+  costName: string;
+  quantity: number;
+}
+
+async function runsRequest<T>(
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<T | null> {
+  if (!RUNS_SERVICE_API_KEY) {
+    console.warn("[runs-client] RUNS_SERVICE_API_KEY not set, skipping");
+    return null;
+  }
+  try {
+    const res = await fetch(`${RUNS_SERVICE_URL}${path}`, {
+      method,
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": RUNS_SERVICE_API_KEY,
+      },
+      ...(body ? { body: JSON.stringify(body) } : {}),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      console.warn(
+        `[runs-client] ${method} ${path} returned ${res.status}: ${text}`,
+      );
+      return null;
+    }
+    return (await res.json()) as T;
+  } catch (err) {
+    console.warn(`[runs-client] ${method} ${path} failed:`, err);
+    return null;
+  }
+}
+
+export async function createRun(
+  params: CreateRunParams,
+): Promise<RunsRun | null> {
+  return runsRequest<RunsRun>("POST", "/v1/runs", params);
+}
+
+export async function updateRunStatus(
+  id: string,
+  status: "completed" | "failed",
+): Promise<RunsRun | null> {
+  return runsRequest<RunsRun>("PATCH", `/v1/runs/${id}`, { status });
+}
+
+export async function addRunCosts(
+  id: string,
+  items: CostItem[],
+): Promise<void> {
+  if (items.length === 0) return;
+  await runsRequest("POST", `/v1/runs/${id}/costs`, { items });
+}

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -85,8 +85,8 @@ registry.registerPath({
     "Send a message and receive a streamed AI response via Server-Sent Events (SSE). Supports MCP tool calling and quick-reply buttons.",
   request: {
     headers: z.object({
-      "x-api-key": z.string().openapi({
-        description: "API key used to scope sessions by organization",
+      authorization: z.string().openapi({
+        description: "Bearer token used to scope sessions by organization (format: Bearer <key>)",
       }),
     }),
     body: {
@@ -110,7 +110,7 @@ registry.registerPath({
       },
     },
     401: {
-      description: "Missing X-API-Key header",
+      description: "Missing or invalid Authorization Bearer header",
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
   },

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -86,7 +86,16 @@ registry.registerPath({
   request: {
     headers: z.object({
       authorization: z.string().openapi({
-        description: "Bearer token used to scope sessions by organization (format: Bearer <key>)",
+        description: "Bearer token for authentication (format: Bearer <key>)",
+      }),
+      "x-org-id": z.string().uuid().openapi({
+        description: "Internal org UUID (from client-service)",
+      }),
+      "x-user-id": z.string().uuid().openapi({
+        description: "Internal user UUID (from client-service)",
+      }),
+      "x-run-id": z.string().uuid().openapi({
+        description: "Caller's run ID (used as parentRunId when creating this service's own run)",
       }),
     }),
     body: {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -2,9 +2,12 @@ import { beforeAll, afterAll } from "vitest";
 
 // Test setup - load env vars for integration tests
 beforeAll(() => {
-  process.env.GEMINI_API_KEY = process.env.GEMINI_API_KEY || "test-key";
   process.env.CHAT_SERVICE_DATABASE_URL =
     process.env.CHAT_SERVICE_DATABASE_URL || "postgresql://localhost/chat_test";
+  process.env.KEY_SERVICE_URL =
+    process.env.KEY_SERVICE_URL || "https://key.test.local";
+  process.env.KEY_SERVICE_API_KEY =
+    process.env.KEY_SERVICE_API_KEY || "test-key-svc-key";
 });
 
 afterAll(() => {

--- a/tests/unit/chat-headers.test.ts
+++ b/tests/unit/chat-headers.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi } from "vitest";
+import request from "supertest";
+
+// Mock all heavy dependencies so we can import the Express app
+vi.mock("../../src/db/index.js", () => {
+  function makeValues() {
+    const result: Record<string, unknown> = {
+      returning: vi.fn().mockResolvedValue([{ id: "session-1" }]),
+    };
+    result.then = (
+      resolve: (v: unknown) => void,
+      reject?: (e: unknown) => void,
+    ) => Promise.resolve().then(() => resolve(undefined), reject);
+    return result;
+  }
+  return {
+    db: {
+      insert: vi.fn().mockImplementation(() => ({
+        values: vi.fn().mockImplementation(() => makeValues()),
+      })),
+      query: {
+        messages: {
+          findMany: vi.fn().mockResolvedValue([]),
+        },
+      },
+    },
+  };
+});
+
+vi.mock("../../src/lib/gemini.js", () => ({
+  createGeminiClient: vi.fn().mockImplementation(() => ({
+    model: "gemini-2.5-flash",
+    streamChat: vi.fn().mockReturnValue(
+      (async function* () {
+        yield { type: "done", usage: { promptTokens: 10, outputTokens: 5 } };
+      })(),
+    ),
+    sendFunctionResult: vi.fn(),
+  })),
+  REQUEST_USER_INPUT_TOOL: { name: "request_user_input" },
+}));
+
+vi.mock("../../src/lib/mcp-client.js", () => ({
+  connectMcp: vi.fn().mockRejectedValue(new Error("mocked")),
+}));
+
+const mockCreateRun = vi.fn().mockResolvedValue({ id: "run-1" });
+vi.mock("../../src/lib/runs-client.js", () => ({
+  createRun: mockCreateRun,
+  updateRunStatus: vi.fn().mockResolvedValue(null),
+  addRunCosts: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../src/lib/key-client.js", () => ({
+  decryptAppKey: vi.fn().mockResolvedValue({ key: "test-gemini-key" }),
+}));
+
+vi.mock("drizzle-orm", async (importOriginal) => {
+  const orig = await importOriginal<typeof import("drizzle-orm")>();
+  return { ...orig, eq: vi.fn() };
+});
+
+vi.mock("drizzle-orm/postgres-js/migrator", () => ({
+  migrate: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Import app once (all mocks already registered above)
+process.env.NODE_ENV = "test";
+const { default: app } = await import("../../src/index.js");
+
+const VALID_HEADERS = {
+  Authorization: "Bearer test-api-key",
+  "x-org-id": "550e8400-e29b-41d4-a716-446655440000",
+  "x-user-id": "660e8400-e29b-41d4-a716-446655440001",
+  "x-run-id": "770e8400-e29b-41d4-a716-446655440002",
+};
+
+describe("POST /chat required headers", () => {
+  it("returns 400 when x-org-id is missing", async () => {
+    const res = await request(app)
+      .post("/chat")
+      .set("Authorization", "Bearer test-key")
+      .set("x-user-id", VALID_HEADERS["x-user-id"])
+      .set("x-run-id", VALID_HEADERS["x-run-id"])
+      .send({ message: "hello" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("x-org-id");
+  });
+
+  it("returns 400 when x-user-id is missing", async () => {
+    const res = await request(app)
+      .post("/chat")
+      .set("Authorization", "Bearer test-key")
+      .set("x-org-id", VALID_HEADERS["x-org-id"])
+      .set("x-run-id", VALID_HEADERS["x-run-id"])
+      .send({ message: "hello" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("x-user-id");
+  });
+
+  it("returns 400 when x-run-id is missing", async () => {
+    const res = await request(app)
+      .post("/chat")
+      .set("Authorization", "Bearer test-key")
+      .set("x-org-id", VALID_HEADERS["x-org-id"])
+      .set("x-user-id", VALID_HEADERS["x-user-id"])
+      .send({ message: "hello" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("x-run-id");
+  });
+
+  it("returns 400 listing all missing headers when none provided", async () => {
+    const res = await request(app)
+      .post("/chat")
+      .set("Authorization", "Bearer test-key")
+      .send({ message: "hello" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("x-org-id");
+    expect(res.body.error).toContain("x-user-id");
+    expect(res.body.error).toContain("x-run-id");
+  });
+
+  it("returns 401 before checking headers when auth is missing", async () => {
+    const res = await request(app)
+      .post("/chat")
+      .send({ message: "hello" });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("passes parentRunId, orgId, and userId to createRun from headers", async () => {
+    mockCreateRun.mockClear();
+
+    await request(app)
+      .post("/chat")
+      .set(VALID_HEADERS)
+      .send({ message: "hello" });
+
+    expect(mockCreateRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parentRunId: VALID_HEADERS["x-run-id"],
+        clerkOrgId: VALID_HEADERS["x-org-id"],
+        clerkUserId: VALID_HEADERS["x-user-id"],
+      }),
+    );
+  });
+});

--- a/tests/unit/gemini.test.ts
+++ b/tests/unit/gemini.test.ts
@@ -145,6 +145,34 @@ describe("thoughtSignature preservation", () => {
   });
 });
 
+describe("system prompt references all MCP campaign tools", () => {
+  it("passes system prompt mentioning all campaign MCP tools to Gemini", async () => {
+    const client = createGeminiClient({ apiKey: "test-key" });
+    const gen = client.streamChat([], "hello");
+    for await (const _ of gen) {
+      /* drain */
+    }
+
+    const callArgs = mockGenerateContentStream.mock.calls.at(-1)?.[0];
+    const systemInstruction = callArgs?.config?.systemInstruction as string;
+
+    const expectedTools = [
+      "mcpfactory_list_brands",
+      "mcpfactory_suggest_icp",
+      "mcpfactory_create_campaign",
+      "mcpfactory_list_campaigns",
+      "mcpfactory_campaign_stats",
+      "mcpfactory_stop_campaign",
+      "mcpfactory_resume_campaign",
+      "mcpfactory_campaign_debug",
+    ];
+
+    for (const tool of expectedTools) {
+      expect(systemInstruction).toContain(tool);
+    }
+  });
+});
+
 describe("REQUEST_USER_INPUT_TOOL", () => {
   it("has correct name and required parameters", () => {
     expect(REQUEST_USER_INPUT_TOOL.name).toBe("request_user_input");

--- a/tests/unit/key-client.test.ts
+++ b/tests/unit/key-client.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  process.env.KEY_SERVICE_API_KEY = "test-key-svc-key";
+  process.env.KEY_SERVICE_URL = "https://key.test.local";
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.restoreAllMocks();
+});
+
+async function loadModule() {
+  vi.resetModules();
+  return import("../../src/lib/key-client.js");
+}
+
+describe("decryptAppKey", () => {
+  it("sends GET with correct URL, query params, and caller headers", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ provider: "gemini", key: "decrypted-key" }),
+    });
+
+    const { decryptAppKey } = await loadModule();
+    const result = await decryptAppKey("gemini", {
+      method: "POST",
+      path: "/chat",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://key.test.local/internal/app-keys/gemini/decrypt?appId=chat",
+      expect.objectContaining({
+        method: "GET",
+        headers: {
+          "x-api-key": "test-key-svc-key",
+          "X-Caller-Service": "chat",
+          "X-Caller-Method": "POST",
+          "X-Caller-Path": "/chat",
+        },
+      }),
+    );
+    expect(result).toEqual({ provider: "gemini", key: "decrypted-key" });
+  });
+
+  it("throws on HTTP 404 (key not configured)", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve("Key not configured"),
+    });
+
+    const { decryptAppKey } = await loadModule();
+    await expect(
+      decryptAppKey("gemini", { method: "POST", path: "/chat" }),
+    ).rejects.toThrow(/returned 404/);
+  });
+
+  it("throws on HTTP 400 (missing caller headers)", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: () => Promise.resolve("Missing required caller headers"),
+    });
+
+    const { decryptAppKey } = await loadModule();
+    await expect(
+      decryptAppKey("gemini", { method: "POST", path: "/chat" }),
+    ).rejects.toThrow(/returned 400/);
+  });
+
+  it("throws on HTTP 500 (server error)", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("Internal Server Error"),
+    });
+
+    const { decryptAppKey } = await loadModule();
+    await expect(
+      decryptAppKey("gemini", { method: "POST", path: "/chat" }),
+    ).rejects.toThrow(/returned 500/);
+  });
+
+  it("throws on network error", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("ECONNREFUSED"),
+    );
+
+    const { decryptAppKey } = await loadModule();
+    await expect(
+      decryptAppKey("gemini", { method: "POST", path: "/chat" }),
+    ).rejects.toThrow("ECONNREFUSED");
+  });
+
+  it("throws when KEY_SERVICE_API_KEY is not set", async () => {
+    delete process.env.KEY_SERVICE_API_KEY;
+
+    const { decryptAppKey } = await loadModule();
+    await expect(
+      decryptAppKey("gemini", { method: "POST", path: "/chat" }),
+    ).rejects.toThrow(/KEY_SERVICE_API_KEY is required/);
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("uses default KEY_SERVICE_URL when not set", async () => {
+    delete process.env.KEY_SERVICE_URL;
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ provider: "gemini", key: "key-123" }),
+    });
+
+    const { decryptAppKey } = await loadModule();
+    await decryptAppKey("gemini", { method: "POST", path: "/chat" });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://key.mcpfactory.org/internal/app-keys/gemini/decrypt?appId=chat",
+      expect.anything(),
+    );
+  });
+});

--- a/tests/unit/mcp-client.test.ts
+++ b/tests/unit/mcp-client.test.ts
@@ -53,7 +53,7 @@ describe("connectMcp", () => {
       }),
       expect.objectContaining({
         requestInit: {
-          headers: { "X-API-Key": "test-api-key" },
+          headers: { Authorization: "Bearer test-api-key" },
         },
       })
     );

--- a/tests/unit/runs-client.test.ts
+++ b/tests/unit/runs-client.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  process.env.RUNS_SERVICE_API_KEY = "test-runs-key";
+  process.env.RUNS_SERVICE_URL = "https://runs.test.local";
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.restoreAllMocks();
+});
+
+// Dynamic import so env vars are read fresh
+async function loadModule() {
+  vi.resetModules();
+  return import("../../src/lib/runs-client.js");
+}
+
+describe("createRun", () => {
+  it("sends POST /v1/runs with correct body and headers", async () => {
+    const mockRun = { id: "run-1", status: "running" };
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockRun),
+    });
+
+    const { createRun } = await loadModule();
+    const result = await createRun({
+      clerkOrgId: "org_123",
+      appId: "mcpfactory",
+      serviceName: "chat-service",
+      taskName: "chat",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://runs.test.local/v1/runs",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-API-Key": "test-runs-key",
+        },
+        body: JSON.stringify({
+          clerkOrgId: "org_123",
+          appId: "mcpfactory",
+          serviceName: "chat-service",
+          taskName: "chat",
+        }),
+      }),
+    );
+    expect(result).toEqual(mockRun);
+  });
+
+  it("returns null and logs on HTTP error", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("Internal Server Error"),
+    });
+
+    const { createRun } = await loadModule();
+    const result = await createRun({
+      clerkOrgId: "org_123",
+      appId: "mcpfactory",
+      serviceName: "chat-service",
+      taskName: "chat",
+    });
+
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("returns null and logs on network error", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    (fetch as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("ECONNREFUSED"),
+    );
+
+    const { createRun } = await loadModule();
+    const result = await createRun({
+      clerkOrgId: "org_123",
+      appId: "mcpfactory",
+      serviceName: "chat-service",
+      taskName: "chat",
+    });
+
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});
+
+describe("updateRunStatus", () => {
+  it("sends PATCH /v1/runs/{id} with status", async () => {
+    const mockRun = { id: "run-1", status: "completed" };
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockRun),
+    });
+
+    const { updateRunStatus } = await loadModule();
+    const result = await updateRunStatus("run-1", "completed");
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://runs.test.local/v1/runs/run-1",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ status: "completed" }),
+      }),
+    );
+    expect(result).toEqual(mockRun);
+  });
+
+  it("handles failed status", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: "run-1", status: "failed" }),
+    });
+
+    const { updateRunStatus } = await loadModule();
+    const result = await updateRunStatus("run-1", "failed");
+
+    expect(result?.status).toBe("failed");
+  });
+});
+
+describe("addRunCosts", () => {
+  it("sends POST /v1/runs/{id}/costs with items", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ costs: [] }),
+    });
+
+    const { addRunCosts } = await loadModule();
+    await addRunCosts("run-1", [
+      { costName: "gemini-3-flash-tokens-input", quantity: 100 },
+      { costName: "gemini-3-flash-tokens-output", quantity: 50 },
+    ]);
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://runs.test.local/v1/runs/run-1/costs",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          items: [
+            { costName: "gemini-3-flash-tokens-input", quantity: 100 },
+            { costName: "gemini-3-flash-tokens-output", quantity: 50 },
+          ],
+        }),
+      }),
+    );
+  });
+
+  it("skips request when items array is empty", async () => {
+    const { addRunCosts } = await loadModule();
+    await addRunCosts("run-1", []);
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("handles 422 unknown cost name gracefully", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 422,
+      text: () => Promise.resolve('{"error":"Unknown cost name"}'),
+    });
+
+    const { addRunCosts } = await loadModule();
+    await addRunCosts("run-1", [
+      { costName: "unknown-cost", quantity: 10 },
+    ]);
+
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});
+
+describe("missing RUNS_SERVICE_API_KEY", () => {
+  it("returns null without making requests", async () => {
+    delete process.env.RUNS_SERVICE_API_KEY;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { createRun } = await loadModule();
+    const result = await createRun({
+      clerkOrgId: "org_123",
+      appId: "mcpfactory",
+      serviceName: "chat-service",
+      taskName: "chat",
+    });
+
+    expect(result).toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("RUNS_SERVICE_API_KEY not set"),
+    );
+  });
+});

--- a/tests/unit/runs-client.test.ts
+++ b/tests/unit/runs-client.test.ts
@@ -54,6 +54,40 @@ describe("createRun", () => {
     expect(result).toEqual(mockRun);
   });
 
+  it("includes parentRunId in body when provided", async () => {
+    const mockRun = { id: "run-2", status: "running" };
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockRun),
+    });
+
+    const { createRun } = await loadModule();
+    const result = await createRun({
+      clerkOrgId: "org_123",
+      clerkUserId: "user_456",
+      appId: "mcpfactory",
+      serviceName: "chat-service",
+      taskName: "chat",
+      parentRunId: "caller-run-789",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://runs.test.local/v1/runs",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          clerkOrgId: "org_123",
+          clerkUserId: "user_456",
+          appId: "mcpfactory",
+          serviceName: "chat-service",
+          taskName: "chat",
+          parentRunId: "caller-run-789",
+        }),
+      }),
+    );
+    expect(result).toEqual(mockRun);
+  });
+
   it("returns null and logs on HTTP error", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({


### PR DESCRIPTION
## Summary
- Add `x-org-id`, `x-user-id`, `x-run-id` as required headers on `/chat` (returns 400 if missing)
- Pass caller's `x-run-id` as `parentRunId` when creating this service's own run in runs-service, enabling full run tree tracking
- Use `x-org-id` for session scoping (replaces using Bearer token as orgId)
- Pass `x-user-id` to runs-service for per-user run attribution

## Test plan
- [x] Unit tests: header validation returns 400 for each missing header individually and all together
- [x] Unit test: auth check (401) runs before header validation
- [x] Unit test: `parentRunId` propagated to `createRun()` from `x-run-id` header
- [x] Unit test: `parentRunId` included in runs-service POST body
- [x] All 69 unit tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)