### PR TITLE
feat: add thinking SSE events and tool call IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,17 @@ The response is a stream of SSE events in this order:
 data: {"sessionId":"uuid"}
 ```
 
-### 2. Streaming tokens
+### 2. Thinking (optional)
+When Gemini uses internal reasoning, thinking events are streamed progressively:
+```
+data: {"type":"thinking_start"}
+data: {"type":"thinking_delta","thinking":"Let me analyze the user's request..."}
+data: {"type":"thinking_delta","thinking":"I should check their campaign data first."}
+data: {"type":"thinking_stop"}
+```
+Thinking blocks may appear before tokens and before/after tool calls. The frontend can render these as collapsible "Thinking…" blocks.
+
+### 3. Streaming tokens
 Streamed incrementally as the AI generates its response:
 ```
 data: {"type":"token","content":"Here's"}
@@ -129,29 +139,34 @@ data: {"type":"token","content":" what I"}
 data: {"type":"token","content":" suggest..."}
 ```
 
-### 3. Tool calls (optional)
+### 4. Tool calls (optional)
 If the AI invokes an MCP tool:
 ```
-data: {"type":"tool_call","name":"search_leads","args":{"query":"..."}}
-data: {"type":"tool_result","name":"search_leads","result":{...}}
+data: {"type":"tool_call","id":"tc_550e8400-e29b-41d4-a716-446655440000","name":"search_leads","args":{"query":"..."}}
+data: {"type":"tool_result","id":"tc_550e8400-e29b-41d4-a716-446655440000","name":"search_leads","result":{...}}
 ```
+- `id` — unique identifier matching a `tool_call` to its `tool_result`
+- `name` — the tool name
+- `args` — input arguments as an object
+- `result` — the tool output (string or object)
+
 After a tool result, more `token` events follow with the AI's continuation.
 
-### 4. Input Request (optional)
+### 5. Input Request (optional)
 When the AI needs structured user input (e.g., a URL), it emits an input request instead of asking in plain text:
 ```
 data: {"type":"input_request","input_type":"url","label":"What's your brand URL?","placeholder":"https://yourbrand.com","field":"brand_url"}
 ```
 The frontend should render an appropriate input widget based on `input_type` (`url`, `text`, or `email`). When the user submits, send the value as a regular `/chat` message. The `field` key identifies what the input is for.
 
-### 5. Buttons (optional)
+### 6. Buttons (optional)
 AI-generated quick-reply buttons, sent after all tokens are done:
 ```
 data: {"type":"buttons","buttons":[{"label":"Send Cold Emails","value":"Send Cold Emails"}]}
 ```
 Buttons are extracted from the AI response when it ends with lines formatted as `- [Button Text]`. The button `label` and `value` are both set to the text inside the brackets. Button lines are stripped from the token stream to prevent duplication.
 
-### 6. Done
+### 7. Done
 ```
 data: "[DONE]"
 ```

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,560 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Chat Service",
+    "description": "Multi-app AI chat service. Streams Gemini AI responses via SSE with configurable system prompts and optional MCP tool calling per app.",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:3002"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "HealthResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "ok"
+            ]
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "error"
+        ]
+      },
+      "AppConfigResponse": {
+        "type": "object",
+        "properties": {
+          "orgId": {
+            "type": "string"
+          },
+          "systemPrompt": {
+            "type": "string"
+          },
+          "mcpServerUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "mcpKeyName": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "orgId",
+          "systemPrompt",
+          "mcpServerUrl",
+          "mcpKeyName",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "ValidationErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": {
+              "nullable": true
+            }
+          }
+        },
+        "required": [
+          "error"
+        ]
+      },
+      "AppConfigRequest": {
+        "type": "object",
+        "properties": {
+          "systemPrompt": {
+            "type": "string",
+            "minLength": 1
+          },
+          "mcpServerUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "mcpKeyName": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "systemPrompt"
+        ]
+      },
+      "PlatformConfigResponse": {
+        "type": "object",
+        "properties": {
+          "systemPrompt": {
+            "type": "string"
+          },
+          "mcpServerUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "mcpKeyName": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "systemPrompt",
+          "mcpServerUrl",
+          "mcpKeyName",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "PlatformConfigRequest": {
+        "type": "object",
+        "properties": {
+          "systemPrompt": {
+            "type": "string",
+            "minLength": 1
+          },
+          "mcpServerUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "mcpKeyName": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "systemPrompt"
+        ]
+      },
+      "ChatRequest": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "minLength": 1
+          },
+          "sessionId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "context": {
+            "type": "object",
+            "additionalProperties": {
+              "nullable": true
+            }
+          }
+        },
+        "required": [
+          "message"
+        ]
+      }
+    },
+    "parameters": {}
+  },
+  "paths": {
+    "/health": {
+      "get": {
+        "tags": [
+          "Health"
+        ],
+        "summary": "Health check",
+        "description": "Returns service health status",
+        "responses": {
+          "200": {
+            "description": "Service is healthy",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi.json": {
+      "get": {
+        "tags": [
+          "Docs"
+        ],
+        "summary": "OpenAPI specification",
+        "description": "Returns the OpenAPI 3.0 JSON specification for this service",
+        "responses": {
+          "200": {
+            "description": "OpenAPI spec",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Spec not generated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/config": {
+      "put": {
+        "tags": [
+          "App Config"
+        ],
+        "summary": "Register or update app configuration",
+        "description": "Idempotent upsert of app configuration scoped by org (via x-org-id header). Includes system prompt and optional MCP settings. Call on every cold start.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Service-to-service API key"
+            },
+            "required": true,
+            "description": "Service-to-service API key",
+            "name": "x-api-key",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal org UUID from client-service"
+            },
+            "required": true,
+            "description": "Internal org UUID from client-service",
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal user UUID from client-service"
+            },
+            "required": true,
+            "description": "Internal user UUID from client-service",
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Caller's run ID"
+            },
+            "required": true,
+            "description": "Caller's run ID",
+            "name": "x-run-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID — injected automatically by workflow-service"
+            },
+            "required": false,
+            "description": "Campaign ID — injected automatically by workflow-service",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID — injected automatically by workflow-service"
+            },
+            "required": false,
+            "description": "Brand ID — injected automatically by workflow-service",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name — injected automatically by workflow-service"
+            },
+            "required": false,
+            "description": "Workflow name — injected automatically by workflow-service",
+            "name": "x-workflow-name",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AppConfigRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "App config saved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppConfigResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid x-api-key header",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/platform-config": {
+      "put": {
+        "tags": [
+          "Platform Config"
+        ],
+        "summary": "Register or update platform-wide chat configuration",
+        "description": "Idempotent upsert of a global chat configuration (not scoped to any org). Used as fallback when no per-org config exists. Auth: X-API-Key only — no x-org-id, x-user-id, or x-run-id required. Called on every cold start by api-service.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Service-to-service API key"
+            },
+            "required": true,
+            "description": "Service-to-service API key",
+            "name": "x-api-key",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlatformConfigRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Platform config saved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformConfigResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid x-api-key header",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/chat": {
+      "post": {
+        "tags": [
+          "Chat"
+        ],
+        "summary": "Stream AI chat response",
+        "description": "Send a message and receive a streamed AI response via Server-Sent Events (SSE). Supports MCP tool calling and quick-reply buttons. Requires app config to be registered first via PUT /config.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Service-to-service API key"
+            },
+            "required": true,
+            "description": "Service-to-service API key",
+            "name": "x-api-key",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal org UUID from client-service"
+            },
+            "required": true,
+            "description": "Internal org UUID from client-service",
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal user UUID from client-service"
+            },
+            "required": true,
+            "description": "Internal user UUID from client-service",
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Caller's run ID — used as parentRunId when creating this service's own run in runs-service"
+            },
+            "required": true,
+            "description": "Caller's run ID — used as parentRunId when creating this service's own run in runs-service",
+            "name": "x-run-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID — injected automatically by workflow-service"
+            },
+            "required": false,
+            "description": "Campaign ID — injected automatically by workflow-service",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID — injected automatically by workflow-service"
+            },
+            "required": false,
+            "description": "Brand ID — injected automatically by workflow-service",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name — injected automatically by workflow-service"
+            },
+            "required": false,
+            "description": "Workflow name — injected automatically by workflow-service",
+            "name": "x-workflow-name",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChatRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "SSE stream of chat events (token, thinking_start, thinking_delta, thinking_stop, tool_call, tool_result, input_request, buttons, [DONE])",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid request fields",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid x-api-key header",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "App config not found — register via PUT /config first",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import cors from "cors";
+import crypto from "crypto";
 import { readFileSync, existsSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
@@ -354,6 +355,10 @@ app.post("/chat", requireAuth, async (req, res) => {
         bufferToken(event.content);
       }
 
+      if (event.type === "thinking_start" || event.type === "thinking_delta" || event.type === "thinking_stop") {
+        sendSSE(res, event);
+      }
+
       if (event.type === "done") {
         accumulateUsage(event.usage);
       }
@@ -376,8 +381,10 @@ app.post("/chat", requireAuth, async (req, res) => {
 
         if (!mcpConn) continue;
 
+        const toolCallId = `tc_${crypto.randomUUID()}`;
         sendSSE(res, {
           type: "tool_call",
+          id: toolCallId,
           name: call.name,
           args: call.args,
         });
@@ -393,7 +400,7 @@ app.post("/chat", requireAuth, async (req, res) => {
             result,
           });
 
-          sendSSE(res, { type: "tool_result", name: call.name, result });
+          sendSSE(res, { type: "tool_result", id: toolCallId, name: call.name, result });
 
           // Send function result back to Gemini and stream continuation
           // Gemini 3 with thinking requires thoughtSignature on functionCall parts
@@ -422,6 +429,9 @@ app.post("/chat", requireAuth, async (req, res) => {
           for await (const contEvent of contStream) {
             if (contEvent.type === "token") {
               bufferToken(contEvent.content);
+            }
+            if (contEvent.type === "thinking_start" || contEvent.type === "thinking_delta" || contEvent.type === "thinking_stop") {
+              sendSSE(res, contEvent);
             }
             if (contEvent.type === "done") {
               accumulateUsage(contEvent.usage);

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -57,6 +57,9 @@ export interface UsageMetadata {
 
 export type GeminiEvent =
   | { type: "token"; content: string }
+  | { type: "thinking_start" }
+  | { type: "thinking_delta"; thinking: string }
+  | { type: "thinking_stop" }
   | { type: "function_call"; call: FunctionCall }
   | { type: "done"; usage?: UsageMetadata };
 
@@ -108,6 +111,7 @@ export function createGeminiClient({
       });
 
       let usage: UsageMetadata | undefined;
+      let inThinking = false;
       for await (const chunk of response) {
         if (chunk.usageMetadata) {
           usage = {
@@ -120,7 +124,20 @@ export function createGeminiClient({
         if (!candidate) continue;
 
         for (const part of candidate.content?.parts ?? []) {
-          if (part.thought) continue;
+          if (part.thought) {
+            if (!inThinking) {
+              inThinking = true;
+              yield { type: "thinking_start" } as const;
+            }
+            if (part.text) {
+              yield { type: "thinking_delta", thinking: part.text } as const;
+            }
+            continue;
+          }
+          if (inThinking) {
+            inThinking = false;
+            yield { type: "thinking_stop" } as const;
+          }
           if (part.text) {
             yield { type: "token", content: part.text };
           }
@@ -138,6 +155,9 @@ export function createGeminiClient({
             };
           }
         }
+      }
+      if (inThinking) {
+        yield { type: "thinking_stop" } as const;
       }
 
       yield { type: "done", usage };
@@ -184,6 +204,7 @@ export function createGeminiClient({
       });
 
       let usage: UsageMetadata | undefined;
+      let inThinking = false;
       for await (const chunk of response) {
         if (chunk.usageMetadata) {
           usage = {
@@ -196,7 +217,20 @@ export function createGeminiClient({
         if (!candidate) continue;
 
         for (const part of candidate.content?.parts ?? []) {
-          if (part.thought) continue;
+          if (part.thought) {
+            if (!inThinking) {
+              inThinking = true;
+              yield { type: "thinking_start" } as const;
+            }
+            if (part.text) {
+              yield { type: "thinking_delta", thinking: part.text } as const;
+            }
+            continue;
+          }
+          if (inThinking) {
+            inThinking = false;
+            yield { type: "thinking_stop" } as const;
+          }
           if (part.text) {
             yield { type: "token", content: part.text };
           }
@@ -214,6 +248,9 @@ export function createGeminiClient({
             };
           }
         }
+      }
+      if (inThinking) {
+        yield { type: "thinking_stop" } as const;
       }
 
       yield { type: "done", usage };

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -251,7 +251,7 @@ registry.registerPath({
   responses: {
     200: {
       description:
-        "SSE stream of chat events (token, tool_call, tool_result, input_request, buttons, [DONE])",
+        "SSE stream of chat events (token, thinking_start, thinking_delta, thinking_stop, tool_call, tool_result, input_request, buttons, [DONE])",
       content: {
         "text/event-stream": {
           schema: z.string(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,19 @@ export interface SSETokenEvent {
   content: string;
 }
 
+export interface SSEThinkingStartEvent {
+  type: "thinking_start";
+}
+
+export interface SSEThinkingDeltaEvent {
+  type: "thinking_delta";
+  thinking: string;
+}
+
+export interface SSEThinkingStopEvent {
+  type: "thinking_stop";
+}
+
 export interface SSEButtonsEvent {
   type: "buttons";
   buttons: ButtonRecord[];
@@ -18,12 +31,14 @@ export interface SSEButtonsEvent {
 
 export interface SSEToolCallEvent {
   type: "tool_call";
+  id: string;
   name: string;
   args: Record<string, unknown>;
 }
 
 export interface SSEToolResultEvent {
   type: "tool_result";
+  id: string;
   name: string;
   result: unknown;
 }
@@ -42,6 +57,9 @@ export interface SSESessionEvent {
 
 export type SSEEvent =
   | SSETokenEvent
+  | SSEThinkingStartEvent
+  | SSEThinkingDeltaEvent
+  | SSEThinkingStopEvent
   | SSEButtonsEvent
   | SSEToolCallEvent
   | SSEToolResultEvent

--- a/tests/unit/gemini.test.ts
+++ b/tests/unit/gemini.test.ts
@@ -155,6 +155,174 @@ describe("sendFunctionResult", () => {
   });
 });
 
+describe("thinking events", () => {
+  it("yields thinking_start, thinking_delta, thinking_stop for thought parts", async () => {
+    mockGenerateContentStream.mockResolvedValue(
+      (async function* () {
+        yield {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  { thought: true, text: "Let me think about this..." },
+                ],
+              },
+            },
+          ],
+        };
+        yield {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  { thought: true, text: "I should check the data." },
+                ],
+              },
+            },
+          ],
+        };
+        yield {
+          candidates: [
+            {
+              content: {
+                parts: [{ text: "Here is my response." }],
+              },
+            },
+          ],
+        };
+      })(),
+    );
+
+    const client = createGeminiClient({
+      apiKey: "test-key",
+      systemPrompt: TEST_PROMPT,
+    });
+    const events = [];
+    for await (const event of client.streamChat([], "hello")) {
+      events.push(event);
+    }
+
+    expect(events).toEqual([
+      { type: "thinking_start" },
+      { type: "thinking_delta", thinking: "Let me think about this..." },
+      { type: "thinking_delta", thinking: "I should check the data." },
+      { type: "thinking_stop" },
+      { type: "token", content: "Here is my response." },
+      { type: "done", usage: undefined },
+    ]);
+  });
+
+  it("closes thinking block at end of stream if still open", async () => {
+    mockGenerateContentStream.mockResolvedValue(
+      (async function* () {
+        yield {
+          candidates: [
+            {
+              content: {
+                parts: [{ thought: true, text: "Thinking..." }],
+              },
+            },
+          ],
+        };
+      })(),
+    );
+
+    const client = createGeminiClient({
+      apiKey: "test-key",
+      systemPrompt: TEST_PROMPT,
+    });
+    const events = [];
+    for await (const event of client.streamChat([], "hello")) {
+      events.push(event);
+    }
+
+    expect(events).toEqual([
+      { type: "thinking_start" },
+      { type: "thinking_delta", thinking: "Thinking..." },
+      { type: "thinking_stop" },
+      { type: "done", usage: undefined },
+    ]);
+  });
+
+  it("emits no thinking events when no thought parts present", async () => {
+    mockGenerateContentStream.mockResolvedValue(
+      (async function* () {
+        yield {
+          candidates: [
+            {
+              content: {
+                parts: [{ text: "Direct response." }],
+              },
+            },
+          ],
+        };
+      })(),
+    );
+
+    const client = createGeminiClient({
+      apiKey: "test-key",
+      systemPrompt: TEST_PROMPT,
+    });
+    const events = [];
+    for await (const event of client.streamChat([], "hello")) {
+      events.push(event);
+    }
+
+    expect(events).toEqual([
+      { type: "token", content: "Direct response." },
+      { type: "done", usage: undefined },
+    ]);
+  });
+
+  it("yields thinking events in sendFunctionResult too", async () => {
+    mockGenerateContentStream.mockResolvedValue(
+      (async function* () {
+        yield {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  { thought: true, text: "Processing the result..." },
+                ],
+              },
+            },
+          ],
+        };
+        yield {
+          candidates: [
+            {
+              content: {
+                parts: [{ text: "Based on the tool result..." }],
+              },
+            },
+          ],
+        };
+      })(),
+    );
+
+    const client = createGeminiClient({
+      apiKey: "test-key",
+      systemPrompt: TEST_PROMPT,
+    });
+    const events = [];
+    for await (const event of client.sendFunctionResult(
+      [],
+      "tool",
+      { data: "ok" },
+    )) {
+      events.push(event);
+    }
+
+    expect(events).toEqual([
+      { type: "thinking_start" },
+      { type: "thinking_delta", thinking: "Processing the result..." },
+      { type: "thinking_stop" },
+      { type: "token", content: "Based on the tool result..." },
+      { type: "done", usage: undefined },
+    ]);
+  });
+});
+
 describe("thoughtSignature preservation", () => {
   it("yields thoughtSignature from function call parts", async () => {
     mockGenerateContentStream.mockResolvedValue(

--- a/tests/unit/types.test.ts
+++ b/tests/unit/types.test.ts
@@ -4,6 +4,11 @@ import type {
   SSETokenEvent,
   SSEButtonsEvent,
   SSEInputRequestEvent,
+  SSEThinkingStartEvent,
+  SSEThinkingDeltaEvent,
+  SSEThinkingStopEvent,
+  SSEToolCallEvent,
+  SSEToolResultEvent,
 } from "../../src/types.js";
 
 describe("types", () => {
@@ -58,5 +63,46 @@ describe("types", () => {
       field: "some_field",
     };
     expect(event.placeholder).toBeUndefined();
+  });
+
+  it("SSEThinkingStartEvent shape", () => {
+    const event: SSEThinkingStartEvent = { type: "thinking_start" };
+    expect(event.type).toBe("thinking_start");
+  });
+
+  it("SSEThinkingDeltaEvent shape", () => {
+    const event: SSEThinkingDeltaEvent = {
+      type: "thinking_delta",
+      thinking: "Let me analyze...",
+    };
+    expect(event.type).toBe("thinking_delta");
+    expect(event.thinking).toBe("Let me analyze...");
+  });
+
+  it("SSEThinkingStopEvent shape", () => {
+    const event: SSEThinkingStopEvent = { type: "thinking_stop" };
+    expect(event.type).toBe("thinking_stop");
+  });
+
+  it("SSEToolCallEvent includes id field", () => {
+    const event: SSEToolCallEvent = {
+      type: "tool_call",
+      id: "tc_abc-123",
+      name: "search_leads",
+      args: { query: "tech companies" },
+    };
+    expect(event.id).toBe("tc_abc-123");
+    expect(event.name).toBe("search_leads");
+  });
+
+  it("SSEToolResultEvent includes matching id field", () => {
+    const event: SSEToolResultEvent = {
+      type: "tool_result",
+      id: "tc_abc-123",
+      name: "search_leads",
+      result: { leads: [] },
+    };
+    expect(event.id).toBe("tc_abc-123");
+    expect(event.name).toBe("search_leads");
   });
 });


### PR DESCRIPTION
## Summary
- **Thinking events**: Emit `thinking_start`, `thinking_delta`, `thinking_stop` SSE events from Gemini's internal reasoning (previously filtered out). Uses Option A (streaming) so the frontend sees thinking appear progressively.
- **Tool call IDs**: Add unique `id` field (format `tc_<uuid>`) to both `tool_call` and `tool_result` SSE events so the frontend can match them.
- Updated TypeScript types, Zod OpenAPI schemas, and README SSE protocol docs.

## Test plan
- [x] 4 new tests for thinking events in `gemini.test.ts` (start/delta/stop lifecycle, stream-end close, no-thinking case, sendFunctionResult)
- [x] 3 new tests for tool call/result `id` fields and thinking event shapes in `types.test.ts`
- [x] All 127 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)