### PR TITLE
fix: support chained tool calls with incremental Gemini history

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -354,211 +354,197 @@ app.post("/chat", requireAuth, async (req, res) => {
       ...BUILTIN_TOOLS,
     ];
 
-    const stream = gemini.streamChat(
-      geminiHistory,
-      message.trim(),
-      allTools,
-    );
-
     function accumulateUsage(usage?: UsageMetadata) {
       if (!usage) return;
       totalPromptTokens += usage.promptTokens;
       totalOutputTokens += usage.outputTokens;
     }
 
-    for await (const event of stream) {
-      if (event.type === "token") {
-        bufferToken(event.content);
+    // Track turn history incrementally so chained tool calls include prior calls/results
+    const turnParts: Content[] = [];
+
+    /**
+     * Execute a server-side tool (built-in or MCP) and return the result.
+     * Returns null if the tool is client-side (request_user_input) or unhandled.
+     */
+    async function executeTool(
+      call: { name: string; args: Record<string, unknown>; thoughtSignature?: string },
+    ): Promise<{ name: string; result: unknown } | "input_request" | null> {
+      // Client-side tool: emit input_request and signal to stop
+      if (call.name === "request_user_input") {
+        const args = (call.args as Record<string, unknown>) || {};
+        sendSSE(res, {
+          type: "input_request",
+          input_type: args.input_type ?? "text",
+          label: args.label ?? "Please provide input",
+          ...(args.placeholder ? { placeholder: args.placeholder } : {}),
+          field: args.field ?? "input",
+          ...(args.value ? { value: args.value } : {}),
+        });
+        emittedInputRequest = true;
+        return "input_request";
       }
 
-      if (event.type === "thinking_start" || event.type === "thinking_delta" || event.type === "thinking_stop") {
-        sendSSE(res, event);
-      }
+      // Built-in workflow tools
+      if (call.name === "update_workflow" || call.name === "validate_workflow") {
+        const wfParams = {
+          orgId,
+          userId,
+          runId: runId!,
+          trackingHeaders: Object.keys(trackingHeaders).length > 0 ? trackingHeaders as Record<string, string> : undefined,
+        };
+        const args = (call.args as Record<string, unknown>) || {};
+        let result: unknown;
 
-      if (event.type === "done") {
-        accumulateUsage(event.usage);
-      }
-
-      if (event.type === "function_call") {
-        const { call } = event;
-
-        // Client-side tool: emit input_request and end stream
-        if (call.name === "request_user_input") {
-          const args = (call.args as Record<string, unknown>) || {};
-          sendSSE(res, {
-            type: "input_request",
-            input_type: args.input_type ?? "text",
-            label: args.label ?? "Please provide input",
-            ...(args.placeholder ? { placeholder: args.placeholder } : {}),
-            field: args.field ?? "input",
-            ...(args.value ? { value: args.value } : {}),
-          });
-          emittedInputRequest = true;
-          break;
+        if (call.name === "update_workflow") {
+          const { workflowId, ...updateBody } = args;
+          result = await updateWorkflow(
+            workflowId as string,
+            updateBody as { name?: string; description?: string; tags?: string[] },
+            wfParams,
+          );
+        } else {
+          result = await validateWorkflow(
+            args.workflowId as string,
+            wfParams,
+          );
         }
 
-        // Built-in workflow tools: execute directly via workflow-service
-        if (call.name === "update_workflow" || call.name === "validate_workflow") {
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
+      // MCP tools
+      if (mcpConn) {
+        const result = await mcpConn.callTool(
+          call.name,
+          (call.args as Record<string, unknown>) || {},
+        );
+        toolCalls.push({
+          name: call.name,
+          args: (call.args as Record<string, unknown>) || {},
+          result,
+        });
+        return { name: call.name, result };
+      }
+
+      return null;
+    }
+
+    /**
+     * Process a Gemini stream, handling tokens, thinking events, and tool calls.
+     * When a tool call is encountered, executes it, appends both the call and result
+     * to turnParts, sends a continuation to Gemini, and recursively processes the
+     * continuation stream. This ensures chained tool calls work correctly and each
+     * continuation sees the full history of prior calls in the same turn.
+     */
+    async function processStream(
+      stream: AsyncGenerator<import("./lib/gemini.js").GeminiEvent>,
+      depth = 0,
+    ): Promise<void> {
+      const MAX_TOOL_CHAIN_DEPTH = 10;
+
+      for await (const event of stream) {
+        if (event.type === "token") {
+          bufferToken(event.content);
+        }
+
+        if (event.type === "thinking_start" || event.type === "thinking_delta" || event.type === "thinking_stop") {
+          sendSSE(res, event);
+        }
+
+        if (event.type === "done") {
+          accumulateUsage(event.usage);
+        }
+
+        if (event.type === "function_call") {
+          const { call } = event;
+
           const toolCallId = `tc_${crypto.randomUUID()}`;
-          sendSSE(res, {
-            type: "tool_call",
-            id: toolCallId,
-            name: call.name,
-            args: call.args,
-          });
+          if (call.name !== "request_user_input") {
+            sendSSE(res, {
+              type: "tool_call",
+              id: toolCallId,
+              name: call.name,
+              args: call.args,
+            });
+          }
 
           try {
-            const wfParams = {
-              orgId,
-              userId,
-              runId,
-              trackingHeaders: Object.keys(trackingHeaders).length > 0 ? trackingHeaders as Record<string, string> : undefined,
-            };
-            const args = (call.args as Record<string, unknown>) || {};
-            let result: unknown;
+            const toolResult = await executeTool(call);
 
-            if (call.name === "update_workflow") {
-              const { workflowId, ...updateBody } = args;
-              result = await updateWorkflow(
-                workflowId as string,
-                updateBody as { name?: string; description?: string; tags?: string[] },
-                wfParams,
-              );
-            } else {
-              result = await validateWorkflow(
-                args.workflowId as string,
-                wfParams,
-              );
+            if (toolResult === "input_request") {
+              return; // Stop processing — client needs input
             }
 
-            toolCalls.push({ name: call.name, args, result });
-            sendSSE(res, { type: "tool_result", id: toolCallId, name: call.name, result });
+            if (toolResult === null) {
+              continue; // Unhandled tool, skip
+            }
 
-            // Continue conversation with tool result
+            sendSSE(res, { type: "tool_result", id: toolCallId, name: call.name, result: toolResult.result });
+
+            if (depth >= MAX_TOOL_CHAIN_DEPTH) {
+              console.warn(`Tool chain depth limit reached (${MAX_TOOL_CHAIN_DEPTH}), stopping`);
+              continue;
+            }
+
+            // Build the functionCall part with thoughtSignature for Gemini history
             const functionCallPart: Record<string, unknown> = {
               functionCall: { name: call.name, args: call.args || {} },
             };
             if (call.thoughtSignature) {
               functionCallPart.thoughtSignature = call.thoughtSignature;
             }
-            const updatedHistory: Content[] = [
-              ...geminiHistory,
-              { role: "user", parts: [{ text: message.trim() }] },
-              {
-                role: "model",
-                parts: [functionCallPart as Part],
-              },
-            ];
 
+            // Append the function call to turn history (sendFunctionResult adds the response)
+            turnParts.push({
+              role: "model",
+              parts: [functionCallPart as Part],
+            });
+
+            // Send continuation with full incremental history
             const contStream = gemini.sendFunctionResult(
-              updatedHistory,
+              [...geminiHistory, { role: "user", parts: [{ text: message.trim() }] }, ...turnParts],
               call.name,
-              result,
+              toolResult.result,
               allTools,
             );
 
-            for await (const contEvent of contStream) {
-              if (contEvent.type === "token") {
-                bufferToken(contEvent.content);
-              }
-              if (contEvent.type === "thinking_start" || contEvent.type === "thinking_delta" || contEvent.type === "thinking_stop") {
-                sendSSE(res, contEvent);
-              }
-              if (contEvent.type === "done") {
-                accumulateUsage(contEvent.usage);
-              }
-            }
+            // Add the function response to turnParts AFTER creating the stream,
+            // so future chained calls see the complete history
+            turnParts.push({
+              role: "user",
+              parts: [
+                {
+                  functionResponse: {
+                    name: call.name,
+                    response: { result: toolResult.result },
+                  },
+                } as Part,
+              ],
+            });
+
+            // Recursively process continuation (may contain more tool calls)
+            await processStream(contStream, depth + 1);
+            return; // Continuation handled the rest of the turn
           } catch (toolErr: unknown) {
             const errMsg = toolErr instanceof Error ? toolErr.message : String(toolErr);
-            console.error(`Built-in tool ${call.name} failed:`, errMsg);
+            console.error(`Tool call ${call.name} failed:`, errMsg);
             const errorContent = ` (Tool call failed: ${errMsg})`;
             fullResponse += errorContent;
             sendSSE(res, { type: "tool_result", id: toolCallId, name: call.name, result: { error: errMsg } });
           }
-          continue;
-        }
-
-        if (!mcpConn) continue;
-
-        const toolCallId = `tc_${crypto.randomUUID()}`;
-        sendSSE(res, {
-          type: "tool_call",
-          id: toolCallId,
-          name: call.name,
-          args: call.args,
-        });
-
-        try {
-          const result = await mcpConn.callTool(
-            call.name,
-            (call.args as Record<string, unknown>) || {},
-          );
-          toolCalls.push({
-            name: call.name,
-            args: (call.args as Record<string, unknown>) || {},
-            result,
-          });
-
-          sendSSE(res, { type: "tool_result", id: toolCallId, name: call.name, result });
-
-          // Send function result back to Gemini and stream continuation
-          // Gemini 3 with thinking requires thoughtSignature on functionCall parts
-          const functionCallPart: Record<string, unknown> = {
-            functionCall: { name: call.name, args: call.args || {} },
-          };
-          if (call.thoughtSignature) {
-            functionCallPart.thoughtSignature = call.thoughtSignature;
-          }
-          const updatedHistory: Content[] = [
-            ...geminiHistory,
-            { role: "user", parts: [{ text: message.trim() }] },
-            {
-              role: "model",
-              parts: [functionCallPart as Part],
-            },
-          ];
-
-          const contStream = gemini.sendFunctionResult(
-            updatedHistory,
-            call.name,
-            result,
-            allTools,
-          );
-
-          for await (const contEvent of contStream) {
-            if (contEvent.type === "token") {
-              bufferToken(contEvent.content);
-            }
-            if (contEvent.type === "thinking_start" || contEvent.type === "thinking_delta" || contEvent.type === "thinking_stop") {
-              sendSSE(res, contEvent);
-            }
-            if (contEvent.type === "done") {
-              accumulateUsage(contEvent.usage);
-            }
-          }
-        } catch (toolErr: unknown) {
-          const errDetail =
-            toolErr instanceof Error
-              ? {
-                  message: toolErr.message,
-                  ...Object.fromEntries(
-                    Object.entries(
-                      toolErr as unknown as Record<string, unknown>,
-                    ),
-                  ),
-                }
-              : toolErr;
-          console.error(
-            `Tool call ${call.name} failed:`,
-            JSON.stringify(errDetail, null, 2),
-          );
-          const errorMsg =
-            " (Tool call failed, continuing without result.)";
-          fullResponse += errorMsg;
-          sendSSE(res, { type: "token", content: errorMsg });
         }
       }
     }
+
+    const stream = gemini.streamChat(
+      geminiHistory,
+      message.trim(),
+      allTools,
+    );
+
+    await processStream(stream);
 
     // Finalize buffer: handle any remaining incomplete line
     if (lineBuf) {

--- a/tests/unit/gemini.test.ts
+++ b/tests/unit/gemini.test.ts
@@ -398,6 +398,149 @@ describe("thoughtSignature preservation", () => {
   });
 });
 
+describe("chained function calls", () => {
+  it("sendFunctionResult yields function_call events (enables chaining)", async () => {
+    mockGenerateContentStream.mockResolvedValue(
+      (async function* () {
+        yield {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    functionCall: { name: "validate_workflow", args: { workflowId: "wf-1" } },
+                    thoughtSignature: "sig_chain_123",
+                  },
+                ],
+              },
+            },
+          ],
+        };
+      })(),
+    );
+
+    const client = createGeminiClient({
+      apiKey: "test-key",
+      systemPrompt: TEST_PROMPT,
+    });
+    const events = [];
+    for await (const event of client.sendFunctionResult(
+      [
+        { role: "user", parts: [{ text: "update and validate" }] },
+        {
+          role: "model",
+          parts: [
+            {
+              functionCall: { name: "update_workflow", args: { workflowId: "wf-1" } },
+              thoughtSignature: "sig_first_abc",
+            },
+          ],
+        },
+      ],
+      "update_workflow",
+      { success: true },
+    )) {
+      events.push(event);
+    }
+
+    const fcEvent = events.find((e) => e.type === "function_call");
+    expect(fcEvent).toBeDefined();
+    expect(fcEvent!.type === "function_call" && fcEvent!.call.name).toBe("validate_workflow");
+    expect(fcEvent!.type === "function_call" && fcEvent!.call.thoughtSignature).toBe("sig_chain_123");
+  });
+
+  it("passes incremental history including prior function calls to continuation", async () => {
+    // Simulate: first call for streamChat returns update_workflow,
+    // then sendFunctionResult should receive history with the prior call + response
+    let capturedContents: unknown[] = [];
+
+    mockGenerateContentStream.mockImplementation((opts: { contents: unknown[] }) => {
+      capturedContents = opts.contents;
+      return Promise.resolve(
+        (async function* () {
+          yield {
+            candidates: [
+              { content: { parts: [{ text: "All done!" }] } },
+            ],
+          };
+        })(),
+      );
+    });
+
+    const client = createGeminiClient({
+      apiKey: "test-key",
+      systemPrompt: TEST_PROMPT,
+    });
+
+    // Build history that mimics what processStream builds incrementally:
+    // [userMessage, model(update_workflow+sig), user(functionResponse(update_workflow)),
+    //  model(validate_workflow+sig)]
+    const history = [
+      { role: "user", parts: [{ text: "update and validate my workflow" }] },
+      {
+        role: "model",
+        parts: [
+          {
+            functionCall: { name: "update_workflow", args: { workflowId: "wf-1" } },
+            thoughtSignature: "sig_update_abc",
+          },
+        ],
+      },
+      {
+        role: "user",
+        parts: [
+          {
+            functionResponse: {
+              name: "update_workflow",
+              response: { result: { success: true } },
+            },
+          },
+        ],
+      },
+      {
+        role: "model",
+        parts: [
+          {
+            functionCall: { name: "validate_workflow", args: { workflowId: "wf-1" } },
+            thoughtSignature: "sig_validate_def",
+          },
+        ],
+      },
+    ];
+
+    const gen = client.sendFunctionResult(
+      history,
+      "validate_workflow",
+      { valid: true },
+    );
+    for await (const _ of gen) {
+      /* drain */
+    }
+
+    // Verify the full history was passed to the API, including:
+    // - The prior update_workflow call with thoughtSignature
+    // - The prior update_workflow response
+    // - The validate_workflow call with thoughtSignature
+    // - The validate_workflow response (added by sendFunctionResult)
+    expect(capturedContents).toHaveLength(5); // 4 history + 1 functionResponse
+
+    // First model turn has update_workflow with thoughtSignature
+    const modelTurn1 = capturedContents[1] as { role: string; parts: { functionCall?: unknown; thoughtSignature?: string }[] };
+    expect(modelTurn1.role).toBe("model");
+    expect(modelTurn1.parts[0]).toHaveProperty("thoughtSignature", "sig_update_abc");
+
+    // Second model turn has validate_workflow with thoughtSignature
+    const modelTurn2 = capturedContents[3] as { role: string; parts: { functionCall?: unknown; thoughtSignature?: string }[] };
+    expect(modelTurn2.role).toBe("model");
+    expect(modelTurn2.parts[0]).toHaveProperty("thoughtSignature", "sig_validate_def");
+
+    // Last element is the functionResponse added by sendFunctionResult
+    const lastContent = capturedContents[4] as { role: string; parts: { functionResponse?: unknown }[] };
+    expect(lastContent.role).toBe("user");
+    expect(lastContent.parts[0]).toHaveProperty("functionResponse");
+  });
+});
+
 describe("usage metadata", () => {
   it("includes usage in done event from streamChat", async () => {
     mockGenerateContentStream.mockResolvedValue(


### PR DESCRIPTION
## Summary
- **Chained tool calls were silently dropped**: Continuation streams (after a tool result) only handled `token`/`thinking`/`done` events — any `function_call` in a continuation was ignored. E.g., Gemini calls `update_workflow` then `validate_workflow` in one turn → second call never executed.
- **History rebuilt incorrectly**: Each tool call rebuilt Gemini history from scratch, omitting prior calls and their `thoughtSignature` values. Gemini with thinking mode rejects requests missing `thought_signature` on `functionCall` parts → `INVALID_ARGUMENT` error.
- **Fix**: Refactored tool execution into a recursive `processStream` loop that handles `function_call` events at any depth, builds history incrementally with all prior calls/results/signatures, and caps recursion at 10.

## Test plan
- [x] New test: `sendFunctionResult` yields `function_call` events (enables chaining)
- [x] New test: incremental history includes prior function calls with `thoughtSignature`
- [x] All 148 unit tests pass
- [ ] Manual test: trigger update_workflow + validate_workflow in same chat turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)