### PR TITLE
feat: require x-run-id header for run tree tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,14 @@ npm run dev            # starts on port 3002
 
 ## Authentication
 
-All endpoints (except `/health` and `/openapi.json`) require three headers:
+All endpoints (except `/health` and `/openapi.json`) require these headers:
 
 | Header | Description |
 |---|---|
 | `x-api-key` | Service-to-service API key |
 | `x-org-id` | Internal org UUID from client-service |
 | `x-user-id` | Internal user UUID from client-service |
+| `x-run-id` | Caller's run ID — used as `parentRunId` when creating this service's own run in runs-service |
 
 ## App Config Registration
 
@@ -68,8 +69,7 @@ Request body:
     "brandUrl": "https://example.com",
     "objective": "clicks",
     "budgetAmount": 500
-  },
-  "parentRunId": "optional-parent-run-uuid"
+  }
 }
 ```
 
@@ -77,7 +77,6 @@ Request body:
 - `appId` (required) — identifies which app config (system prompt, MCP) to use
 - `sessionId` (optional) — resume an existing session; omit to start a new one
 - `context` (optional) — free-form JSON injected into the system prompt for this request only (not stored)
-- `parentRunId` (optional, uuid) — links this chat run to a parent run in RunsService for hierarchical cost tracking
 
 The response is a stream of SSE events in this order:
 
@@ -202,7 +201,7 @@ src/
   types.ts          # SSE event TypeScript interfaces
   schemas.ts        # Zod schemas, OpenAPI registry, and request/response types
   middleware/
-    auth.ts         # requireAuth middleware (x-api-key, x-org-id, x-user-id)
+    auth.ts         # requireAuth middleware (x-api-key, x-org-id, x-user-id, x-run-id)
   db/
     index.ts        # Drizzle client init
     schema.ts       # sessions + messages + app_configs table definitions

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,7 @@ app.put("/apps/:appId/config", requireAuth, async (req, res) => {
 // --- Chat ---
 
 app.post("/chat", requireAuth, async (req, res) => {
-  const { orgId, userId } = res.locals as AuthLocals;
+  const { orgId, userId, runId: callerRunId } = res.locals as AuthLocals;
 
   const parsed = ChatRequestSchema.safeParse(req.body);
   if (!parsed.success) {
@@ -107,7 +107,7 @@ app.post("/chat", requireAuth, async (req, res) => {
       .json({ error: "Invalid request", details: parsed.error.flatten() });
   }
 
-  const { message, sessionId, appId, context, parentRunId } = parsed.data;
+  const { message, sessionId, appId, context } = parsed.data;
 
   // Look up app config
   const [appConfig] = await db
@@ -182,14 +182,14 @@ app.post("/chat", requireAuth, async (req, res) => {
 
     sendSSE(res, { sessionId: currentSessionId });
 
-    // Register run in RunsService
+    // Register run in RunsService (caller's runId becomes our parentRunId)
     const run = await createRun({
       orgId,
       userId,
       appId,
       serviceName: "chat-service",
       taskName: "chat",
-      ...(parentRunId ? { parentRunId } : {}),
+      parentRunId: callerRunId,
     });
     if (run) runId = run.id;
 

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -3,6 +3,7 @@ import type { Request, Response, NextFunction } from "express";
 export interface AuthLocals {
   orgId: string;
   userId: string;
+  runId: string;
 }
 
 export function requireAuth(
@@ -28,7 +29,14 @@ export function requireAuth(
     return;
   }
 
+  const runId = req.headers["x-run-id"];
+  if (!runId || typeof runId !== "string") {
+    res.status(400).json({ error: "x-run-id header is required" });
+    return;
+  }
+
   res.locals.orgId = orgId;
   res.locals.userId = userId;
+  res.locals.runId = runId;
   next();
 }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -108,6 +108,9 @@ registry.registerPath({
       "x-user-id": z.string().openapi({
         description: "Internal user UUID from client-service",
       }),
+      "x-run-id": z.string().uuid().openapi({
+        description: "Caller's run ID",
+      }),
     }),
     body: {
       content: { "application/json": { schema: AppConfigRequestSchema } },
@@ -141,7 +144,6 @@ export const ChatRequestSchema = z
     sessionId: z.string().uuid().optional(),
     appId: z.string().min(1, "appId is required"),
     context: z.record(z.string(), z.unknown()).optional(),
-    parentRunId: z.string().uuid().optional(),
   })
   .openapi("ChatRequest");
 
@@ -164,6 +166,10 @@ registry.registerPath({
       }),
       "x-user-id": z.string().openapi({
         description: "Internal user UUID from client-service",
+      }),
+      "x-run-id": z.string().uuid().openapi({
+        description:
+          "Caller's run ID — used as parentRunId when creating this service's own run in runs-service",
       }),
     }),
     body: {

--- a/tests/unit/auth-middleware.test.ts
+++ b/tests/unit/auth-middleware.test.ts
@@ -50,16 +50,32 @@ describe("requireAuth middleware", () => {
     expect(next).not.toHaveBeenCalled();
   });
 
-  it("calls next and sets locals when all headers are present", () => {
+  it("returns 400 when x-run-id is missing", () => {
     const { req, res, next } = mockReqRes({
       "x-api-key": "test-key",
       "x-org-id": "org-123",
       "x-user-id": "user-456",
     });
     requireAuth(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "x-run-id header is required",
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("calls next and sets locals when all headers are present", () => {
+    const { req, res, next } = mockReqRes({
+      "x-api-key": "test-key",
+      "x-org-id": "org-123",
+      "x-user-id": "user-456",
+      "x-run-id": "run-789",
+    });
+    requireAuth(req, res, next);
     expect(next).toHaveBeenCalled();
     expect(res.locals.orgId).toBe("org-123");
     expect(res.locals.userId).toBe("user-456");
+    expect(res.locals.runId).toBe("run-789");
     expect(res.status).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/schemas.test.ts
+++ b/tests/unit/schemas.test.ts
@@ -80,41 +80,7 @@ describe("ChatRequestSchema", () => {
     expect(result.success).toBe(true);
   });
 
-  it("accepts valid parentRunId (uuid)", () => {
-    const result = ChatRequestSchema.safeParse({
-      message: "Hello",
-      appId: "my-app",
-      parentRunId: "550e8400-e29b-41d4-a716-446655440000",
-    });
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.parentRunId).toBe(
-        "550e8400-e29b-41d4-a716-446655440000",
-      );
-    }
-  });
-
-  it("rejects non-uuid parentRunId", () => {
-    const result = ChatRequestSchema.safeParse({
-      message: "Hello",
-      appId: "my-app",
-      parentRunId: "not-a-uuid",
-    });
-    expect(result.success).toBe(false);
-  });
-
-  it("accepts request without parentRunId", () => {
-    const result = ChatRequestSchema.safeParse({
-      message: "Hello",
-      appId: "my-app",
-    });
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.parentRunId).toBeUndefined();
-    }
-  });
-
-  it("strips extra fields", () => {
+  it("strips extra fields including parentRunId (now a header)", () => {
     const result = ChatRequestSchema.safeParse({
       message: "Hello",
       appId: "my-app",


### PR DESCRIPTION
## Summary
- Add `x-run-id` as a required header in `requireAuth` middleware (alongside `x-api-key`, `x-org-id`, `x-user-id`)
- Move `parentRunId` from the request body to the `x-run-id` header — the caller's run ID is always used as `parentRunId` when creating this service's own run in runs-service
- Remove `parentRunId` from `ChatRequestSchema` body (now comes from header)
- Update OpenAPI spec with `x-run-id` header on both `/chat` and `/apps/{appId}/config`

## Test plan
- [x] Auth middleware test: returns 400 when x-run-id is missing
- [x] Auth middleware test: sets `runId` in `res.locals` when all headers present
- [x] Schema test: `parentRunId` stripped from body as extra field
- [x] All 99 unit tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)