### PR TITLE
feat: input_request value pre-fill + update_workflow tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,12 +152,20 @@ data: {"type":"tool_result","id":"tc_550e8400-e29b-41d4-a716-446655440000","name
 
 After a tool result, more `token` events follow with the AI's continuation.
 
+The service includes a built-in `update_workflow` tool that the AI can invoke to update workflow metadata (name, description, tags) directly via workflow-service, without requiring the user to type it manually.
+
 ### 5. Input Request (optional)
 When the AI needs structured user input (e.g., a URL), it emits an input request instead of asking in plain text:
 ```
 data: {"type":"input_request","input_type":"url","label":"What's your brand URL?","placeholder":"https://yourbrand.com","field":"brand_url"}
 ```
 The frontend should render an appropriate input widget based on `input_type` (`url`, `text`, or `email`). When the user submits, send the value as a regular `/chat` message. The `field` key identifies what the input is for.
+
+An optional `value` field can pre-fill the input when the AI already has a suggested value:
+```
+data: {"type":"input_request","input_type":"text","label":"New description","placeholder":"...","field":"new_description","value":"Automated cold email outreach campaign..."}
+```
+If `value` is present, the frontend should render the input pre-filled so the user can confirm with a single click. If absent, the field starts empty.
 
 ### 6. Buttons (optional)
 AI-generated quick-reply buttons, sent after all tokens are done:
@@ -199,6 +207,8 @@ Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token st
 | `KEY_SERVICE_URL` | No | Key-service endpoint (default: `https://key.mcpfactory.org`) |
 | `RUNS_SERVICE_URL` | No | RunsService endpoint (default: `https://runs.mcpfactory.org`) |
 | `RUNS_SERVICE_API_KEY` | No | API key for RunsService (runs tracking disabled if unset) |
+| `WORKFLOW_SERVICE_URL` | No | Workflow-service endpoint (default: `https://windmill.distribute.org`) |
+| `WORKFLOW_SERVICE_API_KEY` | No | API key for workflow-service (update_workflow tool disabled if unset) |
 | `PORT` | No | Server port (default: `3002`) |
 
 ## Database

--- a/openapi.json
+++ b/openapi.json
@@ -190,6 +190,11 @@
             "type": "string",
             "description": "Identifier for what the input represents",
             "example": "brand_url"
+          },
+          "value": {
+            "type": "string",
+            "description": "Pre-filled value for the input field. When present, the frontend renders the field already populated so the user can confirm with a single click. When absent, the field is empty.",
+            "example": "Automated cold email outreach campaign targeting SaaS founders"
           }
         },
         "required": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,10 @@ import {
   createGeminiClient,
   buildSystemPrompt,
   REQUEST_USER_INPUT_TOOL,
+  UPDATE_WORKFLOW_TOOL,
   type UsageMetadata,
 } from "./lib/gemini.js";
+import { updateWorkflow } from "./lib/workflow-client.js";
 import { connectMcp, type McpConnection } from "./lib/mcp-client.js";
 import { createRun, updateRunStatus, addRunCosts } from "./lib/runs-client.js";
 import { resolveKey, decryptOrgKey, type ResolvedKey } from "./lib/key-client.js";
