### PR TITLE
feat: remove appId from contract, scope config by orgId

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ CI will warn if source files change without corresponding test changes. Do not s
 
 ## Architecture
 
-- `src/index.ts` — Express server, `/chat`, `/apps/:appId/config`, `/health`, `/openapi.json`
+- `src/index.ts` — Express server, `/chat`, `/config`, `/health`, `/openapi.json`
 - `src/schemas.ts` — Zod schemas (source of truth for validation + OpenAPI)
 - `src/types.ts` — SSE event TypeScript interfaces
 - `src/middleware/auth.ts` — Auth middleware (Authorization Bearer + x-org-id + x-user-id)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Chat Service
 
-Multi-app AI chat service. Streams Gemini AI responses via SSE with configurable system prompts and optional MCP tool calling per app.
+Multi-org AI chat service. Streams Gemini AI responses via SSE with configurable system prompts and optional MCP tool calling per org.
 
 ## Quick Start
 
@@ -23,9 +23,9 @@ All endpoints (except `/health` and `/openapi.json`) require these headers:
 
 ## App Config Registration
 
-Before using `/chat`, apps must register their configuration via:
+Before using `/chat`, orgs must register their configuration via:
 
-`PUT /apps/:appId/config`
+`PUT /config`
 
 Request body:
 ```json
@@ -36,16 +36,15 @@ Request body:
 }
 ```
 
-- `systemPrompt` (required) — the system prompt sent to Gemini for this app
+- `systemPrompt` (required) — the system prompt sent to Gemini for this org
 - `mcpServerUrl` (optional) — MCP server URL to connect to for tool calling
 - `mcpKeyName` (optional) — BYOK provider name in key-service; the org's key is decrypted at runtime and used as Bearer token for the MCP server
 
