### PR TITLE
feat: add get_prompt_template built-in tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ After a tool result, more `token` events follow with the AI's continuation.
 |---|---|
 | `update_workflow` | Updates a workflow's metadata (name, description, tags) via workflow-service `PUT /workflows/{id}` |
 | `validate_workflow` | Validates a workflow's DAG structure via workflow-service `POST /workflows/{id}/validate` |
+| `get_prompt_template` | Retrieves a stored prompt template by type from content-generation `GET /prompts?type=...` |
 | `request_user_input` | Asks the user for structured input (see Input Request below) |
 
 **Native Gemini tools** (always enabled, invoked automatically by the model):
@@ -214,6 +215,8 @@ Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token st
 | `RUNS_SERVICE_API_KEY` | No | API key for RunsService (runs tracking disabled if unset) |
 | `WORKFLOW_SERVICE_URL` | No | Workflow-service endpoint (default: `https://workflow.mcpfactory.org`) |
 | `WORKFLOW_SERVICE_API_KEY` | No | API key for workflow-service (built-in workflow tools fail if unset) |
+| `CONTENT_GENERATION_SERVICE_URL` | No | Content-generation service endpoint (default: `https://content-generation.distribute.you`) |
+| `CONTENT_GENERATION_SERVICE_API_KEY` | No | API key for content-generation service (get_prompt_template tool fails if unset) |
 | `PORT` | No | Server port (default: `3002`) |
 
 ## Database
@@ -283,7 +286,8 @@ src/
     gemini.ts          # Gemini AI client, streaming + function calling, buildSystemPrompt helper, built-in tool declarations
     key-client.ts      # Key-service client for resolving Gemini keys (platform or BYOK per org)
     runs-client.ts     # RunsService HTTP client for run tracking and cost reporting
-    workflow-client.ts # Workflow-service client for update_workflow and validate_workflow built-in tools
+    workflow-client.ts              # Workflow-service client for update_workflow and validate_workflow built-in tools
+    content-generation-client.ts    # Content-generation service client for get_prompt_template built-in tool
 scripts/
   generate-openapi.ts  # Generates openapi.json from zod schemas via OpenApiGeneratorV3
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import {
   updateWorkflow,
   validateWorkflow,
 } from "./lib/workflow-client.js";
+import { getPromptTemplate } from "./lib/content-generation-client.js";
 import { createRun, updateRunStatus, addRunCosts } from "./lib/runs-client.js";
 import { resolveKey, type ResolvedKey } from "./lib/key-client.js";
 import { ChatRequestSchema, AppConfigRequestSchema, PlatformConfigRequestSchema } from "./schemas.js";
@@ -376,6 +377,23 @@ app.post("/chat", requireAuth, async (req, res) => {
             wfParams,
           );
         }
+
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
+      // Built-in content-generation tools
+      if (call.name === "get_prompt_template") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const result = await getPromptTemplate(
+          args.type as string,
+          {
+            orgId,
+            userId,
+            runId: runId!,
+            trackingHeaders: Object.keys(trackingHeaders).length > 0 ? trackingHeaders as Record<string, string> : undefined,
+          },
+        );
 
         toolCalls.push({ name: call.name, args, result });
         return { name: call.name, result };

--- a/src/lib/content-generation-client.ts
+++ b/src/lib/content-generation-client.ts
@@ -1,0 +1,54 @@
+const CONTENT_GENERATION_SERVICE_URL =
+  process.env.CONTENT_GENERATION_SERVICE_URL || "https://content-generation.distribute.you";
+const CONTENT_GENERATION_SERVICE_API_KEY = process.env.CONTENT_GENERATION_SERVICE_API_KEY;
+
+export interface PromptTemplate {
+  id: string;
+  type: string;
+  prompt: string;
+  variables: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ContentGenerationCallParams {
+  orgId: string;
+  userId: string;
+  runId: string;
+  trackingHeaders?: Record<string, string>;
+}
+
+export async function getPromptTemplate(
+  type: string,
+  params: ContentGenerationCallParams,
+): Promise<PromptTemplate> {
+  if (!CONTENT_GENERATION_SERVICE_API_KEY) {
+    throw new Error(
+      "[content-generation-client] CONTENT_GENERATION_SERVICE_API_KEY is required",
+    );
+  }
+
+  const url = `${CONTENT_GENERATION_SERVICE_URL}/prompts?type=${encodeURIComponent(type)}`;
+  const headers: Record<string, string> = {
+    "x-api-key": CONTENT_GENERATION_SERVICE_API_KEY,
+    "x-org-id": params.orgId,
+    "x-user-id": params.userId,
+    "x-run-id": params.runId,
+  };
+  if (params.trackingHeaders) {
+    for (const [k, v] of Object.entries(params.trackingHeaders)) {
+      if (v) headers[k] = v;
+    }
+  }
+
+  const res = await fetch(url, { method: "GET", headers });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `[content-generation-client] GET /prompts?type=${type} returned ${res.status}: ${text}`,
+    );
+  }
+
+  return (await res.json()) as PromptTemplate;
+}

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -89,10 +89,28 @@ export const VALIDATE_WORKFLOW_TOOL: FunctionDeclaration = {
   },
 };
 
