### PR TITLE
feat: add workflow tools, fix input_request misuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,18 @@ data: {"type":"tool_result","id":"tc_550e8400-e29b-41d4-a716-446655440000","name
 
 After a tool result, more `token` events follow with the AI's continuation.
 
-The service includes a built-in `update_workflow` tool that the AI can invoke to update workflow metadata (name, description, tags) directly via workflow-service, without requiring the user to type it manually.
+**Built-in tools** (always available, no MCP server needed):
+
+| Tool | Description |
+|---|---|
+| `update_workflow` | Updates a workflow's metadata (name, description, tags) via workflow-service `PUT /workflows/{id}` |
+| `validate_workflow` | Validates a workflow's DAG structure via workflow-service `POST /workflows/{id}/validate` |
+| `request_user_input` | Asks the user for structured input (see Input Request below) |
+
+Built-in tools emit `tool_call` and `tool_result` events like MCP tools. The frontend should render them the same way (e.g., collapsible tool call blocks).
 
 ### 5. Input Request (optional)
-When the AI needs structured user input (e.g., a URL), it emits an input request instead of asking in plain text:
+When the AI genuinely needs information it does not have, it emits an input request:
 ```
 data: {"type":"input_request","input_type":"url","label":"What's your brand URL?","placeholder":"https://yourbrand.com","field":"brand_url"}
 ```
@@ -166,6 +174,8 @@ An optional `value` field can pre-fill the input when the AI already has a sugge
 data: {"type":"input_request","input_type":"text","label":"New description","placeholder":"...","field":"new_description","value":"Automated cold email outreach campaign..."}
 ```
 If `value` is present, the frontend should render the input pre-filled so the user can confirm with a single click. If absent, the field starts empty.
+
+**Note:** The AI is instructed to only use `input_request` when it genuinely lacks information. Values already present in the `context` parameter or conversation history are used directly — the AI will not re-ask for them.
 
 ### 6. Buttons (optional)
 AI-generated quick-reply buttons, sent after all tokens are done:
@@ -207,8 +217,8 @@ Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token st
 | `KEY_SERVICE_URL` | No | Key-service endpoint (default: `https://key.mcpfactory.org`) |
 | `RUNS_SERVICE_URL` | No | RunsService endpoint (default: `https://runs.mcpfactory.org`) |
 | `RUNS_SERVICE_API_KEY` | No | API key for RunsService (runs tracking disabled if unset) |
-| `WORKFLOW_SERVICE_URL` | No | Workflow-service endpoint (default: `https://windmill.distribute.org`) |
-| `WORKFLOW_SERVICE_API_KEY` | No | API key for workflow-service (update_workflow tool disabled if unset) |
+| `WORKFLOW_SERVICE_URL` | No | Workflow-service endpoint (default: `https://workflow.mcpfactory.org`) |
+| `WORKFLOW_SERVICE_API_KEY` | No | API key for workflow-service (built-in workflow tools fail if unset) |
 | `PORT` | No | Server port (default: `3002`) |
 
 ## Database
@@ -275,10 +285,11 @@ src/
     index.ts        # Drizzle client init
     schema.ts       # sessions + messages + app_configs + platform_configs table definitions
   lib/
-    gemini.ts       # Gemini AI client, streaming + function calling, buildSystemPrompt helper
-    mcp-client.ts   # MCP server connection via Streamable HTTP transport + tool execution
-    key-client.ts   # Key-service client for resolving Gemini keys (platform or BYOK per org) and org MCP keys
-    runs-client.ts  # RunsService HTTP client for run tracking and cost reporting
+    gemini.ts          # Gemini AI client, streaming + function calling, buildSystemPrompt helper, built-in tool declarations
+    mcp-client.ts      # MCP server connection via Streamable HTTP transport + tool execution
+    key-client.ts      # Key-service client for resolving Gemini keys (platform or BYOK per org) and org MCP keys
+    runs-client.ts     # RunsService HTTP client for run tracking and cost reporting
+    workflow-client.ts # Workflow-service client for update_workflow and validate_workflow built-in tools
 scripts/
   generate-openapi.ts  # Generates openapi.json from zod schemas via OpenApiGeneratorV3
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,11 +10,13 @@ import { eq, and } from "drizzle-orm";
 import {
   createGeminiClient,
   buildSystemPrompt,
-  REQUEST_USER_INPUT_TOOL,
-  UPDATE_WORKFLOW_TOOL,
+  BUILTIN_TOOLS,
   type UsageMetadata,
 } from "./lib/gemini.js";
-import { updateWorkflow } from "./lib/workflow-client.js";
+import {
+  updateWorkflow,
+  validateWorkflow,
+} from "./lib/workflow-client.js";
 import { connectMcp, type McpConnection } from "./lib/mcp-client.js";
 import { createRun, updateRunStatus, addRunCosts } from "./lib/runs-client.js";
 import { resolveKey, decryptOrgKey, type ResolvedKey } from "./lib/key-client.js";
@@ -335,11 +337,10 @@ app.post("/chat", requireAuth, async (req, res) => {
       }
     }
 
-    // Merge MCP tools with local client-side tools
+    // Merge MCP tools with built-in tools
     const allTools = [
       ...(mcpConn?.tools ?? []),
-      REQUEST_USER_INPUT_TOOL,
-      UPDATE_WORKFLOW_TOOL,
+      ...BUILTIN_TOOLS,
     ];
 
     const stream = gemini.streamChat(
@@ -385,10 +386,8 @@ app.post("/chat", requireAuth, async (req, res) => {
           break;
         }
 
-        // Client-side tool: update workflow via workflow-service
-        if (call.name === "update_workflow") {
-          const args = (call.args as Record<string, unknown>) || {};
-          const workflowId = args.workflow_id as string;
+        // Built-in workflow tools: execute directly via workflow-service
+        if (call.name === "update_workflow" || call.name === "validate_workflow") {
           const toolCallId = `tc_${crypto.randomUUID()}`;
           sendSSE(res, {
             type: "tool_call",
@@ -397,57 +396,73 @@ app.post("/chat", requireAuth, async (req, res) => {
             args: call.args,
           });
 
-          const result = await updateWorkflow(
-            workflowId,
-            {
-              ...(args.name ? { name: args.name as string } : {}),
-              ...(args.description ? { description: args.description as string } : {}),
-              ...(args.tags ? { tags: args.tags as string[] } : {}),
-            },
-            {
+          try {
+            const wfParams = {
               orgId,
               userId,
               runId,
-              trackingHeaders,
-            },
-          );
+              trackingHeaders: Object.keys(trackingHeaders).length > 0 ? trackingHeaders as Record<string, string> : undefined,
+            };
+            const args = (call.args as Record<string, unknown>) || {};
+            let result: unknown;
 
-          toolCalls.push({ name: call.name, args: call.args, result });
-          sendSSE(res, { type: "tool_result", id: toolCallId, name: call.name, result });
-
-          // Send result back to Gemini for continuation
-          const functionCallPart: Record<string, unknown> = {
-            functionCall: { name: call.name, args: call.args || {} },
-          };
-          if (call.thoughtSignature) {
-            functionCallPart.thoughtSignature = call.thoughtSignature;
-          }
-          const updatedHistory: Content[] = [
-            ...geminiHistory,
-            { role: "user", parts: [{ text: message.trim() }] },
-            {
-              role: "model",
-              parts: [functionCallPart as Part],
-            },
-          ];
-
-          const contStream = gemini.sendFunctionResult(
-            updatedHistory,
-            call.name,
-            result,
-            allTools,
-          );
-
-          for await (const contEvent of contStream) {
-            if (contEvent.type === "token") {
-              bufferToken(contEvent.content);
+            if (call.name === "update_workflow") {
+              const { workflowId, ...updateBody } = args;
+              result = await updateWorkflow(
+                workflowId as string,
+                updateBody as { name?: string; description?: string; tags?: string[] },
+                wfParams,
+              );
+            } else {
+              result = await validateWorkflow(
+                args.workflowId as string,
+                wfParams,
+              );
             }
-            if (contEvent.type === "thinking_start" || contEvent.type === "thinking_delta" || contEvent.type === "thinking_stop") {
-              sendSSE(res, contEvent);
+
+            toolCalls.push({ name: call.name, args, result });
+            sendSSE(res, { type: "tool_result", id: toolCallId, name: call.name, result });
+
+            // Continue conversation with tool result
+            const functionCallPart: Record<string, unknown> = {
+              functionCall: { name: call.name, args: call.args || {} },
+            };
+            if (call.thoughtSignature) {
+              functionCallPart.thoughtSignature = call.thoughtSignature;
             }
-            if (contEvent.type === "done") {
-              accumulateUsage(contEvent.usage);
+            const updatedHistory: Content[] = [
+              ...geminiHistory,
+              { role: "user", parts: [{ text: message.trim() }] },
+              {
+                role: "model",
+                parts: [functionCallPart as Part],
+              },
+            ];
+
+            const contStream = gemini.sendFunctionResult(
+              updatedHistory,
+              call.name,
+              result,
+              allTools,
+            );
+
+            for await (const contEvent of contStream) {
+              if (contEvent.type === "token") {
+                bufferToken(contEvent.content);
+              }
+              if (contEvent.type === "thinking_start" || contEvent.type === "thinking_delta" || contEvent.type === "thinking_stop") {
+                sendSSE(res, contEvent);
+              }
+              if (contEvent.type === "done") {
+                accumulateUsage(contEvent.usage);
+              }
             }
+          } catch (toolErr: unknown) {
+            const errMsg = toolErr instanceof Error ? toolErr.message : String(toolErr);
+            console.error(`Built-in tool ${call.name} failed:`, errMsg);
+            const errorContent = ` (Tool call failed: ${errMsg})`;
+            fullResponse += errorContent;
+            sendSSE(res, { type: "tool_result", id: toolCallId, name: call.name, result: { error: errMsg } });
           }
           continue;
         }

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -11,7 +11,7 @@ import {
 export const REQUEST_USER_INPUT_TOOL: FunctionDeclaration = {
   name: "request_user_input",
   description:
-    "Ask the user for structured input via a frontend widget. Use this instead of asking in plain text when you need a specific data type like a URL, email, or text field.",
+    "Ask the user for structured input via a frontend widget. ONLY use this when you genuinely need information that you do not already have — check your context and conversation history first. NEVER use this for confirmations, yes/no questions, or to echo back values the user already provided. If the user confirms an action (e.g. says 'yes' or 'go ahead'), execute the action directly using the appropriate tool instead of sending another form.",
   parameters: {
     type: Type.OBJECT,
     properties: {
@@ -45,21 +45,22 @@ export const REQUEST_USER_INPUT_TOOL: FunctionDeclaration = {
 export const UPDATE_WORKFLOW_TOOL: FunctionDeclaration = {
   name: "update_workflow",
   description:
-    "Update an existing workflow's name, description, or tags. Use this to directly modify workflow metadata instead of asking the user to do it manually.",
+    "Update a workflow's metadata (name, description, tags). Use this to directly modify a workflow when the user asks — do not use input_request to confirm values you already know.",
   parameters: {
     type: Type.OBJECT,
     properties: {
-      workflow_id: {
+      workflowId: {
         type: Type.STRING,
-        description: "The UUID of the workflow to update",
+        description:
+          "UUID of the workflow to update. If available in context, use it directly — do NOT ask the user for it.",
       },
       name: {
         type: Type.STRING,
-        description: "New name for the workflow (optional)",
+        description: "New workflow name (optional)",
       },
       description: {
         type: Type.STRING,
-        description: "New description for the workflow (optional)",
+        description: "New workflow description (optional)",
       },
       tags: {
         type: Type.ARRAY,
@@ -67,9 +68,32 @@ export const UPDATE_WORKFLOW_TOOL: FunctionDeclaration = {
         description: "New tags for the workflow (optional)",
       },
     },
-    required: ["workflow_id"],
+    required: ["workflowId"],
   },
 };
+
+export const VALIDATE_WORKFLOW_TOOL: FunctionDeclaration = {
+  name: "validate_workflow",
+  description:
+    "Validate a workflow's DAG structure. Returns whether the workflow is valid and any errors found. Use this when the user asks to check or validate a workflow.",
+  parameters: {
+    type: Type.OBJECT,
+    properties: {
+      workflowId: {
+        type: Type.STRING,
+        description:
+          "UUID of the workflow to validate. If available in context, use it directly — do NOT ask the user for it.",
+      },
+    },
+    required: ["workflowId"],
+  },
+};
+
+export const BUILTIN_TOOLS: FunctionDeclaration[] = [
+  REQUEST_USER_INPUT_TOOL,
+  UPDATE_WORKFLOW_TOOL,
+  VALIDATE_WORKFLOW_TOOL,
+];
 
 export interface FunctionCall {
   name: string;
@@ -102,7 +126,19 @@ export function buildSystemPrompt(
   context?: Record<string, unknown>,
 ): string {
   if (!context || Object.keys(context).length === 0) return basePrompt;
-  return `${basePrompt}\n\n---\n## Additional Context (this request only)\n${JSON.stringify(context, null, 2)}`;
+
+  const contextKeys = Object.keys(context);
+  const contextInstructions = [
+    `\n\n---\n## Additional Context (this request only)`,
+    JSON.stringify(context, null, 2),
+    `\n## IMPORTANT: Context Usage Rules`,
+    `The values above (${contextKeys.join(", ")}) are already known — use them directly when calling tools.`,
+    `Do NOT call request_user_input to ask for any value that is already present in this context.`,
+    `For example, if workflowId is in context and you need to update or validate the workflow, pass it directly to the tool.`,
+    `Only use request_user_input when you genuinely need information that is NOT available in context or conversation history.`,
+  ].join("\n");
+
+  return `${basePrompt}${contextInstructions}`;
 }
 
 export function createGeminiClient({

--- a/src/lib/workflow-client.ts
+++ b/src/lib/workflow-client.ts
@@ -1,64 +1,80 @@
 const WORKFLOW_SERVICE_URL =
-  process.env.WORKFLOW_SERVICE_URL || "https://windmill.distribute.org";
+  process.env.WORKFLOW_SERVICE_URL || "https://workflow.mcpfactory.org";
 const WORKFLOW_SERVICE_API_KEY = process.env.WORKFLOW_SERVICE_API_KEY;
 
-export interface UpdateWorkflowParams {
-  name?: string;
-  description?: string;
-  tags?: string[];
-}
-
-export interface UpdateWorkflowContext {
+export interface WorkflowCallParams {
   orgId: string;
   userId: string;
   runId?: string;
   trackingHeaders?: Record<string, string>;
 }
 
-export async function updateWorkflow(
-  workflowId: string,
-  params: UpdateWorkflowParams,
-  ctx: UpdateWorkflowContext,
-): Promise<{ success: boolean; data?: unknown; error?: string }> {
+function buildHeaders(params: WorkflowCallParams): Record<string, string> {
   if (!WORKFLOW_SERVICE_API_KEY) {
-    return { success: false, error: "WORKFLOW_SERVICE_API_KEY not configured" };
+    throw new Error(
+      "[workflow-client] WORKFLOW_SERVICE_API_KEY is required",
+    );
   }
 
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
-    "X-API-Key": WORKFLOW_SERVICE_API_KEY,
-    "x-org-id": ctx.orgId,
-    "x-user-id": ctx.userId,
+    "x-api-key": WORKFLOW_SERVICE_API_KEY,
+    "x-org-id": params.orgId,
+    "x-user-id": params.userId,
   };
-  if (ctx.runId) headers["x-run-id"] = ctx.runId;
-  if (ctx.trackingHeaders) {
-    for (const [k, v] of Object.entries(ctx.trackingHeaders)) {
+  if (params.runId) headers["x-run-id"] = params.runId;
+  if (params.trackingHeaders) {
+    for (const [k, v] of Object.entries(params.trackingHeaders)) {
       if (v) headers[k] = v;
     }
   }
+  return headers;
+}
 
-  try {
-    const res = await fetch(
-      `${WORKFLOW_SERVICE_URL}/workflows/${workflowId}`,
-      {
-        method: "PUT",
-        headers,
-        body: JSON.stringify(params),
-      },
+export interface UpdateWorkflowBody {
+  name?: string;
+  description?: string;
+  tags?: string[];
+}
+
+export async function updateWorkflow(
+  workflowId: string,
+  body: UpdateWorkflowBody,
+  params: WorkflowCallParams,
+): Promise<unknown> {
+  const url = `${WORKFLOW_SERVICE_URL}/workflows/${encodeURIComponent(workflowId)}`;
+  const res = await fetch(url, {
+    method: "PUT",
+    headers: buildHeaders(params),
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `[workflow-client] PUT /workflows/${workflowId} returned ${res.status}: ${text}`,
     );
-
-    if (!res.ok) {
-      const text = await res.text().catch(() => "");
-      return {
-        success: false,
-        error: `Workflow service returned ${res.status}: ${text}`,
-      };
-    }
-
-    const data = await res.json();
-    return { success: true, data };
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    return { success: false, error: `Workflow service request failed: ${msg}` };
   }
+
+  return await res.json();
+}
+
+export async function validateWorkflow(
+  workflowId: string,
+  params: WorkflowCallParams,
+): Promise<unknown> {
+  const url = `${WORKFLOW_SERVICE_URL}/workflows/${encodeURIComponent(workflowId)}/validate`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: buildHeaders(params),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `[workflow-client] POST /workflows/${workflowId}/validate returned ${res.status}: ${text}`,
+    );
+  }
+
+  return await res.json();
 }

--- a/tests/unit/gemini.test.ts
+++ b/tests/unit/gemini.test.ts
@@ -25,6 +25,8 @@ import {
   buildSystemPrompt,
   REQUEST_USER_INPUT_TOOL,
   UPDATE_WORKFLOW_TOOL,
+  VALIDATE_WORKFLOW_TOOL,
+  BUILTIN_TOOLS,
 } from "../../src/lib/gemini.js";
 
 const TEST_PROMPT = "You are a test assistant.";
@@ -489,6 +491,25 @@ describe("buildSystemPrompt", () => {
     expect(result).toContain("## Additional Context (this request only)");
     expect(result).toContain("https://example.com");
   });
+
+  it("includes context usage rules that reference the context keys", () => {
+    const result = buildSystemPrompt("Base prompt.", {
+      workflowId: "wf-123",
+      brandUrl: "https://example.com",
+    });
+    expect(result).toContain("## IMPORTANT: Context Usage Rules");
+    expect(result).toContain("workflowId, brandUrl");
+    expect(result).toContain("Do NOT call request_user_input");
+  });
+
+  it("instructs LLM to use workflowId directly from context", () => {
+    const result = buildSystemPrompt("Base prompt.", {
+      workflowId: "wf-abc-123",
+    });
+    expect(result).toContain("wf-abc-123");
+    expect(result).toContain("workflowId");
+    expect(result).toContain("use them directly when calling tools");
+  });
 });
 
 describe("REQUEST_USER_INPUT_TOOL", () => {
@@ -508,19 +529,54 @@ describe("REQUEST_USER_INPUT_TOOL", () => {
     expect(props).toHaveProperty("value");
     expect(params.required).toEqual(["input_type", "label", "field"]);
   });
+
+  it("description warns against using for confirmations", () => {
+    expect(REQUEST_USER_INPUT_TOOL.description).toContain(
+      "NEVER use this for confirmations",
+    );
+    expect(REQUEST_USER_INPUT_TOOL.description).toContain(
+      "genuinely need information",
+    );
+  });
 });
 
 describe("UPDATE_WORKFLOW_TOOL", () => {
-  it("has correct name and required parameters", () => {
+  it("has correct name and required workflowId parameter", () => {
     expect(UPDATE_WORKFLOW_TOOL.name).toBe("update_workflow");
     expect(UPDATE_WORKFLOW_TOOL.parameters).toBeDefined();
 
     const params = UPDATE_WORKFLOW_TOOL.parameters as Record<string, unknown>;
     const props = params.properties as Record<string, unknown>;
-    expect(props).toHaveProperty("workflow_id");
+    expect(props).toHaveProperty("workflowId");
     expect(props).toHaveProperty("name");
     expect(props).toHaveProperty("description");
     expect(props).toHaveProperty("tags");
-    expect(params.required).toEqual(["workflow_id"]);
+    expect(params.required).toEqual(["workflowId"]);
+  });
+
+  it("description instructs to use context workflowId directly", () => {
+    expect(UPDATE_WORKFLOW_TOOL.description).toContain(
+      "do not use input_request",
+    );
+  });
+});
+
+describe("VALIDATE_WORKFLOW_TOOL", () => {
+  it("has correct name and required workflowId parameter", () => {
+    expect(VALIDATE_WORKFLOW_TOOL.name).toBe("validate_workflow");
+    const params = VALIDATE_WORKFLOW_TOOL.parameters as Record<string, unknown>;
+    const props = params.properties as Record<string, unknown>;
+    expect(props).toHaveProperty("workflowId");
+    expect(params.required).toEqual(["workflowId"]);
+  });
+});
+
+describe("BUILTIN_TOOLS", () => {
+  it("includes all three built-in tools", () => {
+    const names = BUILTIN_TOOLS.map((t) => t.name);
+    expect(names).toContain("request_user_input");
+    expect(names).toContain("update_workflow");
+    expect(names).toContain("validate_workflow");
+    expect(BUILTIN_TOOLS).toHaveLength(3);
   });
 });

--- a/tests/unit/workflow-client.test.ts
+++ b/tests/unit/workflow-client.test.ts
@@ -1,123 +1,155 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-// Store original env
 const originalEnv = { ...process.env };
 
+beforeEach(() => {
+  process.env.WORKFLOW_SERVICE_API_KEY = "test-wf-key";
+  process.env.WORKFLOW_SERVICE_URL = "https://workflow.test.local";
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.restoreAllMocks();
+});
+
+async function loadModule() {
+  vi.resetModules();
+  return import("../../src/lib/workflow-client.js");
+}
+
 describe("updateWorkflow", () => {
-  let fetchSpy: ReturnType<typeof vi.spyOn>;
-
-  beforeEach(() => {
-    process.env.WORKFLOW_SERVICE_URL = "https://test-workflow.example.com";
-    process.env.WORKFLOW_SERVICE_API_KEY = "test-api-key";
-    fetchSpy = vi.spyOn(globalThis, "fetch");
-  });
-
-  afterEach(() => {
-    process.env = { ...originalEnv };
-    vi.restoreAllMocks();
-    vi.resetModules();
-  });
-
-  async function loadModule() {
-    return import("../../src/lib/workflow-client.js");
-  }
-
-  it("sends PUT request with correct headers and body", async () => {
-    fetchSpy.mockResolvedValue(
-      new Response(JSON.stringify({ id: "wf-123", name: "Updated" }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      }),
-    );
+  it("sends PUT with correct URL, headers, and body", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: "wf-123", description: "Updated" }),
+    });
 
     const { updateWorkflow } = await loadModule();
     const result = await updateWorkflow(
       "wf-123",
-      { name: "New Name", description: "New desc" },
+      { description: "Updated description" },
       { orgId: "org-1", userId: "user-1", runId: "run-1" },
     );
 
-    expect(result.success).toBe(true);
-    expect(result.data).toEqual({ id: "wf-123", name: "Updated" });
-
-    expect(fetchSpy).toHaveBeenCalledWith(
-      "https://test-workflow.example.com/workflows/wf-123",
+    expect(fetch).toHaveBeenCalledWith(
+      "https://workflow.test.local/workflows/wf-123",
       expect.objectContaining({
         method: "PUT",
-        body: JSON.stringify({ name: "New Name", description: "New desc" }),
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          "x-api-key": "test-wf-key",
+          "x-org-id": "org-1",
+          "x-user-id": "user-1",
+          "x-run-id": "run-1",
+        }),
+        body: JSON.stringify({ description: "Updated description" }),
       }),
     );
-
-    const callHeaders = fetchSpy.mock.calls[0][1]?.headers as Record<string, string>;
-    expect(callHeaders["X-API-Key"]).toBe("test-api-key");
-    expect(callHeaders["x-org-id"]).toBe("org-1");
-    expect(callHeaders["x-user-id"]).toBe("user-1");
-    expect(callHeaders["x-run-id"]).toBe("run-1");
+    expect(result).toEqual({ id: "wf-123", description: "Updated" });
   });
 
   it("forwards tracking headers", async () => {
-    fetchSpy.mockResolvedValue(
-      new Response(JSON.stringify({}), { status: 200, headers: { "Content-Type": "application/json" } }),
-    );
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: "wf-123" }),
+    });
 
     const { updateWorkflow } = await loadModule();
     await updateWorkflow(
       "wf-123",
-      { tags: ["email", "outreach"] },
+      { name: "new-name" },
       {
         orgId: "org-1",
         userId: "user-1",
-        trackingHeaders: { "x-campaign-id": "camp-1", "x-brand-id": "brand-1" },
+        trackingHeaders: { "x-campaign-id": "camp-1" },
       },
     );
 
-    const callHeaders = fetchSpy.mock.calls[0][1]?.headers as Record<string, string>;
+    const callHeaders = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].headers;
     expect(callHeaders["x-campaign-id"]).toBe("camp-1");
-    expect(callHeaders["x-brand-id"]).toBe("brand-1");
   });
 
-  it("returns error when API key is not configured", async () => {
+  it("throws on HTTP error", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve("Not found"),
+    });
+
+    const { updateWorkflow } = await loadModule();
+    await expect(
+      updateWorkflow("wf-bad", { description: "x" }, { orgId: "o", userId: "u" }),
+    ).rejects.toThrow(/returned 404/);
+  });
+
+  it("throws when WORKFLOW_SERVICE_API_KEY is not set", async () => {
     delete process.env.WORKFLOW_SERVICE_API_KEY;
 
     const { updateWorkflow } = await loadModule();
-    const result = await updateWorkflow(
-      "wf-123",
-      { name: "test" },
-      { orgId: "org-1", userId: "user-1" },
-    );
+    await expect(
+      updateWorkflow("wf-1", { description: "x" }, { orgId: "o", userId: "u" }),
+    ).rejects.toThrow(/WORKFLOW_SERVICE_API_KEY is required/);
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain("WORKFLOW_SERVICE_API_KEY not configured");
-    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("validateWorkflow", () => {
+  it("sends POST with correct URL and headers", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ valid: true, errors: [] }),
+    });
+
+    const { validateWorkflow } = await loadModule();
+    const result = await validateWorkflow("wf-456", {
+      orgId: "org-1",
+      userId: "user-1",
+      runId: "run-1",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://workflow.test.local/workflows/wf-456/validate",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "x-api-key": "test-wf-key",
+          "x-org-id": "org-1",
+          "x-user-id": "user-1",
+          "x-run-id": "run-1",
+        }),
+      }),
+    );
+    expect(result).toEqual({ valid: true, errors: [] });
   });
 
-  it("returns error on non-ok response", async () => {
-    fetchSpy.mockResolvedValue(
-      new Response("Not Found", { status: 404 }),
-    );
+  it("throws on HTTP error", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("Internal error"),
+    });
 
-    const { updateWorkflow } = await loadModule();
-    const result = await updateWorkflow(
-      "wf-999",
-      { name: "test" },
-      { orgId: "org-1", userId: "user-1" },
-    );
-
-    expect(result.success).toBe(false);
-    expect(result.error).toContain("404");
+    const { validateWorkflow } = await loadModule();
+    await expect(
+      validateWorkflow("wf-bad", { orgId: "o", userId: "u" }),
+    ).rejects.toThrow(/returned 500/);
   });
 
-  it("returns error on network failure", async () => {
-    fetchSpy.mockRejectedValue(new Error("Connection refused"));
+  it("uses default WORKFLOW_SERVICE_URL when not set", async () => {
+    delete process.env.WORKFLOW_SERVICE_URL;
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ valid: true }),
+    });
 
-    const { updateWorkflow } = await loadModule();
-    const result = await updateWorkflow(
-      "wf-123",
-      { name: "test" },
-      { orgId: "org-1", userId: "user-1" },
+    const { validateWorkflow } = await loadModule();
+    await validateWorkflow("wf-1", { orgId: "o", userId: "u" });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://workflow.mcpfactory.org/workflows/wf-1/validate",
+      expect.anything(),
     );
-
-    expect(result.success).toBe(false);
-    expect(result.error).toContain("Connection refused");
   });
 });


### PR DESCRIPTION
## Summary
- **Built-in workflow tools**: Adds `update_workflow` and `validate_workflow` as built-in tools that call workflow-service directly (`PUT /workflows/{id}` and `POST /workflows/{id}/validate`). The LLM can now act on workflows instead of asking the user to do it via forms.
- **Context-aware system prompt**: `buildSystemPrompt` now appends explicit instructions telling the LLM to use context values (like `workflowId`) directly when calling tools, instead of re-asking via `request_user_input`.
- **Restricted input_request**: Updated `request_user_input` tool description to prohibit using it for confirmations, yes/no questions, or values already in context. Reserved for genuinely missing information only.

## Test plan
- [x] New `workflow-client.test.ts` — 7 tests covering `updateWorkflow` and `validateWorkflow` (headers, error handling, env vars)
- [x] Updated `gemini.test.ts` — tests for new tool declarations (`UPDATE_WORKFLOW_TOOL`, `VALIDATE_WORKFLOW_TOOL`, `BUILTIN_TOOLS`), updated `buildSystemPrompt` context rules, and `request_user_input` description changes
- [x] All 143 unit tests pass
- [ ] Verify `WORKFLOW_SERVICE_URL` and `WORKFLOW_SERVICE_API_KEY` env vars are set in Railway before deploying

🤖 Generated with [Claude Code](https://claude.com/claude-code)