@@ -337,6 +339,7 @@ app.post("/chat", requireAuth, async (req, res) => {
     const allTools = [
       ...(mcpConn?.tools ?? []),
       REQUEST_USER_INPUT_TOOL,
+      UPDATE_WORKFLOW_TOOL,
     ];
 
     const stream = gemini.streamChat(
@@ -376,9 +379,77 @@ app.post("/chat", requireAuth, async (req, res) => {
             label: args.label ?? "Please provide input",
             ...(args.placeholder ? { placeholder: args.placeholder } : {}),
             field: args.field ?? "input",
+            ...(args.value ? { value: args.value } : {}),
           });
           emittedInputRequest = true;
           break;
+        }
+
+        // Client-side tool: update workflow via workflow-service
+        if (call.name === "update_workflow") {
+          const args = (call.args as Record<string, unknown>) || {};
+          const workflowId = args.workflow_id as string;
+          const toolCallId = `tc_${crypto.randomUUID()}`;
+          sendSSE(res, {
+            type: "tool_call",
+            id: toolCallId,
+            name: call.name,
+            args: call.args,
+          });
+
+          const result = await updateWorkflow(
+            workflowId,
+            {
+              ...(args.name ? { name: args.name as string } : {}),
+              ...(args.description ? { description: args.description as string } : {}),
+              ...(args.tags ? { tags: args.tags as string[] } : {}),
+            },
+            {
+              orgId,
+              userId,
+              runId,
+              trackingHeaders,
+            },
+          );
+
+          toolCalls.push({ name: call.name, args: call.args, result });
+          sendSSE(res, { type: "tool_result", id: toolCallId, name: call.name, result });
+
+          // Send result back to Gemini for continuation
+          const functionCallPart: Record<string, unknown> = {
+            functionCall: { name: call.name, args: call.args || {} },
+          };
+          if (call.thoughtSignature) {
+            functionCallPart.thoughtSignature = call.thoughtSignature;
+          }
+          const updatedHistory: Content[] = [
+            ...geminiHistory,
+            { role: "user", parts: [{ text: message.trim() }] },
+            {
+              role: "model",
+              parts: [functionCallPart as Part],
+            },
+          ];
+
+          const contStream = gemini.sendFunctionResult(
+            updatedHistory,
+            call.name,
+            result,
+            allTools,
+          );
+
+          for await (const contEvent of contStream) {
+            if (contEvent.type === "token") {
+              bufferToken(contEvent.content);
+            }
+            if (contEvent.type === "thinking_start" || contEvent.type === "thinking_delta" || contEvent.type === "thinking_stop") {
+              sendSSE(res, contEvent);
+            }
+            if (contEvent.type === "done") {
+              accumulateUsage(contEvent.usage);
+            }
+          }
+          continue;
         }
 
         if (!mcpConn) continue;

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -32,8 +32,42 @@ export const REQUEST_USER_INPUT_TOOL: FunctionDeclaration = {
         description:
           "A key identifying what this input is for, e.g. brand_url",
       },
+      value: {
+        type: Type.STRING,
+        description:
+          "Optional pre-filled value for the input field. When you already have a suggested value (e.g. a description you generated), set this so the user only has to confirm. Omit to leave the field empty.",
+      },
     },
     required: ["input_type", "label", "field"],
+  },
+};
+
+export const UPDATE_WORKFLOW_TOOL: FunctionDeclaration = {
+  name: "update_workflow",
+  description:
+    "Update an existing workflow's name, description, or tags. Use this to directly modify workflow metadata instead of asking the user to do it manually.",
+  parameters: {
+    type: Type.OBJECT,
+    properties: {
+      workflow_id: {
+        type: Type.STRING,
+        description: "The UUID of the workflow to update",
+      },
+      name: {
+        type: Type.STRING,
+        description: "New name for the workflow (optional)",
+      },
+      description: {
+        type: Type.STRING,
+        description: "New description for the workflow (optional)",
+      },
+      tags: {
+        type: Type.ARRAY,
+        items: { type: Type.STRING },
+        description: "New tags for the workflow (optional)",
+      },
+    },
+    required: ["workflow_id"],
   },
 };
 