+export const GET_PROMPT_TEMPLATE_TOOL: FunctionDeclaration = {
+  name: "get_prompt_template",
+  description:
+    "Retrieve a stored prompt template by type from the content-generation service. Use this when the user asks to see, review, or check a prompt template (e.g. cold-email, follow-up).",
+  parameters: {
+    type: Type.OBJECT,
+    properties: {
+      type: {
+        type: Type.STRING,
+        description:
+          "The prompt type to look up (e.g. 'cold-email', 'follow-up', 'sales-email')",
+      },
+    },
+    required: ["type"],
+  },
+};
+
 export const BUILTIN_TOOLS: FunctionDeclaration[] = [
   REQUEST_USER_INPUT_TOOL,
   UPDATE_WORKFLOW_TOOL,
   VALIDATE_WORKFLOW_TOOL,
+  GET_PROMPT_TEMPLATE_TOOL,
 ];
 
 export interface FunctionCall {

--- a/tests/unit/content-generation-client.test.ts
+++ b/tests/unit/content-generation-client.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  process.env.CONTENT_GENERATION_SERVICE_API_KEY = "test-cg-key";
+  process.env.CONTENT_GENERATION_SERVICE_URL = "https://content-generation.test.local";
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.restoreAllMocks();
+});
+
+async function loadModule() {
+  vi.resetModules();
+  return import("../../src/lib/content-generation-client.js");
+}
+
+describe("getPromptTemplate", () => {
+  it("sends GET with correct URL, headers, and query param", async () => {
+    const mockPrompt = {
+      id: "p-1",
+      type: "cold-email",
+      prompt: "Write a cold email for {{leadFirstName}}",
+      variables: ["leadFirstName"],
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    };
+
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockPrompt),
+    });
+
+    const { getPromptTemplate } = await loadModule();
+    const result = await getPromptTemplate("cold-email", {
+      orgId: "org-1",
+      userId: "user-1",
+      runId: "run-1",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://content-generation.test.local/prompts?type=cold-email",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          "x-api-key": "test-cg-key",
+          "x-org-id": "org-1",
+          "x-user-id": "user-1",
+          "x-run-id": "run-1",
+        }),
+      }),
+    );
+    expect(result).toEqual(mockPrompt);
+  });
+
+  it("encodes special characters in type parameter", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: "p-1", type: "cold email", prompt: "", variables: [], createdAt: "", updatedAt: "" }),
+    });
+
+    const { getPromptTemplate } = await loadModule();
+    await getPromptTemplate("cold email", {
+      orgId: "org-1",
+      userId: "user-1",
+      runId: "run-1",
+    });
+
+    const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(calledUrl).toBe("https://content-generation.test.local/prompts?type=cold%20email");
+  });
+
+  it("forwards tracking headers", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: "p-1", type: "t", prompt: "", variables: [], createdAt: "", updatedAt: "" }),
+    });
+
+    const { getPromptTemplate } = await loadModule();
+    await getPromptTemplate("cold-email", {
+      orgId: "org-1",
+      userId: "user-1",
+      runId: "run-1",
+      trackingHeaders: { "x-campaign-id": "camp-1" },
+    });
+
+    const callHeaders = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].headers;
+    expect(callHeaders["x-campaign-id"]).toBe("camp-1");
+  });
+
+  it("throws on HTTP error", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve("Not found"),
+    });
+
+    const { getPromptTemplate } = await loadModule();
+    await expect(
+      getPromptTemplate("nonexistent", { orgId: "o", userId: "u", runId: "r" }),
+    ).rejects.toThrow(/returned 404/);
+  });
+
+  it("throws when CONTENT_GENERATION_SERVICE_API_KEY is not set", async () => {
+    delete process.env.CONTENT_GENERATION_SERVICE_API_KEY;
+
+    const { getPromptTemplate } = await loadModule();
+    await expect(
+      getPromptTemplate("cold-email", { orgId: "o", userId: "u", runId: "r" }),
+    ).rejects.toThrow(/CONTENT_GENERATION_SERVICE_API_KEY is required/);
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("uses default URL when CONTENT_GENERATION_SERVICE_URL is not set", async () => {
+    delete process.env.CONTENT_GENERATION_SERVICE_URL;
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: "p-1", type: "t", prompt: "", variables: [], createdAt: "", updatedAt: "" }),
+    });
+
+    const { getPromptTemplate } = await loadModule();
+    await getPromptTemplate("cold-email", { orgId: "o", userId: "u", runId: "r" });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://content-generation.distribute.you/prompts?type=cold-email",
+      expect.anything(),
+    );
+  });
+});

--- a/tests/unit/gemini.test.ts
+++ b/tests/unit/gemini.test.ts
@@ -715,12 +715,13 @@ describe("VALIDATE_WORKFLOW_TOOL", () => {
 });
 
 describe("BUILTIN_TOOLS", () => {
-  it("includes all three built-in tools", () => {
+  it("includes all built-in tools", () => {
     const names = BUILTIN_TOOLS.map((t) => t.name);
     expect(names).toContain("request_user_input");
     expect(names).toContain("update_workflow");
     expect(names).toContain("validate_workflow");
-    expect(BUILTIN_TOOLS).toHaveLength(3);
+    expect(names).toContain("get_prompt_template");
+    expect(BUILTIN_TOOLS).toHaveLength(4);
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds a new `get_prompt_template` built-in tool that calls `GET /prompts?type=...` on content-generation service
- Fixes issue where the chatbot hallucinated when users asked to see their prompt templates (e.g. cold-email prompt)
- Includes new `content-generation-client.ts` module, tool declaration in `gemini.ts`, execution handler in `index.ts`

## New env vars
- `CONTENT_GENERATION_SERVICE_URL` (optional, defaults to `https://content-generation.distribute.you`)
- `CONTENT_GENERATION_SERVICE_API_KEY` (required for the tool to work)

## Test plan
- [x] Unit tests for `content-generation-client.ts` (6 tests: GET call, URL encoding, tracking headers, HTTP errors, missing API key, default URL)
- [x] Updated `BUILTIN_TOOLS` test to include new tool
- [x] All 148 unit tests passing
- [ ] Set `CONTENT_GENERATION_SERVICE_API_KEY` env var on Railway before deploying

🤖 Generated with [Claude Code](https://claude.com/claude-code)