### PR TITLE
feat: add PUT /platform-config endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,42 @@ Response:
 }
 ```
 
+## Platform Config Registration
+
+Register a global (non-org-scoped) chat configuration used as fallback when no per-org config exists:
+
+`PUT /platform-config`
+
+**Auth:** `X-API-Key` only — no `x-org-id`, `x-user-id`, or `x-run-id` headers required.
+
+Request body:
+```json
+{
+  "systemPrompt": "You are a helpful assistant...",
+  "mcpServerUrl": "https://mcp.example.com",
+  "mcpKeyName": "platform-mcp"
+}
+```
+
+- `systemPrompt` (required) — the default system prompt for all orgs without a per-org config
+- `mcpServerUrl` (optional) — default MCP server URL
+- `mcpKeyName` (optional) — default MCP key name
+
+This endpoint is **idempotent** (upsert). Called on every cold start by api-service.
+
+**Config resolution in POST /chat:** Per-org config (from `PUT /config`) takes priority. If none exists, the platform config (from `PUT /platform-config`) is used. If neither exists, the request fails with 404. There is no merging — it's one or the other.
+
+Response:
+```json
+{
+  "systemPrompt": "...",
+  "mcpServerUrl": "https://mcp.example.com",
+  "mcpKeyName": "platform-mcp",
+  "createdAt": "2026-02-26T00:00:00.000Z",
+  "updatedAt": "2026-02-26T00:00:00.000Z"
+}
+```
+
 ## SSE Protocol
 
 `POST /chat` with headers `Content-Type: application/json`, `x-api-key`, `x-org-id`, `x-user-id`.
@@ -147,6 +183,7 @@ Uses PostgreSQL via Drizzle ORM. Three tables:
 - **sessions** — conversation sessions scoped by `orgId` and `userId`
 - **messages** — chat messages with role, content, optional `toolCalls`, `buttons` JSONB, and `runId` linking to RunsService
 - **app_configs** — per-org configuration (system prompt, MCP settings) with unique constraint on `orgId`
+- **platform_configs** — global platform-wide chat configuration (fallback when no per-org config exists)
 
 Migrations run automatically on server start. To generate new migrations after schema changes:
 
@@ -194,14 +231,14 @@ Uses `node:20-alpine`. Requires Node >= 20.
 
 ```
 src/
-  index.ts          # Express server, /chat, /config, /health, /openapi.json
+  index.ts          # Express server, /chat, /config, /platform-config, /health, /openapi.json
   types.ts          # SSE event TypeScript interfaces
   schemas.ts        # Zod schemas, OpenAPI registry, and request/response types
   middleware/
-    auth.ts         # requireAuth middleware (x-api-key, x-org-id, x-user-id, x-run-id)
+    auth.ts         # requireAuth middleware (x-api-key, x-org-id, x-user-id, x-run-id) + requireInternalAuth (x-api-key only)
   db/
     index.ts        # Drizzle client init
-    schema.ts       # sessions + messages + app_configs table definitions
+    schema.ts       # sessions + messages + app_configs + platform_configs table definitions
   lib/
     gemini.ts       # Gemini AI client, streaming + function calling, buildSystemPrompt helper
     mcp-client.ts   # MCP server connection via Streamable HTTP transport + tool execution

