### PR TITLE
fix: key-client sends x-run-id for downstream tracing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -184,6 +184,7 @@ app.post("/chat", requireAuth, async (req, res) => {
       provider: "gemini",
       orgId,
       userId,
+      runId: callerRunId,
       caller: { method: "POST", path: "/chat" },
       trackingHeaders,
     });
@@ -278,6 +279,7 @@ app.post("/chat", requireAuth, async (req, res) => {
           provider: appConfig.mcpKeyName,
           orgId,
           userId,
+          runId,
           caller: { method: "POST", path: "/chat" },
           trackingHeaders,
         });

--- a/src/lib/key-client.ts
+++ b/src/lib/key-client.ts
@@ -19,6 +19,7 @@ export interface KeyResolutionParams {
   provider: string;
   orgId: string;
   userId: string;
+  runId: string;
   caller: CallerInfo;
   trackingHeaders?: TrackingHeaders;
 }
@@ -38,13 +39,14 @@ export async function resolveKey(
     );
   }
 
-  const { provider, orgId, userId, caller, trackingHeaders } = params;
+  const { provider, orgId, userId, runId, caller, trackingHeaders } = params;
   const url = `${KEY_SERVICE_URL}/keys/${encodeURIComponent(provider)}/decrypt`;
 
   const headers: Record<string, string> = {
     "x-api-key": KEY_SERVICE_API_KEY,
     "x-org-id": orgId,
     "x-user-id": userId,
+    "x-run-id": runId,
     "X-Caller-Service": CALLER_SERVICE,
     "X-Caller-Method": caller.method,
     "X-Caller-Path": caller.path,

--- a/tests/unit/key-client.test.ts
+++ b/tests/unit/key-client.test.ts
@@ -35,6 +35,7 @@ describe("resolveKey", () => {
       provider: "gemini",
       orgId: "org-uuid-123",
       userId: "user-uuid-456",
+      runId: "run-uuid-789",
       caller: { method: "POST", path: "/chat" },
     });
 
@@ -46,6 +47,7 @@ describe("resolveKey", () => {
           "x-api-key": "test-key-svc-key",
           "x-org-id": "org-uuid-123",
           "x-user-id": "user-uuid-456",
+          "x-run-id": "run-uuid-789",
           "X-Caller-Service": "chat",
           "X-Caller-Method": "POST",
           "X-Caller-Path": "/chat",
@@ -75,6 +77,7 @@ describe("resolveKey", () => {
       provider: "gemini",
       orgId: "org-byok",
       userId: "user-byok",
+      runId: "run-1",
       caller: { method: "POST", path: "/chat" },
     });
 
@@ -94,7 +97,8 @@ describe("resolveKey", () => {
         provider: "gemini",
         orgId: "org-123",
         userId: "user-123",
-        caller: { method: "POST", path: "/chat" },
+        runId: "run-1",
+      caller: { method: "POST", path: "/chat" },
       }),
     ).rejects.toThrow(/returned 404/);
   });
@@ -112,7 +116,8 @@ describe("resolveKey", () => {
         provider: "gemini",
         orgId: "org-123",
         userId: "user-123",
-        caller: { method: "POST", path: "/chat" },
+        runId: "run-1",
+      caller: { method: "POST", path: "/chat" },
       }),
     ).rejects.toThrow(/returned 400/);
   });
@@ -130,7 +135,8 @@ describe("resolveKey", () => {
         provider: "gemini",
         orgId: "org-123",
         userId: "user-123",
-        caller: { method: "POST", path: "/chat" },
+        runId: "run-1",
+      caller: { method: "POST", path: "/chat" },
       }),
     ).rejects.toThrow(/returned 500/);
   });
@@ -146,7 +152,8 @@ describe("resolveKey", () => {
         provider: "gemini",
         orgId: "org-123",
         userId: "user-123",
-        caller: { method: "POST", path: "/chat" },
+        runId: "run-1",
+      caller: { method: "POST", path: "/chat" },
       }),
     ).rejects.toThrow("ECONNREFUSED");
   });
@@ -160,7 +167,8 @@ describe("resolveKey", () => {
         provider: "gemini",
         orgId: "org-123",
         userId: "user-123",
-        caller: { method: "POST", path: "/chat" },
+        runId: "run-1",
+      caller: { method: "POST", path: "/chat" },
       }),
     ).rejects.toThrow(/KEY_SERVICE_API_KEY is required/);
 
@@ -184,6 +192,7 @@ describe("resolveKey", () => {
       provider: "gemini",
       orgId: "org-123",
       userId: "user-123",
+      runId: "run-1",
       caller: { method: "POST", path: "/chat" },
     });
 

--- a/tests/unit/workflow-tracking.test.ts
+++ b/tests/unit/workflow-tracking.test.ts
@@ -209,6 +209,7 @@ describe("key-client forwards tracking headers", () => {
       provider: "gemini",
       orgId: "org-1",
       userId: "user-1",
+      runId: "run-1",
       caller: { method: "POST", path: "/chat" },
       trackingHeaders: { "x-campaign-id": "camp-1", "x-workflow-name": "flow-1" },
     });
@@ -235,6 +236,7 @@ describe("key-client forwards tracking headers", () => {
       provider: "mcp",
       orgId: "org-1",
       userId: "user-1",
+      runId: "run-1",
       caller: { method: "POST", path: "/chat" },
       trackingHeaders: { "x-brand-id": "brand-1" },
     });
@@ -262,6 +264,7 @@ describe("key-client forwards tracking headers", () => {
       provider: "gemini",
       orgId: "org-1",
       userId: "user-1",
+      runId: "run-1",
       caller: { method: "POST", path: "/chat" },
     });
 


### PR DESCRIPTION
## Summary
- `key-client` now sends `x-run-id` on every call to key-service, even though key-service doesn't require it — it's used for downstream logging/tracing
- Rule: always send the full identity triplet (`x-org-id`, `x-user-id`, `x-run-id`) on every service-to-service call, no exceptions

All downstream clients are now consistent:

| Client | `x-org-id` | `x-user-id` | `x-run-id` |
|---|---|---|---|
| workflow-client | OK | OK | OK |
| key-client | OK | OK | OK |
| runs-client | OK | OK | OK |

## Test plan
- [x] `key-client.test.ts`: verifies `x-run-id` is sent in headers (8 tests)
- [x] `workflow-tracking.test.ts`: all resolveKey calls include runId (11 tests)
- [x] Full suite: 144 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)