### PR TITLE
fix: don't combine googleSearch with function calling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -240,6 +240,7 @@ app.post("/chat", requireAuth, async (req, res) => {
     }
 
     sendSSE(res, { sessionId: currentSessionId });
+    console.log(`[chat] session="${currentSessionId}" org="${orgId}" user="${userId}" — start`);
 
     // Register run in RunsService (mandatory — fail request if unavailable)
     try {
@@ -249,8 +250,9 @@ app.post("/chat", requireAuth, async (req, res) => {
         trackingHeaders,
       );
       runId = run.id;
+      console.log(`[chat] session="${currentSessionId}" run="${runId}" created`);
     } catch (runErr) {
-      console.error("Failed to create run:", runErr);
+      console.error(`[chat] session="${currentSessionId}" run creation failed:`, runErr);
       sendSSE(res, {
         type: "error",
         message: "Service temporarily unavailable (run tracking). Please try again.",
@@ -541,6 +543,7 @@ app.post("/chat", requireAuth, async (req, res) => {
       }
     }
 
+    console.log(`[chat] session="${currentSessionId}" streaming — model="${gemini.model}" tools=${allTools.length} history=${geminiHistory.length}`);
     const stream = gemini.streamChat(
       geminiHistory,
       message.trim(),
@@ -548,6 +551,7 @@ app.post("/chat", requireAuth, async (req, res) => {
     );
 
     await processStream(stream);
+    console.log(`[chat] session="${currentSessionId}" stream complete — tokens=${totalPromptTokens}+${totalOutputTokens} response=${fullResponse.length}chars`);
 
     // Finalize buffer: handle any remaining incomplete line
     if (lineBuf) {
@@ -610,7 +614,7 @@ app.post("/chat", requireAuth, async (req, res) => {
     sendSSE(res, "[DONE]");
   } catch (err) {
     chatFailed = true;
-    console.error("Chat error:", err);
+    console.error(`[chat] org="${orgId}" unhandled error:`, err);
     sendSSE(res, {
       type: "error",
       message: "An unexpected error occurred. Please try again.",

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -157,6 +157,10 @@ export function createGeminiClient({
       userMessage: string,
       tools?: FunctionDeclaration[],
     ): AsyncGenerator<GeminiEvent> {
+      // Gemini does not allow combining built-in tools (google_search, url_context)
+      // with function calling in the same request. Use function calling when we have
+      // tool declarations, otherwise enable google search + URL context.
+      const hasTools = tools && tools.length > 0;
       const response = await ai.models.generateContentStream({
         model,
         contents: [
@@ -165,12 +169,10 @@ export function createGeminiClient({
         ],
         config: {
           systemInstruction: systemPrompt,
-          tools: [
-            ...(tools?.length ? [{ functionDeclarations: tools }] : []),
-            { googleSearch: {} },
-            { urlContext: {} },
-          ],
-          toolConfig: tools?.length
+          tools: hasTools
+            ? [{ functionDeclarations: tools }]
+            : [{ googleSearch: {} }, { urlContext: {} }],
+          toolConfig: hasTools
             ? {
                 functionCallingConfig: {
                   mode: FunctionCallingConfigMode.AUTO,
@@ -253,6 +255,7 @@ export function createGeminiClient({
       result: unknown,
       tools?: FunctionDeclaration[],
     ): AsyncGenerator<GeminiEvent> {
+      const hasTools = tools && tools.length > 0;
       const response = await ai.models.generateContentStream({
         model,
         contents: [
@@ -271,12 +274,10 @@ export function createGeminiClient({
         ],
         config: {
           systemInstruction: systemPrompt,
-          tools: [
-            ...(tools?.length ? [{ functionDeclarations: tools }] : []),
-            { googleSearch: {} },
-            { urlContext: {} },
-          ],
-          toolConfig: tools?.length
+          tools: hasTools
+            ? [{ functionDeclarations: tools }]
+            : [{ googleSearch: {} }, { urlContext: {} }],
+          toolConfig: hasTools
             ? {
                 functionCallingConfig: {
                   mode: FunctionCallingConfigMode.AUTO,

--- a/tests/unit/gemini.test.ts
+++ b/tests/unit/gemini.test.ts
@@ -731,7 +731,7 @@ describe("native Gemini tools (googleSearch + urlContext)", () => {
     );
   });
 
-  it("passes googleSearch and urlContext in tools array for streamChat", async () => {
+  it("uses googleSearch + urlContext when NO function tools are provided", async () => {
     const client = createGeminiClient({
       apiKey: "test-key",
       systemPrompt: TEST_PROMPT,
@@ -743,15 +743,14 @@ describe("native Gemini tools (googleSearch + urlContext)", () => {
 
     const callArgs = mockGenerateContentStream.mock.calls.at(-1)?.[0];
     const tools = callArgs?.config?.tools;
-    expect(tools).toEqual(
-      expect.arrayContaining([
-        { googleSearch: {} },
-        { urlContext: {} },
-      ]),
-    );
+    expect(tools).toEqual([
+      { googleSearch: {} },
+      { urlContext: {} },
+    ]);
+    expect(callArgs?.config?.toolConfig).toBeUndefined();
   });
 
-  it("passes googleSearch and urlContext in tools array for sendFunctionResult", async () => {
+  it("uses googleSearch + urlContext in sendFunctionResult when no tools", async () => {
     const client = createGeminiClient({
       apiKey: "test-key",
       systemPrompt: TEST_PROMPT,
@@ -763,15 +762,13 @@ describe("native Gemini tools (googleSearch + urlContext)", () => {
 
     const callArgs = mockGenerateContentStream.mock.calls.at(-1)?.[0];
     const tools = callArgs?.config?.tools;
-    expect(tools).toEqual(
-      expect.arrayContaining([
-        { googleSearch: {} },
-        { urlContext: {} },
-      ]),
-    );
+    expect(tools).toEqual([
+      { googleSearch: {} },
+      { urlContext: {} },
+    ]);
   });
 
-  it("includes functionDeclarations alongside native tools when tools are provided", async () => {
+  it("uses ONLY functionDeclarations when function tools are provided (no googleSearch)", async () => {
     const client = createGeminiClient({
       apiKey: "test-key",
       systemPrompt: TEST_PROMPT,
@@ -786,27 +783,32 @@ describe("native Gemini tools (googleSearch + urlContext)", () => {
 
     const callArgs = mockGenerateContentStream.mock.calls.at(-1)?.[0];
     const tools = callArgs?.config?.tools;
-    expect(tools).toHaveLength(3);
-    expect(tools[0]).toEqual({ functionDeclarations: customTools });
-    expect(tools[1]).toEqual({ googleSearch: {} });
-    expect(tools[2]).toEqual({ urlContext: {} });
+    expect(tools).toEqual([{ functionDeclarations: customTools }]);
+    // Must NOT contain googleSearch — Gemini rejects this combination
+    expect(tools).not.toEqual(
+      expect.arrayContaining([{ googleSearch: {} }]),
+    );
   });
 
-  it("still includes native tools even when no custom tools are provided", async () => {
+  it("uses ONLY functionDeclarations in sendFunctionResult when tools provided", async () => {
     const client = createGeminiClient({
       apiKey: "test-key",
       systemPrompt: TEST_PROMPT,
     });
-    const gen = client.streamChat([], "hello");
+    const customTools = [
+      { name: "my_tool", description: "test", parameters: {} },
+    ];
+    const gen = client.sendFunctionResult([], "tool", { data: "ok" }, customTools);
     for await (const _ of gen) {
       /* drain */
     }
 
     const callArgs = mockGenerateContentStream.mock.calls.at(-1)?.[0];
     const tools = callArgs?.config?.tools;
-    expect(tools).toHaveLength(2);
-    expect(tools[0]).toEqual({ googleSearch: {} });
-    expect(tools[1]).toEqual({ urlContext: {} });
+    expect(tools).toEqual([{ functionDeclarations: customTools }]);
+    expect(tools).not.toEqual(
+      expect.arrayContaining([{ googleSearch: {} }]),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- **Root cause**: Commit #60 added `{ googleSearch: {} }` and `{ urlContext: {} }` to every Gemini API call alongside function declarations. Gemini returns 400: `Built-in tools ({google_search}) and Function Calling cannot be combined in the same request.` This broke ALL chat requests since BUILTIN_TOOLS are always present.
- **Fix**: Use function declarations OR google search/URL context, never both. When tools are present → only `functionDeclarations`. When no tools → `googleSearch` + `urlContext`.
- **Logging**: Added structured `[chat]` logs at session creation, run creation, stream start/end so silent failures show up in Railway.

## Test plan
- [x] Existing gemini tests updated to verify mutual exclusion of google search and function calling
- [x] New test: when function tools provided, googleSearch is NOT in the request
- [x] New test: when no function tools, googleSearch + urlContext ARE used
- [x] All 153 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)