--- a/src/lib/workflow-client.ts
+++ b/src/lib/workflow-client.ts
@@ -1,0 +1,64 @@
+const WORKFLOW_SERVICE_URL =
+  process.env.WORKFLOW_SERVICE_URL || "https://windmill.distribute.org";
+const WORKFLOW_SERVICE_API_KEY = process.env.WORKFLOW_SERVICE_API_KEY;
+
+export interface UpdateWorkflowParams {
+  name?: string;
+  description?: string;
+  tags?: string[];
+}
+
+export interface UpdateWorkflowContext {
+  orgId: string;
+  userId: string;
+  runId?: string;
+  trackingHeaders?: Record<string, string>;
+}
+
+export async function updateWorkflow(
+  workflowId: string,
+  params: UpdateWorkflowParams,
+  ctx: UpdateWorkflowContext,
+): Promise<{ success: boolean; data?: unknown; error?: string }> {
+  if (!WORKFLOW_SERVICE_API_KEY) {
+    return { success: false, error: "WORKFLOW_SERVICE_API_KEY not configured" };
+  }
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "X-API-Key": WORKFLOW_SERVICE_API_KEY,
+    "x-org-id": ctx.orgId,
+    "x-user-id": ctx.userId,
+  };
+  if (ctx.runId) headers["x-run-id"] = ctx.runId;
+  if (ctx.trackingHeaders) {
+    for (const [k, v] of Object.entries(ctx.trackingHeaders)) {
+      if (v) headers[k] = v;
+    }
+  }
+
+  try {
+    const res = await fetch(
+      `${WORKFLOW_SERVICE_URL}/workflows/${workflowId}`,
+      {
+        method: "PUT",
+        headers,
+        body: JSON.stringify(params),
+      },
+    );
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      return {
+        success: false,
+        error: `Workflow service returned ${res.status}: ${text}`,
+      };
+    }
+
+    const data = await res.json();
+    return { success: true, data };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { success: false, error: `Workflow service request failed: ${msg}` };
+  }
+}

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -335,6 +335,12 @@ const SSEInputRequestEventSchema = z
       description: "Identifier for what the input represents",
       example: "brand_url",
     }),
+    value: z.string().optional().openapi({
+      description:
+        "Pre-filled value for the input field. When present, the frontend renders the field " +
+        "already populated so the user can confirm with a single click. When absent, the field is empty.",
+      example: "Automated cold email outreach campaign targeting SaaS founders",
+    }),
   })
   .openapi("SSEInputRequestEvent");
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,7 @@ export interface SSEInputRequestEvent {
   label: string;
   placeholder?: string;
   field: string;
+  value?: string;
 }
 
 export interface SSEErrorEvent {

--- a/tests/unit/gemini.test.ts
+++ b/tests/unit/gemini.test.ts
@@ -24,6 +24,7 @@ import {
   createGeminiClient,
   buildSystemPrompt,
   REQUEST_USER_INPUT_TOOL,
+  UPDATE_WORKFLOW_TOOL,
 } from "../../src/lib/gemini.js";
 
 const TEST_PROMPT = "You are a test assistant.";
@@ -504,6 +505,22 @@ describe("REQUEST_USER_INPUT_TOOL", () => {
     expect(props).toHaveProperty("label");
     expect(props).toHaveProperty("field");
     expect(props).toHaveProperty("placeholder");
+    expect(props).toHaveProperty("value");
     expect(params.required).toEqual(["input_type", "label", "field"]);
+  });
+});
+
+describe("UPDATE_WORKFLOW_TOOL", () => {
+  it("has correct name and required parameters", () => {
+    expect(UPDATE_WORKFLOW_TOOL.name).toBe("update_workflow");
+    expect(UPDATE_WORKFLOW_TOOL.parameters).toBeDefined();
+
+    const params = UPDATE_WORKFLOW_TOOL.parameters as Record<string, unknown>;
+    const props = params.properties as Record<string, unknown>;
+    expect(props).toHaveProperty("workflow_id");
+    expect(props).toHaveProperty("name");
+    expect(props).toHaveProperty("description");
+    expect(props).toHaveProperty("tags");
+    expect(params.required).toEqual(["workflow_id"]);
   });
 });

