### PR TITLE
fix: reject deprecated MCP fields in config endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -335,7 +335,8 @@
         },
         "required": [
           "systemPrompt"
-        ]
+        ],
+        "additionalProperties": false
       },
       "PlatformConfigResponse": {
         "type": "object",
@@ -366,7 +367,8 @@
         },
         "required": [
           "systemPrompt"
-        ]
+        ],
+        "additionalProperties": false
       },
       "ChatRequest": {
         "type": "object",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -85,6 +85,7 @@ export const AppConfigRequestSchema = z
   .object({
     systemPrompt: z.string().min(1, "systemPrompt is required"),
   })
+  .strict()
   .openapi("AppConfigRequest");
 
 export const AppConfigResponseSchema = z
@@ -151,6 +152,7 @@ export const PlatformConfigRequestSchema = z
   .object({
     systemPrompt: z.string().min(1, "systemPrompt is required"),
   })
+  .strict()
   .openapi("PlatformConfigRequest");
 
 export const PlatformConfigResponseSchema = z

--- a/tests/unit/app-config.test.ts
+++ b/tests/unit/app-config.test.ts
@@ -20,4 +20,12 @@ describe("AppConfigRequestSchema", () => {
     const result = AppConfigRequestSchema.safeParse({});
     expect(result.success).toBe(false);
   });
+
+  it("rejects unknown fields (e.g. deprecated mcpServerUrl)", () => {
+    const result = AppConfigRequestSchema.safeParse({
+      systemPrompt: "You are a helpful assistant.",
+      mcpServerUrl: "https://mcp.example.com",
+    });
+    expect(result.success).toBe(false);
+  });
 });

--- a/tests/unit/platform-config.test.ts
+++ b/tests/unit/platform-config.test.ts
@@ -20,4 +20,12 @@ describe("PlatformConfigRequestSchema", () => {
     const result = PlatformConfigRequestSchema.safeParse({});
     expect(result.success).toBe(false);
   });
+
+  it("rejects unknown fields (e.g. deprecated mcpServerUrl)", () => {
+    const result = PlatformConfigRequestSchema.safeParse({
+      systemPrompt: "You are a helpful assistant.",
+      mcpServerUrl: "https://mcp.example.com",
+    });
+    expect(result.success).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- Config request schemas (`PUT /config`, `PUT /platform-config`) now use `.strict()` Zod validation
- Sending unknown fields like `mcpServerUrl` or `mcpKeyName` now returns **400** instead of being silently stripped
- Forces api-service to remove deprecated MCP fields from its cold-start payload

## Test plan
- [x] New test: `AppConfigRequestSchema` rejects unknown fields (e.g. `mcpServerUrl`)
- [x] New test: `PlatformConfigRequestSchema` rejects unknown fields
- [x] 142 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)