### PR TITLE
feat: upgrade to gemini-3.1-pro-preview

### DIFF
--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -73,7 +73,7 @@ export function buildSystemPrompt(
 
 export function createGeminiClient({
   apiKey,
-  model = "gemini-3-flash-preview",
+  model = "gemini-3.1-pro-preview",
   systemPrompt,
 }: GeminiOptions) {
   const ai = new GoogleGenAI({ apiKey });

--- a/tests/unit/gemini.test.ts
+++ b/tests/unit/gemini.test.ts
@@ -35,7 +35,7 @@ describe("createGeminiClient", () => {
     );
   });
 
-  it("defaults to gemini-3-flash-preview model", async () => {
+  it("defaults to gemini-3.1-pro-preview model", async () => {
     const client = createGeminiClient({
       apiKey: "test-key",
       systemPrompt: TEST_PROMPT,
@@ -46,7 +46,7 @@ describe("createGeminiClient", () => {
     }
 
     expect(mockGenerateContentStream).toHaveBeenCalledWith(
-      expect.objectContaining({ model: "gemini-3-flash-preview" }),
+      expect.objectContaining({ model: "gemini-3.1-pro-preview" }),
     );
   });
 
@@ -465,7 +465,7 @@ describe("usage metadata", () => {
       apiKey: "test-key",
       systemPrompt: TEST_PROMPT,
     });
-    expect(client.model).toBe("gemini-3-flash-preview");
+    expect(client.model).toBe("gemini-3.1-pro-preview");
   });
 });
 


### PR DESCRIPTION
## Summary
- Upgrades default Gemini model from `gemini-3-flash-preview` to `gemini-3.1-pro-preview`
- Updates corresponding unit tests

## Why
Gemini 3.1 Pro offers better reasoning, improved token efficiency, and more factually consistent responses. Thinking config (`ThinkingLevel.HIGH`) remains compatible.

## Test plan
- [x] All unit tests pass (128/128)
- [x] Model default test updated to assert `gemini-3.1-pro-preview`

🤖 Generated with [Claude Code](https://claude.com/claude-code)