### PR TITLE
fix: send required headers to workflow-service

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -407,7 +407,7 @@ app.post("/chat", requireAuth, async (req, res) => {
             {
               orgId,
               userId,
-              runId,
+              runId: runId ?? callerRunId,
               trackingHeaders,
             },
           );

--- a/src/lib/workflow-client.ts
+++ b/src/lib/workflow-client.ts
@@ -11,7 +11,7 @@ export interface UpdateWorkflowParams {
 export interface UpdateWorkflowContext {
   orgId: string;
   userId: string;
-  runId?: string;
+  runId: string;
   trackingHeaders?: Record<string, string>;
 }
 
@@ -26,11 +26,11 @@ export async function updateWorkflow(
 
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
-    "X-API-Key": WORKFLOW_SERVICE_API_KEY,
+    "x-api-key": WORKFLOW_SERVICE_API_KEY,
     "x-org-id": ctx.orgId,
     "x-user-id": ctx.userId,
+    "x-run-id": ctx.runId,
   };
-  if (ctx.runId) headers["x-run-id"] = ctx.runId;
   if (ctx.trackingHeaders) {
     for (const [k, v] of Object.entries(ctx.trackingHeaders)) {
       if (v) headers[k] = v;

--- a/tests/unit/workflow-client.test.ts
+++ b/tests/unit/workflow-client.test.ts
@@ -49,7 +49,7 @@ describe("updateWorkflow", () => {
     );
 
     const callHeaders = fetchSpy.mock.calls[0][1]?.headers as Record<string, string>;
-    expect(callHeaders["X-API-Key"]).toBe("test-api-key");
+    expect(callHeaders["x-api-key"]).toBe("test-api-key");
     expect(callHeaders["x-org-id"]).toBe("org-1");
     expect(callHeaders["x-user-id"]).toBe("user-1");
     expect(callHeaders["x-run-id"]).toBe("run-1");
@@ -67,6 +67,7 @@ describe("updateWorkflow", () => {
       {
         orgId: "org-1",
         userId: "user-1",
+        runId: "run-1",
         trackingHeaders: { "x-campaign-id": "camp-1", "x-brand-id": "brand-1" },
       },
     );
@@ -83,7 +84,7 @@ describe("updateWorkflow", () => {
     const result = await updateWorkflow(
       "wf-123",
       { name: "test" },
-      { orgId: "org-1", userId: "user-1" },
+      { orgId: "org-1", userId: "user-1", runId: "run-1" },
     );
 
     expect(result.success).toBe(false);
@@ -100,11 +101,30 @@ describe("updateWorkflow", () => {
     const result = await updateWorkflow(
       "wf-999",
       { name: "test" },
-      { orgId: "org-1", userId: "user-1" },
+      { orgId: "org-1", userId: "user-1", runId: "run-1" },
     );
 
     expect(result.success).toBe(false);
     expect(result.error).toContain("404");
+  });
+
+  it("always sends x-run-id header (regression: workflow-service 400)", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({}), { status: 200, headers: { "Content-Type": "application/json" } }),
+    );
+
+    const { updateWorkflow } = await loadModule();
+    await updateWorkflow(
+      "wf-123",
+      { name: "test" },
+      { orgId: "org-1", userId: "user-1", runId: "run-1" },
+    );
+
+    const callHeaders = fetchSpy.mock.calls[0][1]?.headers as Record<string, string>;
+    expect(callHeaders["x-run-id"]).toBe("run-1");
+    expect(callHeaders["x-org-id"]).toBe("org-1");
+    expect(callHeaders["x-user-id"]).toBe("user-1");
+    expect(callHeaders["x-api-key"]).toBe("test-api-key");
   });
 
   it("returns error on network failure", async () => {
@@ -114,7 +134,7 @@ describe("updateWorkflow", () => {
     const result = await updateWorkflow(
       "wf-123",
       { name: "test" },
-      { orgId: "org-1", userId: "user-1" },
+      { orgId: "org-1", userId: "user-1", runId: "run-1" },
     );
 
     expect(result.success).toBe(false);


### PR DESCRIPTION
## Summary
- **Bug**: The `update_workflow` built-in tool was failing with 400 from workflow-service because `x-run-id` was conditionally set (omitted when `createRun` hadn't completed) and `x-api-key` used wrong casing (`X-API-Key`)
- **Fix**: Made `x-run-id` always required in `UpdateWorkflowContext`, falling back to the caller's run ID. Normalized API key header to lowercase `x-api-key` to match workflow-service's OpenAPI spec
- Added regression test verifying all required headers are always sent

## Test plan
- [x] Regression test: `always sends x-run-id header (regression: workflow-service 400)`
- [x] All existing workflow-client tests updated and passing
- [x] Full test suite green (138 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)