-This endpoint is **idempotent** (upsert on `appId + orgId`). Call it on every cold start.
+This endpoint is **idempotent** (upsert on `orgId` from the `x-org-id` header). Call it on every cold start.
 
 Response:
 ```json
 {
-  "appId": "sales-cold-emails",
   "orgId": "org-uuid",
   "systemPrompt": "...",
   "mcpServerUrl": "https://mcp.mcpfactory.org",
@@ -63,7 +62,6 @@ Request body:
 ```json
 {
   "message": "Hello",
-  "appId": "sales-cold-emails",
   "sessionId": "optional-uuid",
   "context": {
     "brandUrl": "https://example.com",
@@ -74,7 +72,6 @@ Request body:
 ```
 
 - `message` (required) — the user's chat message
-- `appId` (required) — identifies which app config (system prompt, MCP) to use
 - `sessionId` (optional) — resume an existing session; omit to start a new one
 - `context` (optional) — free-form JSON injected into the system prompt for this request only (not stored)
 
@@ -147,9 +144,9 @@ Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token st
 
 Uses PostgreSQL via Drizzle ORM. Three tables:
 
-- **sessions** — conversation sessions scoped by `orgId`, `userId`, and `appId`
+- **sessions** — conversation sessions scoped by `orgId` and `userId`
 - **messages** — chat messages with role, content, optional `toolCalls`, `buttons` JSONB, and `runId` linking to RunsService
-- **app_configs** — per-app configuration (system prompt, MCP settings) with unique constraint on `(appId, orgId)`
+- **app_configs** — per-org configuration (system prompt, MCP settings) with unique constraint on `orgId`
 
 Migrations run automatically on server start. To generate new migrations after schema changes:
 
@@ -197,7 +194,7 @@ Uses `node:20-alpine`. Requires Node >= 20.
 
 ```
 src/
-  index.ts          # Express server, /chat, /apps/:appId/config, /health, /openapi.json
+  index.ts          # Express server, /chat, /config, /health, /openapi.json
   types.ts          # SSE event TypeScript interfaces
   schemas.ts        # Zod schemas, OpenAPI registry, and request/response types
   middleware/

--- a/drizzle/0003_flawless_vermin.sql
+++ b/drizzle/0003_flawless_vermin.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "app_configs" DROP CONSTRAINT "app_configs_app_id_org_id_unique";--> statement-breakpoint
+ALTER TABLE "app_configs" DROP COLUMN "app_id";--> statement-breakpoint
+ALTER TABLE "sessions" DROP COLUMN "app_id";--> statement-breakpoint
+ALTER TABLE "app_configs" ADD CONSTRAINT "app_configs_org_id_unique" UNIQUE("org_id");

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,214 @@
+{
+  "id": "37a81928-a2b3-4f8c-89c3-646ffede0154",
+  "prevId": "eaa3e474-0696-48a5-8216-8a9ecf0eb23d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_configs": {
+      "name": "app_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mcp_server_url": {
+          "name": "mcp_server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_key_name": {
+          "name": "mcp_key_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_configs_org_id_unique": {
+          "name": "app_configs_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buttons": {
+          "name": "buttons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1772086797154,
       "tag": "0002_nice_molecule_man",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1773382183091,
+      "tag": "0003_flawless_vermin",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -4,7 +4,6 @@ export const sessions = pgTable("sessions", {
   id: uuid("id").primaryKey().defaultRandom(),
   orgId: text("org_id").notNull(),
   userId: text("user_id"),
-  appId: text("app_id"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 });
@@ -27,7 +26,6 @@ export const appConfigs = pgTable(
   "app_configs",
   {
     id: uuid("id").primaryKey().defaultRandom(),
-    appId: text("app_id").notNull(),
     orgId: text("org_id").notNull(),
     systemPrompt: text("system_prompt").notNull(),
     mcpServerUrl: text("mcp_server_url"),
@@ -35,7 +33,7 @@ export const appConfigs = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
-  (table) => [unique("app_configs_app_id_org_id_unique").on(table.appId, table.orgId)],
+  (table) => [unique("app_configs_org_id_unique").on(table.orgId)],
 );
 
 export interface ToolCallRecord {

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,8 +51,7 @@ app.get("/health", (_req, res) => {
 
 // --- App Config Registration ---
 
-app.put("/apps/:appId/config", requireAuth, async (req, res) => {
-  const { appId } = req.params;
+app.put("/config", requireAuth, async (req, res) => {
   const { orgId } = res.locals as AuthLocals;
 
   const parsed = AppConfigRequestSchema.safeParse(req.body);
@@ -67,14 +66,13 @@ app.put("/apps/:appId/config", requireAuth, async (req, res) => {
   const [config] = await db
     .insert(appConfigs)
     .values({
-      appId,
       orgId,
       systemPrompt,
       mcpServerUrl: mcpServerUrl ?? null,
       mcpKeyName: mcpKeyName ?? null,
     })
     .onConflictDoUpdate({
-      target: [appConfigs.appId, appConfigs.orgId],
+      target: [appConfigs.orgId],
       set: {
         systemPrompt,
         mcpServerUrl: mcpServerUrl ?? null,
@@ -85,7 +83,6 @@ app.put("/apps/:appId/config", requireAuth, async (req, res) => {
     .returning();
 
   res.json({
-    appId: config.appId,
     orgId: config.orgId,
     systemPrompt: config.systemPrompt,
     mcpServerUrl: config.mcpServerUrl,
@@ -107,17 +104,17 @@ app.post("/chat", requireAuth, async (req, res) => {
       .json({ error: "Invalid request", details: parsed.error.flatten() });
   }
 
-  const { message, sessionId, appId, context } = parsed.data;
+  const { message, sessionId, context } = parsed.data;
 
-  // Look up app config
+  // Look up app config by orgId
   const [appConfig] = await db
     .select()
     .from(appConfigs)
-    .where(and(eq(appConfigs.appId, appId), eq(appConfigs.orgId, orgId)));
+    .where(eq(appConfigs.orgId, orgId));
 
   if (!appConfig) {
     return res.status(404).json({
-      error: `App config not found for appId="${appId}". Register via PUT /apps/${appId}/config first.`,
+      error: `App config not found for org="${orgId}". Register via PUT /config first.`,
     });
   }
 
@@ -160,7 +157,7 @@ app.post("/chat", requireAuth, async (req, res) => {
     if (!currentSessionId) {
       const [session] = await db
         .insert(sessions)
-        .values({ orgId, userId, appId })
+        .values({ orgId, userId })
         .returning();
       currentSessionId = session.id;
     } else {
@@ -186,7 +183,6 @@ app.post("/chat", requireAuth, async (req, res) => {
     const run = await createRun({
       orgId,
       userId,
-      appId,
       serviceName: "chat-service",
       taskName: "chat",
       parentRunId: callerRunId,

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -5,7 +5,6 @@ const RUNS_SERVICE_API_KEY = process.env.RUNS_SERVICE_API_KEY;
 export interface RunsRun {
   id: string;
   organizationId: string;
-  appId: string;
   serviceName: string;
   taskName: string;
   status: string;
@@ -16,7 +15,6 @@ export interface RunsRun {
 export interface CreateRunParams {
   orgId: string;
   userId?: string;
-  appId: string;
   serviceName: string;
   taskName: string;
   parentRunId?: string;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -77,7 +77,6 @@ export const AppConfigRequestSchema = z
 
 export const AppConfigResponseSchema = z
   .object({
-    appId: z.string(),
     orgId: z.string(),
     systemPrompt: z.string(),
     mcpServerUrl: z.string().nullable(),
@@ -91,13 +90,12 @@ export type AppConfigRequest = z.infer<typeof AppConfigRequestSchema>;
 
 registry.registerPath({
   method: "put",
-  path: "/apps/{appId}/config",
+  path: "/config",
   tags: ["App Config"],
   summary: "Register or update app configuration",
   description:
-    "Idempotent upsert of app configuration including system prompt and optional MCP settings. Call on every cold start.",
+    "Idempotent upsert of app configuration scoped by org (via x-org-id header). Includes system prompt and optional MCP settings. Call on every cold start.",
   request: {
-    params: z.object({ appId: z.string() }),
     headers: z.object({
       "x-api-key": z.string().openapi({
         description: "Service-to-service API key",
@@ -142,7 +140,6 @@ export const ChatRequestSchema = z
   .object({
     message: z.string().min(1, "message is required"),
     sessionId: z.string().uuid().optional(),
-    appId: z.string().min(1, "appId is required"),
     context: z.record(z.string(), z.unknown()).optional(),
   })
   .openapi("ChatRequest");
@@ -155,7 +152,7 @@ registry.registerPath({
   tags: ["Chat"],
   summary: "Stream AI chat response",
   description:
-    "Send a message and receive a streamed AI response via Server-Sent Events (SSE). Supports MCP tool calling and quick-reply buttons. Requires app config to be registered first via PUT /apps/{appId}/config.",
+    "Send a message and receive a streamed AI response via Server-Sent Events (SSE). Supports MCP tool calling and quick-reply buttons. Requires app config to be registered first via PUT /config.",
   request: {
     headers: z.object({
       "x-api-key": z.string().openapi({
@@ -197,7 +194,7 @@ registry.registerPath({
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
     404: {
-      description: "App config not found — register via PUT /apps/{appId}/config first",
+      description: "App config not found — register via PUT /config first",
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,9 +3,7 @@ import type { ButtonRecord, ToolCallRecord } from "./db/schema.js";
 export interface ChatRequest {
   message: string;
   sessionId?: string;
-  appId: string;
   context?: Record<string, unknown>;
-  parentRunId?: string;
 }
 
 export interface SSETokenEvent {

--- a/tests/integration/db.test.ts
+++ b/tests/integration/db.test.ts
@@ -59,18 +59,16 @@ describe("database integration", () => {
     expect(gone).toBeUndefined();
   });
 
-  it("should create session with userId and appId", async () => {
+  it("should create session with userId (appId removed)", async () => {
     const [created] = await db
       .insert(schema.sessions)
       .values({
         orgId: "test-org-new",
         userId: "test-user-123",
-        appId: "test-app",
       })
       .returning();
 
     expect(created.userId).toBe("test-user-123");
-    expect(created.appId).toBe("test-app");
 
     await db
       .delete(schema.sessions)
@@ -143,12 +141,11 @@ describe("database integration", () => {
       .where(eq(schema.sessions.id, session.id));
   });
 
-  it("should create and upsert app_configs", async () => {
+  it("should create and upsert app_configs by orgId", async () => {
     // Insert
     const [config] = await db
       .insert(schema.appConfigs)
       .values({
-        appId: "test-app-config",
         orgId: "test-org-config",
         systemPrompt: "You are a test assistant.",
         mcpServerUrl: "https://mcp.test.local",
@@ -156,20 +153,19 @@ describe("database integration", () => {
       })
       .returning();
 
-    expect(config.appId).toBe("test-app-config");
+    expect(config.orgId).toBe("test-org-config");
     expect(config.systemPrompt).toBe("You are a test assistant.");
     expect(config.mcpServerUrl).toBe("https://mcp.test.local");
 
-    // Upsert (update on conflict)
+    // Upsert (update on conflict by orgId)
     const [updated] = await db
       .insert(schema.appConfigs)
       .values({
-        appId: "test-app-config",
         orgId: "test-org-config",
         systemPrompt: "Updated prompt.",
       })
       .onConflictDoUpdate({
-        target: [schema.appConfigs.appId, schema.appConfigs.orgId],
+        target: [schema.appConfigs.orgId],
         set: {
           systemPrompt: "Updated prompt.",
           mcpServerUrl: null,
@@ -186,11 +182,6 @@ describe("database integration", () => {
     // Cleanup
     await db
       .delete(schema.appConfigs)
-      .where(
-        and(
-          eq(schema.appConfigs.appId, "test-app-config"),
-          eq(schema.appConfigs.orgId, "test-org-config"),
-        ),
-      );
+      .where(eq(schema.appConfigs.orgId, "test-org-config"));
   });
 });

--- a/tests/unit/openapi.test.ts
+++ b/tests/unit/openapi.test.ts
@@ -47,14 +47,16 @@ describe("openapi.json", () => {
     expect(chat.responses["404"]).toBeDefined();
   });
 
-  it("documents PUT /apps/{appId}/config", () => {
+  it("documents PUT /config (org-scoped, no appId in path)", () => {
     const spec = JSON.parse(readFileSync(openapiPath, "utf-8"));
-    const appConfig = spec.paths["/apps/{appId}/config"]?.put;
+    const appConfig = spec.paths["/config"]?.put;
     expect(appConfig).toBeDefined();
     expect(appConfig.requestBody.content["application/json"]).toBeDefined();
     expect(appConfig.responses["200"]).toBeDefined();
     expect(appConfig.responses["400"]).toBeDefined();
     expect(appConfig.responses["401"]).toBeDefined();
+    // Old path should not exist
+    expect(spec.paths["/apps/{appId}/config"]).toBeUndefined();
   });
 
   it("documents GET /openapi.json", () => {
@@ -74,13 +76,13 @@ describe("openapi.json", () => {
     expect(spec.components?.schemas?.AppConfigResponse).toBeDefined();
   });
 
-  it("ChatRequest schema requires message and appId fields", () => {
+  it("ChatRequest schema requires only message (appId removed)", () => {
     const spec = JSON.parse(readFileSync(openapiPath, "utf-8"));
     const chatReq = spec.components.schemas.ChatRequest;
     expect(chatReq.required).toContain("message");
-    expect(chatReq.required).toContain("appId");
+    expect(chatReq.required).not.toContain("appId");
     expect(chatReq.properties.message.type).toBe("string");
-    expect(chatReq.properties.appId.type).toBe("string");
+    expect(chatReq.properties.appId).toBeUndefined();
     expect(chatReq.properties.sessionId.type).toBe("string");
   });
 });

--- a/tests/unit/runs-client.test.ts
+++ b/tests/unit/runs-client.test.ts
@@ -31,7 +31,6 @@ describe("createRun", () => {
     const result = await createRun({
       orgId: "org-uuid-123",
       userId: "user-uuid-456",
-      appId: "sales-cold-emails",
       serviceName: "chat-service",
       taskName: "chat",
     });
@@ -47,7 +46,6 @@ describe("createRun", () => {
         body: JSON.stringify({
           orgId: "org-uuid-123",
           userId: "user-uuid-456",
-          appId: "sales-cold-emails",
           serviceName: "chat-service",
           taskName: "chat",
         }),
@@ -67,7 +65,6 @@ describe("createRun", () => {
     await createRun({
       orgId: "org-uuid-123",
       userId: "user-uuid-456",
-      appId: "sales-cold-emails",
       serviceName: "chat-service",
       taskName: "chat",
       parentRunId: "parent-run-uuid",
@@ -79,7 +76,6 @@ describe("createRun", () => {
         body: JSON.stringify({
           orgId: "org-uuid-123",
           userId: "user-uuid-456",
-          appId: "sales-cold-emails",
           serviceName: "chat-service",
           taskName: "chat",
           parentRunId: "parent-run-uuid",
@@ -99,7 +95,6 @@ describe("createRun", () => {
     const { createRun } = await loadModule();
     const result = await createRun({
       orgId: "org-123",
-      appId: "my-app",
       serviceName: "chat-service",
       taskName: "chat",
     });
@@ -117,7 +112,6 @@ describe("createRun", () => {
     const { createRun } = await loadModule();
     const result = await createRun({
       orgId: "org-123",
-      appId: "my-app",
       serviceName: "chat-service",
       taskName: "chat",
     });
@@ -220,7 +214,6 @@ describe("missing RUNS_SERVICE_API_KEY", () => {
     const { createRun } = await loadModule();
     const result = await createRun({
       orgId: "org-123",
-      appId: "my-app",
       serviceName: "chat-service",
       taskName: "chat",
     });

--- a/tests/unit/schemas.test.ts
+++ b/tests/unit/schemas.test.ts
@@ -2,15 +2,13 @@ import { describe, it, expect } from "vitest";
 import { ChatRequestSchema } from "../../src/schemas.js";
 
 describe("ChatRequestSchema", () => {
-  it("accepts valid request with message and appId", () => {
+  it("accepts valid request with message", () => {
     const result = ChatRequestSchema.safeParse({
       message: "Hello",
-      appId: "my-app",
     });
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.message).toBe("Hello");
-      expect(result.data.appId).toBe("my-app");
       expect(result.data.sessionId).toBeUndefined();
       expect(result.data.context).toBeUndefined();
     }
@@ -19,7 +17,6 @@ describe("ChatRequestSchema", () => {
   it("accepts valid request with all fields", () => {
     const result = ChatRequestSchema.safeParse({
       message: "Hello",
-      appId: "my-app",
       sessionId: "550e8400-e29b-41d4-a716-446655440000",
       context: { brandUrl: "https://example.com", budget: 500 },
     });
@@ -35,33 +32,23 @@ describe("ChatRequestSchema", () => {
   it("rejects empty message", () => {
     const result = ChatRequestSchema.safeParse({
       message: "",
-      appId: "my-app",
     });
     expect(result.success).toBe(false);
   });
 
   it("rejects missing message", () => {
-    const result = ChatRequestSchema.safeParse({ appId: "my-app" });
+    const result = ChatRequestSchema.safeParse({});
     expect(result.success).toBe(false);
   });
 
-  it("rejects missing appId", () => {
+  it("does not require appId (removed from contract)", () => {
     const result = ChatRequestSchema.safeParse({ message: "Hello" });
-    expect(result.success).toBe(false);
-  });
-
-  it("rejects empty appId", () => {
-    const result = ChatRequestSchema.safeParse({
-      message: "Hello",
-      appId: "",
-    });
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
   });
 
   it("rejects non-uuid sessionId", () => {
     const result = ChatRequestSchema.safeParse({
       message: "Hello",
-      appId: "my-app",
       sessionId: "not-a-uuid",
     });
     expect(result.success).toBe(false);
@@ -70,7 +57,6 @@ describe("ChatRequestSchema", () => {
   it("accepts context with any JSON structure", () => {
     const result = ChatRequestSchema.safeParse({
       message: "Hello",
-      appId: "my-app",
       context: {
         nested: { deep: true },
         array: [1, 2, 3],
@@ -80,15 +66,16 @@ describe("ChatRequestSchema", () => {
     expect(result.success).toBe(true);
   });
 
-  it("strips extra fields including parentRunId (now a header)", () => {
+  it("strips extra fields", () => {
     const result = ChatRequestSchema.safeParse({
       message: "Hello",
-      appId: "my-app",
       extra: "field",
+      appId: "leftover-app-id",
     });
     expect(result.success).toBe(true);
     if (result.success) {
       expect((result.data as Record<string, unknown>).extra).toBeUndefined();
+      expect((result.data as Record<string, unknown>).appId).toBeUndefined();
     }
   });
 });

--- a/tests/unit/types.test.ts
+++ b/tests/unit/types.test.ts
@@ -7,10 +7,9 @@ import type {
 } from "../../src/types.js";
 
 describe("types", () => {
-  it("ChatRequest shape requires appId", () => {
-    const req: ChatRequest = { message: "hello", appId: "my-app" };
+  it("ChatRequest shape requires only message", () => {
+    const req: ChatRequest = { message: "hello" };
     expect(req.message).toBe("hello");
-    expect(req.appId).toBe("my-app");
     expect(req.sessionId).toBeUndefined();
     expect(req.context).toBeUndefined();
   });
@@ -18,7 +17,6 @@ describe("types", () => {
   it("ChatRequest with all optional fields", () => {
     const req: ChatRequest = {
       message: "hi",
-      appId: "my-app",
       sessionId: "abc-123",
       context: { brandUrl: "https://example.com" },
     };


### PR DESCRIPTION
## Summary

- **POST /chat**: removed `appId` from `ChatRequestSchema` — org is identified via `x-org-id` header
- **PUT /apps/{appId}/config → PUT /config**: config endpoint no longer uses `appId` in path; scoped by `orgId` from header
- **DB migration**: drops `app_id` columns from `sessions` and `app_configs`, changes unique constraint from `(appId, orgId)` to `(orgId)`
- **runs-client**: removed `appId` from `CreateRunParams`
- Updated all unit tests, integration tests, README, and CLAUDE.md

Aligns chat-service with api-service refactor (PRs #50/#58) which stopped sending `appId`.

## Test plan

- [x] All 98 unit tests pass
- [ ] Integration tests (CI will run against Neon branch)
- [ ] Verify api-service can call POST /chat without appId
- [ ] Verify api-service can call PUT /config (new path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)