--- a/drizzle/0004_military_retro_girl.sql
+++ b/drizzle/0004_military_retro_girl.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "platform_configs" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"key" text NOT NULL,
+	"system_prompt" text NOT NULL,
+	"mcp_server_url" text,
+	"mcp_key_name" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "platform_configs_key_unique" UNIQUE("key")
+);

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,280 @@
+{
+  "id": "74ef7ca7-8c78-423d-9c27-2ed97216ec12",
+  "prevId": "37a81928-a2b3-4f8c-89c3-646ffede0154",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_configs": {
+      "name": "app_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mcp_server_url": {
+          "name": "mcp_server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_key_name": {
+          "name": "mcp_key_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_configs_org_id_unique": {
+          "name": "app_configs_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buttons": {
+          "name": "buttons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platform_configs": {
+      "name": "platform_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mcp_server_url": {
+          "name": "mcp_server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_key_name": {
+          "name": "mcp_key_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "platform_configs_key_unique": {
+          "name": "platform_configs_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1773382183091,
       "tag": "0003_flawless_vermin",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1773386153282,
+      "tag": "0004_military_retro_girl",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -36,6 +36,16 @@ export const appConfigs = pgTable(
   (table) => [unique("app_configs_org_id_unique").on(table.orgId)],
 );
 
+export const platformConfigs = pgTable("platform_configs", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  key: text("key").notNull().unique(),
+  systemPrompt: text("system_prompt").notNull(),
+  mcpServerUrl: text("mcp_server_url"),
+  mcpKeyName: text("mcp_key_name"),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
 export interface ToolCallRecord {
   name: string;
   args: Record<string, unknown>;
@@ -53,3 +63,5 @@ export type Message = typeof messages.$inferSelect;
 export type NewMessage = typeof messages.$inferInsert;
 export type AppConfig = typeof appConfigs.$inferSelect;
 export type NewAppConfig = typeof appConfigs.$inferInsert;
+export type PlatformConfig = typeof platformConfigs.$inferSelect;
+export type NewPlatformConfig = typeof platformConfigs.$inferInsert;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { readFileSync, existsSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 import { db } from "./db/index.js";
-import { sessions, messages, appConfigs } from "./db/schema.js";
+import { sessions, messages, appConfigs, platformConfigs } from "./db/schema.js";
 import { eq, and } from "drizzle-orm";
 import {
   createGeminiClient,
@@ -15,8 +15,8 @@ import {
 import { connectMcp, type McpConnection } from "./lib/mcp-client.js";
 import { createRun, updateRunStatus, addRunCosts } from "./lib/runs-client.js";
 import { resolveKey, decryptOrgKey, type ResolvedKey } from "./lib/key-client.js";
-import { ChatRequestSchema, AppConfigRequestSchema } from "./schemas.js";
-import { requireAuth, type AuthLocals } from "./middleware/auth.js";
+import { ChatRequestSchema, AppConfigRequestSchema, PlatformConfigRequestSchema } from "./schemas.js";
+import { requireAuth, requireInternalAuth, type AuthLocals } from "./middleware/auth.js";
 import type { Content, Part } from "@google/genai";
 import type { ButtonRecord, ToolCallRecord } from "./db/schema.js";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
@@ -92,6 +92,48 @@ app.put("/config", requireAuth, async (req, res) => {
   });
 });
 
+// --- Platform Config Registration ---
+
+const PLATFORM_CONFIG_KEY = "default";
+
+app.put("/platform-config", requireInternalAuth, async (req, res) => {
+  const parsed = PlatformConfigRequestSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res
+      .status(400)
+      .json({ error: "Invalid request", details: parsed.error.flatten() });
+  }
+
+  const { systemPrompt, mcpServerUrl, mcpKeyName } = parsed.data;
+
+  const [config] = await db
+    .insert(platformConfigs)
+    .values({
+      key: PLATFORM_CONFIG_KEY,
+      systemPrompt,
+      mcpServerUrl: mcpServerUrl ?? null,
+      mcpKeyName: mcpKeyName ?? null,
+    })
+    .onConflictDoUpdate({
+      target: [platformConfigs.key],
+      set: {
+        systemPrompt,
+        mcpServerUrl: mcpServerUrl ?? null,
+        mcpKeyName: mcpKeyName ?? null,
+        updatedAt: new Date(),
+      },
+    })
+    .returning();
+
+  res.json({
+    systemPrompt: config.systemPrompt,
+    mcpServerUrl: config.mcpServerUrl,
+    mcpKeyName: config.mcpKeyName,
+    createdAt: config.createdAt.toISOString(),
+    updatedAt: config.updatedAt.toISOString(),
+  });
+});
+
 // --- Chat ---
 
 app.post("/chat", requireAuth, async (req, res) => {
@@ -106,15 +148,21 @@ app.post("/chat", requireAuth, async (req, res) => {
 
   const { message, sessionId, context } = parsed.data;
 
-  // Look up app config by orgId
-  const [appConfig] = await db
+  // Look up app config by orgId, fall back to platform config
+  const [orgConfig] = await db
     .select()
     .from(appConfigs)
     .where(eq(appConfigs.orgId, orgId));
 
+  const appConfig = orgConfig ?? (await db
+    .select()
+    .from(platformConfigs)
+    .where(eq(platformConfigs.key, PLATFORM_CONFIG_KEY))
+    .then(([row]) => row ?? null));
+
   if (!appConfig) {
     return res.status(404).json({
-      error: `App config not found for org="${orgId}". Register via PUT /config first.`,
+      error: `No chat config found for org="${orgId}". Register via PUT /config or PUT /platform-config.`,
     });
   }
 

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -40,3 +40,16 @@ export function requireAuth(
   res.locals.runId = runId;
   next();
 }
+
+export function requireInternalAuth(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  const apiKey = req.headers["x-api-key"];
+  if (!apiKey || typeof apiKey !== "string") {
+    res.status(401).json({ error: "x-api-key header is required" });
+    return;
+  }
+  next();
+}

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -134,6 +134,65 @@ registry.registerPath({
   },
 });
 
+// --- Platform Config ---
+
+export const PlatformConfigRequestSchema = z
+  .object({
+    systemPrompt: z.string().min(1, "systemPrompt is required"),
+    mcpServerUrl: z.string().url().optional(),
+    mcpKeyName: z.string().min(1).optional(),
+  })
+  .openapi("PlatformConfigRequest");
+
+export const PlatformConfigResponseSchema = z
+  .object({
+    systemPrompt: z.string(),
+    mcpServerUrl: z.string().nullable(),
+    mcpKeyName: z.string().nullable(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+  })
+  .openapi("PlatformConfigResponse");
+
+export type PlatformConfigRequest = z.infer<typeof PlatformConfigRequestSchema>;
+
+registry.registerPath({
+  method: "put",
+  path: "/platform-config",
+  tags: ["Platform Config"],
+  summary: "Register or update platform-wide chat configuration",
+  description:
+    "Idempotent upsert of a global chat configuration (not scoped to any org). Used as fallback when no per-org config exists. Auth: X-API-Key only — no x-org-id, x-user-id, or x-run-id required. Called on every cold start by api-service.",
+  request: {
+    headers: z.object({
+      "x-api-key": z.string().openapi({
+        description: "Service-to-service API key",
+      }),
+    }),
+    body: {
+      content: { "application/json": { schema: PlatformConfigRequestSchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Platform config saved",
+      content: {
+        "application/json": { schema: PlatformConfigResponseSchema },
+      },
+    },
+    400: {
+      description: "Invalid request",
+      content: {
+        "application/json": { schema: ValidationErrorResponseSchema },
+      },
+    },
+    401: {
+      description: "Missing or invalid x-api-key header",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
 // --- Chat ---
 
 export const ChatRequestSchema = z

--- a/tests/unit/internal-auth.test.ts
+++ b/tests/unit/internal-auth.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Request, Response, NextFunction } from "express";
+import { requireInternalAuth } from "../../src/middleware/auth.js";
+
+function mockReqRes(headers: Record<string, string> = {}) {
+  const req = { headers } as unknown as Request;
+  const res = {
+    locals: {} as Record<string, unknown>,
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  } as unknown as Response;
+  const next = vi.fn() as NextFunction;
+  return { req, res, next };
+}
+
+describe("requireInternalAuth middleware", () => {
+  it("returns 401 when x-api-key header is missing", () => {
+    const { req, res, next } = mockReqRes({});
+    requireInternalAuth(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "x-api-key header is required",
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("calls next when x-api-key is present (no org/user/run headers needed)", () => {
+    const { req, res, next } = mockReqRes({
+      "x-api-key": "test-key",
+    });
+    requireInternalAuth(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("does not require x-org-id, x-user-id, or x-run-id", () => {
+    const { req, res, next } = mockReqRes({
+      "x-api-key": "test-key",
+    });
+    requireInternalAuth(req, res, next);
+    expect(next).toHaveBeenCalled();
+    // Should not set any locals
+    expect(res.locals).toEqual({});
+  });
+});

--- a/tests/unit/platform-config.test.ts
+++ b/tests/unit/platform-config.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { PlatformConfigRequestSchema } from "../../src/schemas.js";
+
+describe("PlatformConfigRequestSchema", () => {
+  it("accepts valid config with systemPrompt only", () => {
+    const result = PlatformConfigRequestSchema.safeParse({
+      systemPrompt: "You are a helpful assistant.",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts config with all fields", () => {
+    const result = PlatformConfigRequestSchema.safeParse({
+      systemPrompt: "You are a helpful assistant.",
+      mcpServerUrl: "https://mcp.example.com",
+      mcpKeyName: "mcpfactory",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.mcpServerUrl).toBe("https://mcp.example.com");
+      expect(result.data.mcpKeyName).toBe("mcpfactory");
+    }
+  });
+
+  it("rejects empty systemPrompt", () => {
+    const result = PlatformConfigRequestSchema.safeParse({
+      systemPrompt: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing systemPrompt", () => {
+    const result = PlatformConfigRequestSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid URL for mcpServerUrl", () => {
+    const result = PlatformConfigRequestSchema.safeParse({
+      systemPrompt: "You are a helpful assistant.",
+      mcpServerUrl: "not-a-url",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty mcpKeyName", () => {
+    const result = PlatformConfigRequestSchema.safeParse({
+      systemPrompt: "You are a helpful assistant.",
+      mcpKeyName: "",
+    });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `PUT /platform-config` endpoint for registering a global (non-org-scoped) chat configuration
- Auth: `X-API-Key` only — no `x-org-id`, `x-user-id`, or `x-run-id` headers required
- Body: `{ systemPrompt, mcpServerUrl?, mcpKeyName? }` — idempotent upsert, called on every api-service cold start
- `POST /chat` now falls back to platform config when no per-org config exists (no merging — one or the other)
- New `platform_configs` DB table with Drizzle migration
- New `requireInternalAuth` middleware (X-API-Key only)

## Test plan
- [x] Unit tests for `PlatformConfigRequestSchema` validation (6 tests)
- [x] Unit tests for `requireInternalAuth` middleware (3 tests)
- [ ] Integration tests will run in CI against Neon branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)