### PR TITLE
fix: emit error event on empty Gemini response

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,14 @@ data: {"type":"buttons","buttons":[{"label":"Send Cold Emails","value":"Send Col
 ```
 Buttons are extracted from the AI response when it ends with lines formatted as `- [Button Text]`. The button `label` and `value` are both set to the text inside the brackets. Button lines are stripped from the token stream to prevent duplication.
 
-### 7. Done
+### 7. Error (optional)
+Sent when the AI model returns an empty response (context overflow, safety filter) or an unexpected error occurs:
+```
+data: {"type":"error","message":"The AI model returned an empty response. This may happen when the conversation is too long or the message content triggers a safety filter."}
+```
+The frontend should display the `message` to the user. An `error` event is always followed by `[DONE]`.
+
+### 8. Done
 ```
 data: "[DONE]"
 ```

--- a/openapi.json
+++ b/openapi.json
@@ -235,6 +235,26 @@
           "buttons"
         ]
       },
+      "SSEErrorEvent": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "error"
+            ]
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable error message explaining what went wrong",
+            "example": "The AI model returned an empty response. This may happen when the conversation is too long or the message content triggers a safety filter."
+          }
+        },
+        "required": [
+          "type",
+          "message"
+        ]
+      },
       "HealthResponse": {
         "type": "object",
         "properties": {
@@ -662,7 +682,7 @@
           "Chat"
         ],
         "summary": "Stream AI chat response",
-        "description": "Send a message and receive a streamed AI response via Server-Sent Events (SSE).\n\n**Session lifecycle:**\n- To start a new conversation, omit `sessionId`. The first SSE event will be `{\"sessionId\":\"<uuid>\"}` — store this ID.\n- To continue a conversation, pass that `sessionId` in subsequent requests.\n- If a provided `sessionId` does not exist or belongs to a different org, the stream returns an error and closes.\n\n**SSE event order:**\nEach `data:` line contains a JSON object. Events arrive in this order:\n\n1. **Session** — `{\"sessionId\":\"<uuid>\"}` (always first)\n2. **Thinking** _(optional)_ — `thinking_start` → one or more `thinking_delta` → `thinking_stop`. May appear before tokens and after tool results.\n3. **Tokens** — `{\"type\":\"token\",\"content\":\"...\"}` streamed incrementally as the AI generates text.\n4. **Tool calls** _(optional, repeatable)_ — `tool_call` followed by `tool_result`, then more thinking/tokens as the AI continues.\n5. **Input request** _(optional)_ — `input_request` when the AI needs structured user input (terminates the response).\n6. **Buttons** _(optional)_ — `{\"type\":\"buttons\",\"buttons\":[...]}` with quick-reply options, sent after all tokens.\n7. **Done** — `\"[DONE]\"` (always last).\n\nSee the SSE event schemas (SSESessionEvent, SSETokenEvent, SSEThinkingStartEvent, SSEThinkingDeltaEvent, SSEThinkingStopEvent, SSEToolCallEvent, SSEToolResultEvent, SSEInputRequestEvent, SSEButtonsEvent) in components/schemas for exact payload shapes.\n\nRequires app config to be registered first via PUT /config (or platform config via PUT /platform-config as fallback).",
+        "description": "Send a message and receive a streamed AI response via Server-Sent Events (SSE).\n\n**Session lifecycle:**\n- To start a new conversation, omit `sessionId`. The first SSE event will be `{\"sessionId\":\"<uuid>\"}` — store this ID.\n- To continue a conversation, pass that `sessionId` in subsequent requests.\n- If a provided `sessionId` does not exist or belongs to a different org, the stream returns an error and closes.\n\n**SSE event order:**\nEach `data:` line contains a JSON object. Events arrive in this order:\n\n1. **Session** — `{\"sessionId\":\"<uuid>\"}` (always first)\n2. **Thinking** _(optional)_ — `thinking_start` → one or more `thinking_delta` → `thinking_stop`. May appear before tokens and after tool results.\n3. **Tokens** — `{\"type\":\"token\",\"content\":\"...\"}` streamed incrementally as the AI generates text.\n4. **Tool calls** _(optional, repeatable)_ — `tool_call` followed by `tool_result`, then more thinking/tokens as the AI continues.\n5. **Input request** _(optional)_ — `input_request` when the AI needs structured user input (terminates the response).\n6. **Buttons** _(optional)_ — `{\"type\":\"buttons\",\"buttons\":[...]}` with quick-reply options, sent after all tokens.\n7. **Error** _(optional)_ — `{\"type\":\"error\",\"message\":\"...\"}` if the AI model returns an empty response (context overflow, safety filter) or an unexpected error occurs. Sent before `[DONE]`.\n8. **Done** — `\"[DONE]\"` (always last).\n\nSee the SSE event schemas (SSESessionEvent, SSETokenEvent, SSEThinkingStartEvent, SSEThinkingDeltaEvent, SSEThinkingStopEvent, SSEToolCallEvent, SSEToolResultEvent, SSEInputRequestEvent, SSEButtonsEvent, SSEErrorEvent) in components/schemas for exact payload shapes.\n\nRequires app config to be registered first via PUT /config (or platform config via PUT /platform-config as fallback).",
         "parameters": [
           {
             "schema": {
@@ -747,7 +767,7 @@
         },
         "responses": {
           "200": {
-            "description": "SSE stream of chat events. Each `data:` line is a JSON object matching one of the SSE event schemas (SSESessionEvent, SSETokenEvent, SSEThinkingStartEvent, SSEThinkingDeltaEvent, SSEThinkingStopEvent, SSEToolCallEvent, SSEToolResultEvent, SSEInputRequestEvent, SSEButtonsEvent), except the final `data: \"[DONE]\"` which is a plain string.",
+            "description": "SSE stream of chat events. Each `data:` line is a JSON object matching one of the SSE event schemas (SSESessionEvent, SSETokenEvent, SSEThinkingStartEvent, SSEThinkingDeltaEvent, SSEThinkingStopEvent, SSEToolCallEvent, SSEToolResultEvent, SSEInputRequestEvent, SSEButtonsEvent, SSEErrorEvent), except the final `data: \"[DONE]\"` which is a plain string.",
             "content": {
               "text/event-stream": {
                 "schema": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -288,6 +288,7 @@ app.post("/chat", requireAuth, async (req, res) => {
 
     // Stream response from Gemini
     let fullResponse = "";
+    let emittedInputRequest = false;
     const toolCalls: ToolCallRecord[] = [];
 
     // Line buffer: hold back trailing lines that match button syntax
@@ -376,6 +377,7 @@ app.post("/chat", requireAuth, async (req, res) => {
             ...(args.placeholder ? { placeholder: args.placeholder } : {}),
             field: args.field ?? "input",
           });
+          emittedInputRequest = true;
           break;
         }
 
@@ -484,6 +486,25 @@ app.post("/chat", requireAuth, async (req, res) => {
       sendSSE(res, { type: "buttons", buttons });
     }
 
+    // Detect empty stream: Gemini returned no content (safety filter, context overflow, etc.)
+    if (!fullResponse && !emittedInputRequest && toolCalls.length === 0) {
+      chatFailed = true;
+      console.error(
+        `Empty Gemini response for session="${currentSessionId}" org="${orgId}" — ` +
+          `promptTokens=${totalPromptTokens} outputTokens=${totalOutputTokens} ` +
+          `historyLength=${geminiHistory.length} messageLength=${message.length}`,
+      );
+      sendSSE(res, {
+        type: "error",
+        message:
+          "The AI model returned an empty response. This may happen when the conversation " +
+          "is too long or the message content triggers a safety filter. Please try shortening " +
+          "your message or starting a new conversation.",
+      });
+      sendSSE(res, "[DONE]");
+      return;
+    }
+
     // Save assistant message with cleaned response
     const cleanedResponse =
       buttons.length > 0 ? stripButtons(fullResponse) : fullResponse;
@@ -505,8 +526,8 @@ app.post("/chat", requireAuth, async (req, res) => {
     chatFailed = true;
     console.error("Chat error:", err);
     sendSSE(res, {
-      type: "token",
-      content: "\n\nSorry, something went wrong. Please try again.",
+      type: "error",
+      message: "An unexpected error occurred. Please try again.",
     });
     sendSSE(res, "[DONE]");
   } finally {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -355,6 +355,18 @@ const SSEButtonsEventSchema = z
   })
   .openapi("SSEButtonsEvent");
 
+const SSEErrorEventSchema = z
+  .object({
+    type: z.literal("error"),
+    message: z.string().openapi({
+      description:
+        "Human-readable error message explaining what went wrong",
+      example:
+        "The AI model returned an empty response. This may happen when the conversation is too long or the message content triggers a safety filter.",
+    }),
+  })
+  .openapi("SSEErrorEvent");
+
 // Register all SSE event schemas so they appear in the OpenAPI components
 registry.register("SSESessionEvent", SSESessionEventSchema);
 registry.register("SSETokenEvent", SSETokenEventSchema);
@@ -365,6 +377,7 @@ registry.register("SSEToolCallEvent", SSEToolCallEventSchema);
 registry.register("SSEToolResultEvent", SSEToolResultEventSchema);
 registry.register("SSEInputRequestEvent", SSEInputRequestEventSchema);
 registry.register("SSEButtonsEvent", SSEButtonsEventSchema);
+registry.register("SSEErrorEvent", SSEErrorEventSchema);
 
 registry.registerPath({
   method: "post",
@@ -387,9 +400,10 @@ Each \`data:\` line contains a JSON object. Events arrive in this order:
 4. **Tool calls** _(optional, repeatable)_ — \`tool_call\` followed by \`tool_result\`, then more thinking/tokens as the AI continues.
 5. **Input request** _(optional)_ — \`input_request\` when the AI needs structured user input (terminates the response).
 6. **Buttons** _(optional)_ — \`{"type":"buttons","buttons":[...]}\` with quick-reply options, sent after all tokens.
-7. **Done** — \`"[DONE]"\` (always last).
+7. **Error** _(optional)_ — \`{"type":"error","message":"..."}\` if the AI model returns an empty response (context overflow, safety filter) or an unexpected error occurs. Sent before \`[DONE]\`.
+8. **Done** — \`"[DONE]"\` (always last).
 
-See the SSE event schemas (SSESessionEvent, SSETokenEvent, SSEThinkingStartEvent, SSEThinkingDeltaEvent, SSEThinkingStopEvent, SSEToolCallEvent, SSEToolResultEvent, SSEInputRequestEvent, SSEButtonsEvent) in components/schemas for exact payload shapes.
+See the SSE event schemas (SSESessionEvent, SSETokenEvent, SSEThinkingStartEvent, SSEThinkingDeltaEvent, SSEThinkingStopEvent, SSEToolCallEvent, SSEToolResultEvent, SSEInputRequestEvent, SSEButtonsEvent, SSEErrorEvent) in components/schemas for exact payload shapes.
 
 Requires app config to be registered first via PUT /config (or platform config via PUT /platform-config as fallback).`,
   request: {
@@ -418,7 +432,7 @@ Requires app config to be registered first via PUT /config (or platform config v
       description:
         "SSE stream of chat events. Each `data:` line is a JSON object matching one of the SSE event schemas " +
         "(SSESessionEvent, SSETokenEvent, SSEThinkingStartEvent, SSEThinkingDeltaEvent, SSEThinkingStopEvent, " +
-        'SSEToolCallEvent, SSEToolResultEvent, SSEInputRequestEvent, SSEButtonsEvent), except the final `data: "[DONE]"` which is a plain string.',
+        'SSEToolCallEvent, SSEToolResultEvent, SSEInputRequestEvent, SSEButtonsEvent, SSEErrorEvent), except the final `data: "[DONE]"` which is a plain string.',
       content: {
         "text/event-stream": {
           schema: z.string(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,11 @@ export interface SSEInputRequestEvent {
   field: string;
 }
 
+export interface SSEErrorEvent {
+  type: "error";
+  message: string;
+}
+
 export interface SSESessionEvent {
   sessionId: string;
 }
@@ -64,6 +69,7 @@ export type SSEEvent =
   | SSEToolCallEvent
   | SSEToolResultEvent
   | SSEInputRequestEvent
+  | SSEErrorEvent
   | SSESessionEvent;
 
 export interface GeminiTool {

--- a/tests/unit/openapi.test.ts
+++ b/tests/unit/openapi.test.ts
@@ -76,6 +76,23 @@ describe("openapi.json", () => {
     expect(spec.components?.schemas?.AppConfigResponse).toBeDefined();
   });
 
+  it("includes all SSE event schemas including SSEErrorEvent", () => {
+    const spec = JSON.parse(readFileSync(openapiPath, "utf-8"));
+    const schemas = spec.components?.schemas;
+    expect(schemas?.SSESessionEvent).toBeDefined();
+    expect(schemas?.SSETokenEvent).toBeDefined();
+    expect(schemas?.SSEThinkingStartEvent).toBeDefined();
+    expect(schemas?.SSEThinkingDeltaEvent).toBeDefined();
+    expect(schemas?.SSEThinkingStopEvent).toBeDefined();
+    expect(schemas?.SSEToolCallEvent).toBeDefined();
+    expect(schemas?.SSEToolResultEvent).toBeDefined();
+    expect(schemas?.SSEInputRequestEvent).toBeDefined();
+    expect(schemas?.SSEButtonsEvent).toBeDefined();
+    expect(schemas?.SSEErrorEvent).toBeDefined();
+    expect(schemas?.SSEErrorEvent.properties.type.enum).toEqual(["error"]);
+    expect(schemas?.SSEErrorEvent.properties.message.type).toBe("string");
+  });
+
   it("ChatRequest schema requires only message (appId removed)", () => {
     const spec = JSON.parse(readFileSync(openapiPath, "utf-8"));
     const chatReq = spec.components.schemas.ChatRequest;

--- a/tests/unit/types.test.ts
+++ b/tests/unit/types.test.ts
@@ -9,6 +9,7 @@ import type {
   SSEThinkingStopEvent,
   SSEToolCallEvent,
   SSEToolResultEvent,
+  SSEErrorEvent,
 } from "../../src/types.js";
 
 describe("types", () => {
@@ -104,5 +105,14 @@ describe("types", () => {
     };
     expect(event.id).toBe("tc_abc-123");
     expect(event.name).toBe("search_leads");
+  });
+
+  it("SSEErrorEvent shape", () => {
+    const event: SSEErrorEvent = {
+      type: "error",
+      message: "The AI model returned an empty response.",
+    };
+    expect(event.type).toBe("error");
+    expect(event.message).toBe("The AI model returned an empty response.");
   });
 });


### PR DESCRIPTION
## Summary
- Detects when Gemini returns an empty stream (no tokens, no tool calls, no input_request) and sends `{"type":"error","message":"..."}` instead of silently closing with `[DONE]`
- Replaces the previous fake error-as-token pattern in the catch block with a proper `error` event type
- Adds `SSEErrorEvent` to TypeScript types, OpenAPI schemas, and README
- Logs diagnostic info (session ID, org, token counts, history length) server-side on empty responses

## Context
Dashboard reported that the 3rd message in a conversation (with long pasted email content) returned `sessionId` → `[DONE]` with no content. The Gemini stream was empty (likely context overflow or safety filter) but the service didn't detect or report this.

## Test plan
- [x] All unit tests pass (130/130, including 2 new tests)
- [x] `SSEErrorEvent` schema verified in OpenAPI spec
- [x] `SSEErrorEvent` type shape test added
- [x] Manual verification: empty stream path now emits `error` event before `[DONE]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)