### PR TITLE
fix: remove last MCP reference from OpenAPI spec

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Chat Service",
-    "description": "Multi-app AI chat service. Streams Gemini AI responses via SSE with configurable system prompts and optional MCP tool calling per app.",
+    "description": "Multi-org AI chat service. Streams Gemini AI responses via SSE with configurable system prompts and built-in workflow tools.",
     "version": "1.0.0"
   },
   "servers": [

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -15,7 +15,7 @@ const document = generator.generateDocument({
   info: {
     title: "Chat Service",
     description:
-      "Multi-app AI chat service. Streams Gemini AI responses via SSE with configurable system prompts and optional MCP tool calling per app.",
+      "Multi-org AI chat service. Streams Gemini AI responses via SSE with configurable system prompts and built-in workflow tools.",
     version: "1.0.0",
   },
   servers: [


### PR DESCRIPTION
## Summary
- Removed final MCP mention from the OpenAPI info.description in `scripts/generate-openapi.ts`
- Regenerated `openapi.json`

## Test plan
- [x] `grep -i mcp openapi.json` returns zero matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)