### PR TITLE
fix: send orgId/userId as headers in key-client

### DIFF
--- a/src/lib/key-client.ts
+++ b/src/lib/key-client.ts
@@ -44,11 +44,12 @@ export async function resolveKey(
   }
 
   const { provider, orgId, userId, caller, trackingHeaders } = params;
-  const qs = new URLSearchParams({ orgId, userId });
-  const url = `${KEY_SERVICE_URL}/keys/${encodeURIComponent(provider)}/decrypt?${qs}`;
+  const url = `${KEY_SERVICE_URL}/keys/${encodeURIComponent(provider)}/decrypt`;
 
   const headers: Record<string, string> = {
     "x-api-key": KEY_SERVICE_API_KEY,
+    "x-org-id": orgId,
+    "x-user-id": userId,
     "X-Caller-Service": CALLER_SERVICE,
     "X-Caller-Method": caller.method,
     "X-Caller-Path": caller.path,
@@ -86,10 +87,11 @@ export async function decryptOrgKey(
     );
   }
 
-  const url = `${KEY_SERVICE_URL}/internal/keys/${encodeURIComponent(provider)}/decrypt?orgId=${encodeURIComponent(orgId)}`;
+  const url = `${KEY_SERVICE_URL}/internal/keys/${encodeURIComponent(provider)}/decrypt`;
 
   const headers: Record<string, string> = {
     "x-api-key": KEY_SERVICE_API_KEY,
+    "x-org-id": orgId,
     "X-Caller-Service": CALLER_SERVICE,
     "X-Caller-Method": caller.method,
     "X-Caller-Path": caller.path,

--- a/tests/unit/key-client.test.ts
+++ b/tests/unit/key-client.test.ts
@@ -19,7 +19,7 @@ async function loadModule() {
 }
 
 describe("resolveKey", () => {
-  it("sends GET with correct URL, query params, and caller headers", async () => {
+  it("sends GET with orgId and userId as headers (not query params)", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: () =>
@@ -39,11 +39,13 @@ describe("resolveKey", () => {
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://key.test.local/keys/gemini/decrypt?orgId=org-uuid-123&userId=user-uuid-456",
+      "https://key.test.local/keys/gemini/decrypt",
       expect.objectContaining({
         method: "GET",
         headers: {
           "x-api-key": "test-key-svc-key",
+          "x-org-id": "org-uuid-123",
+          "x-user-id": "user-uuid-456",
           "X-Caller-Service": "chat",
           "X-Caller-Method": "POST",
           "X-Caller-Path": "/chat",
@@ -186,14 +188,14 @@ describe("resolveKey", () => {
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://key.mcpfactory.org/keys/gemini/decrypt?orgId=org-123&userId=user-123",
+      "https://key.mcpfactory.org/keys/gemini/decrypt",
       expect.anything(),
     );
   });
 });
 
 describe("decryptOrgKey", () => {
-  it("sends GET with correct URL including orgId query param", async () => {
+  it("sends GET with correct URL and orgId header", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: () =>
@@ -207,11 +209,12 @@ describe("decryptOrgKey", () => {
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://key.test.local/internal/keys/mcpfactory/decrypt?orgId=org-uuid-123",
+      "https://key.test.local/internal/keys/mcpfactory/decrypt",
       expect.objectContaining({
         method: "GET",
         headers: {
           "x-api-key": "test-key-svc-key",
+          "x-org-id": "org-uuid-123",
           "X-Caller-Service": "chat",
           "X-Caller-Method": "POST",
           "X-Caller-Path": "/chat",


### PR DESCRIPTION
## Summary
- **Bug**: `resolveKey` and `decryptOrgKey` were passing `orgId`/`userId` as query parameters, but key-service requires them as `x-org-id`/`x-user-id` headers — causing 400 `"Missing required header: x-org-id"` errors on every chat request.
- **Fix**: Move `orgId`/`userId` from query params to request headers in both functions.
- **Tests**: Updated existing test expectations to match the new header-based contract.

## Test plan
- [x] All unit tests pass (119/119)
- [x] Integration test skipped locally (requires DB — passes in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)