### PR TITLE
fix: use fixed cost name gemini-google-search-query

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Built-in tools emit `tool_call` and `tool_result` events like MCP tools. The fro
 
 | Tool | Description | Cost tracking |
 |---|---|---|
-| `googleSearch` | Gemini searches the web when it needs real-time information. The model decides autonomously when to search. | Billed per search query executed. Reported as `{model}-google-search-query` cost item in runs-service. |
+| `googleSearch` | Gemini searches the web when it needs real-time information. The model decides autonomously when to search. | Billed per search query executed. Reported as `gemini-google-search-query` cost item in runs-service. |
 | `urlContext` | Gemini reads web page content when URLs appear in the conversation. | Billed as input tokens (page content is injected into context). Already covered by `{model}-tokens-input` cost item. |
 
 These tools are transparent to the frontend — no SSE events are emitted for them. The model's response simply includes grounded information with citations.

--- a/src/index.ts
+++ b/src/index.ts
@@ -648,7 +648,7 @@ app.post("/chat", requireAuth, async (req, res) => {
         ...(totalSearchQueries > 0
           ? [
               {
-                costName: `${costModel}-google-search-query`,
+                costName: "gemini-google-search-query",
                 quantity: totalSearchQueries,
                 costSource,
               },


### PR DESCRIPTION
## Summary
- Uses fixed cost name `gemini-google-search-query` instead of `${costModel}-google-search-query` to match what was registered in costs-service

## Test plan
- [x] All 152 unit tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)