--- a/tests/unit/types.test.ts
+++ b/tests/unit/types.test.ts
@@ -64,6 +64,21 @@ describe("types", () => {
       field: "some_field",
     };
     expect(event.placeholder).toBeUndefined();
+    expect(event.value).toBeUndefined();
+  });
+
+  it("SSEInputRequestEvent with pre-filled value", () => {
+    const event: SSEInputRequestEvent = {
+      type: "input_request",
+      input_type: "text",
+      label: "New description",
+      placeholder: "Enter description...",
+      field: "new_description",
+      value: "Automated cold email outreach campaign",
+    };
+    expect(event.type).toBe("input_request");
+    expect(event.value).toBe("Automated cold email outreach campaign");
+    expect(event.field).toBe("new_description");
   });
 
   it("SSEThinkingStartEvent shape", () => {

--- a/tests/unit/workflow-client.test.ts
+++ b/tests/unit/workflow-client.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Store original env
+const originalEnv = { ...process.env };
+
+describe("updateWorkflow", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.env.WORKFLOW_SERVICE_URL = "https://test-workflow.example.com";
+    process.env.WORKFLOW_SERVICE_API_KEY = "test-api-key";
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  async function loadModule() {
+    return import("../../src/lib/workflow-client.js");
+  }
+
+  it("sends PUT request with correct headers and body", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ id: "wf-123", name: "Updated" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const { updateWorkflow } = await loadModule();
+    const result = await updateWorkflow(
+      "wf-123",
+      { name: "New Name", description: "New desc" },
+      { orgId: "org-1", userId: "user-1", runId: "run-1" },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({ id: "wf-123", name: "Updated" });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://test-workflow.example.com/workflows/wf-123",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ name: "New Name", description: "New desc" }),
+      }),
+    );
+
+    const callHeaders = fetchSpy.mock.calls[0][1]?.headers as Record<string, string>;
+    expect(callHeaders["X-API-Key"]).toBe("test-api-key");
+    expect(callHeaders["x-org-id"]).toBe("org-1");
+    expect(callHeaders["x-user-id"]).toBe("user-1");
+    expect(callHeaders["x-run-id"]).toBe("run-1");
+  });
+
+  it("forwards tracking headers", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({}), { status: 200, headers: { "Content-Type": "application/json" } }),
+    );
+
+    const { updateWorkflow } = await loadModule();
+    await updateWorkflow(
+      "wf-123",
+      { tags: ["email", "outreach"] },
+      {
+        orgId: "org-1",
+        userId: "user-1",
+        trackingHeaders: { "x-campaign-id": "camp-1", "x-brand-id": "brand-1" },
+      },
+    );
+
+    const callHeaders = fetchSpy.mock.calls[0][1]?.headers as Record<string, string>;
+    expect(callHeaders["x-campaign-id"]).toBe("camp-1");
+    expect(callHeaders["x-brand-id"]).toBe("brand-1");
+  });
+
+  it("returns error when API key is not configured", async () => {
+    delete process.env.WORKFLOW_SERVICE_API_KEY;
+
+    const { updateWorkflow } = await loadModule();
+    const result = await updateWorkflow(
+      "wf-123",
+      { name: "test" },
+      { orgId: "org-1", userId: "user-1" },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("WORKFLOW_SERVICE_API_KEY not configured");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns error on non-ok response", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response("Not Found", { status: 404 }),
+    );
+
+    const { updateWorkflow } = await loadModule();
+    const result = await updateWorkflow(
+      "wf-999",
+      { name: "test" },
+      { orgId: "org-1", userId: "user-1" },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("404");
+  });
+
+  it("returns error on network failure", async () => {
+    fetchSpy.mockRejectedValue(new Error("Connection refused"));
+
+    const { updateWorkflow } = await loadModule();
+    const result = await updateWorkflow(
+      "wf-123",
+      { name: "test" },
+      { orgId: "org-1", userId: "user-1" },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Connection refused");
+  });
+});


### PR DESCRIPTION
## Summary
- Add optional `value` field to `SSEInputRequestEvent` schema and `request_user_input` tool — lets the LLM pre-fill input fields with suggested values so users can confirm with one click
- Add built-in `update_workflow` tool that calls `PUT /workflows/{id}` on workflow-service — the LLM can now update workflow name/description/tags directly instead of asking the user to type it manually
- Add `workflow-client.ts` with full error handling for workflow-service HTTP calls

## Test plan
- [x] Unit tests for `value` field on `SSEInputRequestEvent` type (with and without value)
- [x] Unit tests for `REQUEST_USER_INPUT_TOOL` includes `value` property
- [x] Unit tests for `UPDATE_WORKFLOW_TOOL` definition
- [x] Unit tests for `updateWorkflow()` client (success, tracking headers, missing API key, 404, network failure)
- [x] All 136 unit tests pass
- [x] Build + OpenAPI spec regeneration succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)