### PR TITLE
feat: workflow tracking headers (x-campaign-id, x-brand-id, x-workflow-name)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ All endpoints (except `/health` and `/openapi.json`) require these headers:
 | `x-org-id` | Internal org UUID from client-service |
 | `x-user-id` | Internal user UUID from client-service |
 | `x-run-id` | Caller's run ID — used as `parentRunId` when creating this service's own run in runs-service |
+| `x-campaign-id` | _(optional)_ Campaign ID — injected automatically by workflow-service |
+| `x-brand-id` | _(optional)_ Brand ID — injected automatically by workflow-service |
+| `x-workflow-name` | _(optional)_ Workflow name — injected automatically by workflow-service |
 
 ## App Config Registration
 
@@ -181,7 +184,7 @@ Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token st
 Uses PostgreSQL via Drizzle ORM. Three tables:
 
 - **sessions** — conversation sessions scoped by `orgId` and `userId`
-- **messages** — chat messages with role, content, optional `toolCalls`, `buttons` JSONB, and `runId` linking to RunsService
+- **messages** — chat messages with role, content, optional `toolCalls`, `buttons` JSONB, `runId` linking to RunsService, and optional `campaign_id`, `brand_id`, `workflow_name` for workflow tracking
 - **app_configs** — per-org configuration (system prompt, MCP settings) with unique constraint on `orgId`
 - **platform_configs** — global platform-wide chat configuration (fallback when no per-org config exists)
 

--- a/drizzle/0005_neat_norman_osborn.sql
+++ b/drizzle/0005_neat_norman_osborn.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "messages" ADD COLUMN "campaign_id" text;--> statement-breakpoint
+ALTER TABLE "messages" ADD COLUMN "brand_id" text;--> statement-breakpoint
+ALTER TABLE "messages" ADD COLUMN "workflow_name" text;

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,298 @@
+{
+  "id": "a1274845-f9f4-4a59-8819-ca66b7c2736a",
+  "prevId": "74ef7ca7-8c78-423d-9c27-2ed97216ec12",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_configs": {
+      "name": "app_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mcp_server_url": {
+          "name": "mcp_server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_key_name": {
+          "name": "mcp_key_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_configs_org_id_unique": {
+          "name": "app_configs_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buttons": {
+          "name": "buttons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platform_configs": {
+      "name": "platform_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mcp_server_url": {
+          "name": "mcp_server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_key_name": {
+          "name": "mcp_key_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "platform_configs_key_unique": {
+          "name": "platform_configs_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1773386153282,
       "tag": "0004_military_retro_girl",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1773407161270,
+      "tag": "0005_neat_norman_osborn",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -19,6 +19,9 @@ export const messages = pgTable("messages", {
   buttons: jsonb("buttons").$type<ButtonRecord[]>(),
   tokenCount: integer("token_count"),
   runId: uuid("run_id"),
+  campaignId: text("campaign_id"),
+  brandId: text("brand_id"),
+  workflowName: text("workflow_name"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,7 +137,13 @@ app.put("/platform-config", requireInternalAuth, async (req, res) => {
 // --- Chat ---
 
 app.post("/chat", requireAuth, async (req, res) => {
-  const { orgId, userId, runId: callerRunId } = res.locals as AuthLocals;
+  const { orgId, userId, runId: callerRunId, workflowTracking } = res.locals as AuthLocals;
+
+  // Build tracking headers to forward to downstream services
+  const trackingHeaders: Record<string, string> = {};
+  if (workflowTracking.campaignId) trackingHeaders["x-campaign-id"] = workflowTracking.campaignId;
+  if (workflowTracking.brandId) trackingHeaders["x-brand-id"] = workflowTracking.brandId;
+  if (workflowTracking.workflowName) trackingHeaders["x-workflow-name"] = workflowTracking.workflowName;
 
   const parsed = ChatRequestSchema.safeParse(req.body);
   if (!parsed.success) {
@@ -174,6 +180,7 @@ app.post("/chat", requireAuth, async (req, res) => {
       orgId,
       userId,
       caller: { method: "POST", path: "/chat" },
+      trackingHeaders,
     });
   } catch (err) {
     console.error(`Failed to resolve Gemini key for org="${orgId}":`, err);
@@ -234,7 +241,7 @@ app.post("/chat", requireAuth, async (req, res) => {
       serviceName: "chat-service",
       taskName: "chat",
       parentRunId: callerRunId,
-    });
+    }, trackingHeaders);
     if (run) runId = run.id;
 
     // Load conversation history
@@ -257,6 +264,7 @@ app.post("/chat", requireAuth, async (req, res) => {
           appConfig.mcpKeyName,
           orgId,
           { method: "POST", path: "/chat" },
+          trackingHeaders,
         );
         mcpConn = await connectMcp({
           serverUrl: appConfig.mcpServerUrl,
@@ -272,6 +280,9 @@ app.post("/chat", requireAuth, async (req, res) => {
       sessionId: currentSessionId,
       role: "user",
       content: message.trim(),
+      campaignId: workflowTracking.campaignId ?? null,
+      brandId: workflowTracking.brandId ?? null,
+      workflowName: workflowTracking.workflowName ?? null,
     });
 
     // Stream response from Gemini
@@ -474,6 +485,9 @@ app.post("/chat", requireAuth, async (req, res) => {
       buttons: buttons.length > 0 ? buttons : null,
       tokenCount: totalPromptTokens + totalOutputTokens || null,
       runId: runId ?? null,
+      campaignId: workflowTracking.campaignId ?? null,
+      brandId: workflowTracking.brandId ?? null,
+      workflowName: workflowTracking.workflowName ?? null,
     });
 
     sendSSE(res, "[DONE]");
@@ -516,8 +530,8 @@ app.post("/chat", requireAuth, async (req, res) => {
           : []),
       ];
       Promise.all([
-        updateRunStatus(runId, chatFailed ? "failed" : "completed"),
-        addRunCosts(runId, costItems),
+        updateRunStatus(runId, chatFailed ? "failed" : "completed", trackingHeaders),
+        addRunCosts(runId, costItems, trackingHeaders),
       ]).catch(() => {});
     }
 

--- a/src/lib/key-client.ts
+++ b/src/lib/key-client.ts
@@ -14,11 +14,18 @@ export interface DecryptedKey {
   key: string;
 }
 
+export interface TrackingHeaders {
+  "x-campaign-id"?: string;
+  "x-brand-id"?: string;
+  "x-workflow-name"?: string;
+}
+
 export interface KeyResolutionParams {
   provider: string;
   orgId: string;
   userId: string;
   caller: CallerInfo;
+  trackingHeaders?: TrackingHeaders;
 }
 
 export interface ResolvedKey {
@@ -36,18 +43,25 @@ export async function resolveKey(
     );
   }
 
-  const { provider, orgId, userId, caller } = params;
+  const { provider, orgId, userId, caller, trackingHeaders } = params;
   const qs = new URLSearchParams({ orgId, userId });
   const url = `${KEY_SERVICE_URL}/keys/${encodeURIComponent(provider)}/decrypt?${qs}`;
 
+  const headers: Record<string, string> = {
+    "x-api-key": KEY_SERVICE_API_KEY,
+    "X-Caller-Service": CALLER_SERVICE,
+    "X-Caller-Method": caller.method,
+    "X-Caller-Path": caller.path,
+  };
+  if (trackingHeaders) {
+    for (const [k, v] of Object.entries(trackingHeaders)) {
+      if (v) headers[k] = v;
+    }
+  }
+
   const res = await fetch(url, {
     method: "GET",
-    headers: {
-      "x-api-key": KEY_SERVICE_API_KEY,
-      "X-Caller-Service": CALLER_SERVICE,
-      "X-Caller-Method": caller.method,
-      "X-Caller-Path": caller.path,
-    },
+    headers,
   });
 
   if (!res.ok) {
@@ -64,6 +78,7 @@ export async function decryptOrgKey(
   provider: string,
   orgId: string,
   caller: CallerInfo,
+  trackingHeaders?: TrackingHeaders,
 ): Promise<DecryptedKey> {
   if (!KEY_SERVICE_API_KEY) {
     throw new Error(
@@ -73,14 +88,21 @@ export async function decryptOrgKey(
 
   const url = `${KEY_SERVICE_URL}/internal/keys/${encodeURIComponent(provider)}/decrypt?orgId=${encodeURIComponent(orgId)}`;
 
+  const headers: Record<string, string> = {
+    "x-api-key": KEY_SERVICE_API_KEY,
+    "X-Caller-Service": CALLER_SERVICE,
+    "X-Caller-Method": caller.method,
+    "X-Caller-Path": caller.path,
+  };
+  if (trackingHeaders) {
+    for (const [k, v] of Object.entries(trackingHeaders)) {
+      if (v) headers[k] = v;
+    }
+  }
+
   const res = await fetch(url, {
     method: "GET",
-    headers: {
-      "x-api-key": KEY_SERVICE_API_KEY,
-      "X-Caller-Service": CALLER_SERVICE,
-      "X-Caller-Method": caller.method,
-      "X-Caller-Path": caller.path,
-    },
+    headers,
   });
 
   if (!res.ok) {

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -26,22 +26,35 @@ export interface CostItem {
   costSource: "platform" | "org";
 }
 
+export interface TrackingHeaders {
+  "x-campaign-id"?: string;
+  "x-brand-id"?: string;
+  "x-workflow-name"?: string;
+}
+
 async function runsRequest<T>(
   method: string,
   path: string,
   body?: unknown,
+  trackingHeaders?: TrackingHeaders,
 ): Promise<T | null> {
   if (!RUNS_SERVICE_API_KEY) {
     console.warn("[runs-client] RUNS_SERVICE_API_KEY not set, skipping");
     return null;
   }
   try {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "X-API-Key": RUNS_SERVICE_API_KEY,
+    };
+    if (trackingHeaders) {
+      for (const [k, v] of Object.entries(trackingHeaders)) {
+        if (v) headers[k] = v;
+      }
+    }
     const res = await fetch(`${RUNS_SERVICE_URL}${path}`, {
       method,
-      headers: {
-        "Content-Type": "application/json",
-        "X-API-Key": RUNS_SERVICE_API_KEY,
-      },
+      headers,
       ...(body ? { body: JSON.stringify(body) } : {}),
     });
     if (!res.ok) {
@@ -60,21 +73,24 @@ async function runsRequest<T>(
 
 export async function createRun(
   params: CreateRunParams,
+  trackingHeaders?: TrackingHeaders,
 ): Promise<RunsRun | null> {
-  return runsRequest<RunsRun>("POST", "/v1/runs", params);
+  return runsRequest<RunsRun>("POST", "/v1/runs", params, trackingHeaders);
 }
 
 export async function updateRunStatus(
   id: string,
   status: "completed" | "failed",
+  trackingHeaders?: TrackingHeaders,
 ): Promise<RunsRun | null> {
-  return runsRequest<RunsRun>("PATCH", `/v1/runs/${id}`, { status });
+  return runsRequest<RunsRun>("PATCH", `/v1/runs/${id}`, { status }, trackingHeaders);
 }
 
 export async function addRunCosts(
   id: string,
   items: CostItem[],
+  trackingHeaders?: TrackingHeaders,
 ): Promise<void> {
   if (items.length === 0) return;
-  await runsRequest("POST", `/v1/runs/${id}/costs`, { items });
+  await runsRequest("POST", `/v1/runs/${id}/costs`, { items }, trackingHeaders);
 }

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,9 +1,16 @@
 import type { Request, Response, NextFunction } from "express";
 
+export interface WorkflowTrackingHeaders {
+  campaignId?: string;
+  brandId?: string;
+  workflowName?: string;
+}
+
 export interface AuthLocals {
   orgId: string;
   userId: string;
   runId: string;
+  workflowTracking: WorkflowTrackingHeaders;
 }
 
 export function requireAuth(
@@ -38,7 +45,19 @@ export function requireAuth(
   res.locals.orgId = orgId;
   res.locals.userId = userId;
   res.locals.runId = runId;
+  res.locals.workflowTracking = extractWorkflowTracking(req);
   next();
+}
+
+function extractWorkflowTracking(req: Request): WorkflowTrackingHeaders {
+  const tracking: WorkflowTrackingHeaders = {};
+  const campaignId = req.headers["x-campaign-id"];
+  if (typeof campaignId === "string") tracking.campaignId = campaignId;
+  const brandId = req.headers["x-brand-id"];
+  if (typeof brandId === "string") tracking.brandId = brandId;
+  const workflowName = req.headers["x-workflow-name"];
+  if (typeof workflowName === "string") tracking.workflowName = workflowName;
+  return tracking;
 }
 
 export function requireInternalAuth(

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -8,6 +8,20 @@ extendZodWithOpenApi(z);
 
 export const registry = new OpenAPIRegistry();
 
+// --- Workflow tracking headers (optional, injected by workflow-service) ---
+
+const workflowTrackingHeaders = {
+  "x-campaign-id": z.string().optional().openapi({
+    description: "Campaign ID — injected automatically by workflow-service",
+  }),
+  "x-brand-id": z.string().optional().openapi({
+    description: "Brand ID — injected automatically by workflow-service",
+  }),
+  "x-workflow-name": z.string().optional().openapi({
+    description: "Workflow name — injected automatically by workflow-service",
+  }),
+};
+
 // --- Shared schemas ---
 
 export const ErrorResponseSchema = z
@@ -109,6 +123,7 @@ registry.registerPath({
       "x-run-id": z.string().uuid().openapi({
         description: "Caller's run ID",
       }),
+      ...workflowTrackingHeaders,
     }),
     body: {
       content: { "application/json": { schema: AppConfigRequestSchema } },
@@ -227,6 +242,7 @@ registry.registerPath({
         description:
           "Caller's run ID — used as parentRunId when creating this service's own run in runs-service",
       }),
+      ...workflowTrackingHeaders,
     }),
     body: {
       content: { "application/json": { schema: ChatRequestSchema } },

--- a/tests/unit/workflow-tracking.test.ts
+++ b/tests/unit/workflow-tracking.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Request, Response, NextFunction } from "express";
+import { requireAuth, type AuthLocals } from "../../src/middleware/auth.js";
+
+function mockReqRes(headers: Record<string, string> = {}) {
+  const req = { headers } as unknown as Request;
+  const res = {
+    locals: {} as Record<string, unknown>,
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  } as unknown as Response;
+  const next = vi.fn() as NextFunction;
+  return { req, res, next };
+}
+
+const BASE_HEADERS = {
+  "x-api-key": "test-key",
+  "x-org-id": "org-123",
+  "x-user-id": "user-456",
+  "x-run-id": "run-789",
+};
+
+describe("workflow tracking headers in auth middleware", () => {
+  it("extracts all three tracking headers when present", () => {
+    const { req, res, next } = mockReqRes({
+      ...BASE_HEADERS,
+      "x-campaign-id": "camp-abc",
+      "x-brand-id": "brand-xyz",
+      "x-workflow-name": "outreach-v2",
+    });
+    requireAuth(req, res, next);
+    expect(next).toHaveBeenCalled();
+    const locals = res.locals as unknown as AuthLocals;
+    expect(locals.workflowTracking).toEqual({
+      campaignId: "camp-abc",
+      brandId: "brand-xyz",
+      workflowName: "outreach-v2",
+    });
+  });
+
+  it("returns empty tracking object when no tracking headers present", () => {
+    const { req, res, next } = mockReqRes(BASE_HEADERS);
+    requireAuth(req, res, next);
+    expect(next).toHaveBeenCalled();
+    const locals = res.locals as unknown as AuthLocals;
+    expect(locals.workflowTracking).toEqual({});
+  });
+
+  it("extracts partial tracking headers (only campaign-id)", () => {
+    const { req, res, next } = mockReqRes({
+      ...BASE_HEADERS,
+      "x-campaign-id": "camp-only",
+    });
+    requireAuth(req, res, next);
+    expect(next).toHaveBeenCalled();
+    const locals = res.locals as unknown as AuthLocals;
+    expect(locals.workflowTracking).toEqual({
+      campaignId: "camp-only",
+    });
+  });
+
+  it("does not break existing auth flow", () => {
+    const { req, res, next } = mockReqRes({
+      ...BASE_HEADERS,
+      "x-campaign-id": "camp-123",
+    });
+    requireAuth(req, res, next);
+    expect(res.locals.orgId).toBe("org-123");
+    expect(res.locals.userId).toBe("user-456");
+    expect(res.locals.runId).toBe("run-789");
+  });
+});
+
+describe("runs-client forwards tracking headers", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.RUNS_SERVICE_API_KEY = "test-runs-key";
+    process.env.RUNS_SERVICE_URL = "https://runs.test.local";
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+  });
+
+  async function loadModule() {
+    vi.resetModules();
+    return import("../../src/lib/runs-client.js");
+  }
+
+  it("forwards tracking headers on createRun", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: "run-1", status: "running" }),
+    });
+
+    const { createRun } = await loadModule();
+    await createRun(
+      { orgId: "org-1", serviceName: "chat-service", taskName: "chat" },
+      { "x-campaign-id": "camp-1", "x-brand-id": "brand-1", "x-workflow-name": "flow-1" },
+    );
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://runs.test.local/v1/runs",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-campaign-id": "camp-1",
+          "x-brand-id": "brand-1",
+          "x-workflow-name": "flow-1",
+        }),
+      }),
+    );
+  });
+
+  it("does not include tracking headers when not provided", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: "run-1", status: "running" }),
+    });
+
+    const { createRun } = await loadModule();
+    await createRun({ orgId: "org-1", serviceName: "chat-service", taskName: "chat" });
+
+    const callHeaders = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].headers;
+    expect(callHeaders["x-campaign-id"]).toBeUndefined();
+    expect(callHeaders["x-brand-id"]).toBeUndefined();
+    expect(callHeaders["x-workflow-name"]).toBeUndefined();
+  });
+
+  it("forwards tracking headers on updateRunStatus", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: "run-1", status: "completed" }),
+    });
+
+    const { updateRunStatus } = await loadModule();
+    await updateRunStatus("run-1", "completed", { "x-campaign-id": "camp-2" });
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-campaign-id": "camp-2",
+        }),
+      }),
+    );
+  });
+
+  it("forwards tracking headers on addRunCosts", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ costs: [] }),
+    });
+
+    const { addRunCosts } = await loadModule();
+    await addRunCosts(
+      "run-1",
+      [{ costName: "gemini-3-flash-tokens-input", quantity: 100, costSource: "platform" as const }],
+      { "x-brand-id": "brand-3" },
+    );
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-brand-id": "brand-3",
+        }),
+      }),
+    );
+  });
+});
+
+describe("key-client forwards tracking headers", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.KEY_SERVICE_API_KEY = "test-key-svc-key";
+    process.env.KEY_SERVICE_URL = "https://key.test.local";
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+  });
+
+  async function loadModule() {
+    vi.resetModules();
+    return import("../../src/lib/key-client.js");
+  }
+
+  it("forwards tracking headers on resolveKey", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ provider: "gemini", key: "k", keySource: "platform" }),
+    });
+
+    const { resolveKey } = await loadModule();
+    await resolveKey({
+      provider: "gemini",
+      orgId: "org-1",
+      userId: "user-1",
+      caller: { method: "POST", path: "/chat" },
+      trackingHeaders: { "x-campaign-id": "camp-1", "x-workflow-name": "flow-1" },
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-campaign-id": "camp-1",
+          "x-workflow-name": "flow-1",
+        }),
+      }),
+    );
+  });
+
+  it("forwards tracking headers on decryptOrgKey", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ provider: "mcp", key: "k" }),
+    });
+
+    const { decryptOrgKey } = await loadModule();
+    await decryptOrgKey("mcp", "org-1", { method: "POST", path: "/chat" }, {
+      "x-brand-id": "brand-1",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-brand-id": "brand-1",
+        }),
+      }),
+    );
+  });
+
+  it("does not include tracking headers when not provided", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ provider: "gemini", key: "k", keySource: "platform" }),
+    });
+
+    const { resolveKey } = await loadModule();
+    await resolveKey({
+      provider: "gemini",
+      orgId: "org-1",
+      userId: "user-1",
+      caller: { method: "POST", path: "/chat" },
+    });
+
+    const callHeaders = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].headers;
+    expect(callHeaders["x-campaign-id"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Accept optional `x-campaign-id`, `x-brand-id`, `x-workflow-name` headers (injected by workflow-service on all HTTP calls from workflows)
- Store them as nullable columns in `messages` table via new Drizzle migration
- Forward them to runs-service and key-service on all downstream HTTP calls
- Add headers to Zod OpenAPI schemas for `/chat` and `/config` endpoints
- 11 new unit tests covering middleware extraction, runs-client forwarding, and key-client forwarding

## Test plan
- [x] All 118 unit tests pass (11 new)
- [ ] CI passes (check-tests, run-tests, test-integration)
- [ ] Verify migration creates columns on Neon branch
- [ ] Manual: POST /chat with tracking headers → verify they appear in messages table

🤖 Generated with [Claude Code](https://claude.com/claude-code)