### PR TITLE
feat: add update_prompt_template built-in tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ After a tool result, more `token` events follow with the AI's continuation.
 | `update_workflow` | Updates a workflow's metadata (name, description, tags) via workflow-service `PUT /workflows/{id}` |
 | `validate_workflow` | Validates a workflow's DAG structure via workflow-service `POST /workflows/{id}/validate` |
 | `get_prompt_template` | Retrieves a stored prompt template by type from content-generation `GET /prompts?type=...` |
+| `update_prompt_template` | Creates a new version of an existing prompt template via content-generation `PUT /prompts` (auto-versions: e.g. `cold-email` → `cold-email-v2`) |
 | `request_user_input` | Asks the user for structured input (see Input Request below) |
 
 **Native Gemini tools** (always enabled, invoked automatically by the model):

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import {
   updateWorkflow,
   validateWorkflow,
 } from "./lib/workflow-client.js";
-import { getPromptTemplate } from "./lib/content-generation-client.js";
+import { getPromptTemplate, updatePromptTemplate } from "./lib/content-generation-client.js";
 import { createRun, updateRunStatus, addRunCosts } from "./lib/runs-client.js";
 import { resolveKey, type ResolvedKey } from "./lib/key-client.js";
 import { ChatRequestSchema, AppConfigRequestSchema, PlatformConfigRequestSchema } from "./schemas.js";
@@ -387,6 +387,27 @@ app.post("/chat", requireAuth, async (req, res) => {
         const args = (call.args as Record<string, unknown>) || {};
         const result = await getPromptTemplate(
           args.type as string,
+          {
+            orgId,
+            userId,
+            runId: runId!,
+            trackingHeaders: Object.keys(trackingHeaders).length > 0 ? trackingHeaders as Record<string, string> : undefined,
+          },
+        );
+
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
+      // Built-in prompt update tool
+      if (call.name === "update_prompt_template") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const result = await updatePromptTemplate(
+          {
+            sourceType: args.sourceType as string,
+            prompt: args.prompt as string,
+            variables: args.variables as string[],
+          },
           {
             orgId,
             userId,

--- a/src/lib/content-generation-client.ts
+++ b/src/lib/content-generation-client.ts
@@ -52,3 +52,49 @@ export async function getPromptTemplate(
 
   return (await res.json()) as PromptTemplate;
 }
+
+export interface UpdatePromptBody {
+  sourceType: string;
+  prompt: string;
+  variables: string[];
+}
+
+export async function updatePromptTemplate(
+  body: UpdatePromptBody,
+  params: ContentGenerationCallParams,
+): Promise<PromptTemplate> {
+  if (!CONTENT_GENERATION_SERVICE_API_KEY) {
+    throw new Error(
+      "[content-generation-client] CONTENT_GENERATION_SERVICE_API_KEY is required",
+    );
+  }
+
+  const url = `${CONTENT_GENERATION_SERVICE_URL}/prompts`;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "x-api-key": CONTENT_GENERATION_SERVICE_API_KEY,
+    "x-org-id": params.orgId,
+    "x-user-id": params.userId,
+    "x-run-id": params.runId,
+  };
+  if (params.trackingHeaders) {
+    for (const [k, v] of Object.entries(params.trackingHeaders)) {
+      if (v) headers[k] = v;
+    }
+  }
+
+  const res = await fetch(url, {
+    method: "PUT",
+    headers,
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `[content-generation-client] PUT /prompts returned ${res.status}: ${text}`,
+    );
+  }
+
+  return (await res.json()) as PromptTemplate;
+}

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -106,11 +106,40 @@ export const GET_PROMPT_TEMPLATE_TOOL: FunctionDeclaration = {
   },
 };
 
+export const UPDATE_PROMPT_TEMPLATE_TOOL: FunctionDeclaration = {
+  name: "update_prompt_template",
+  description:
+    "Create a new version of an existing prompt template. The original is never modified — a new version is created automatically (e.g. 'cold-email' → 'cold-email-v2'). Use this when the user wants to update, improve, or modify a prompt template.",
+  parameters: {
+    type: Type.OBJECT,
+    properties: {
+      sourceType: {
+        type: Type.STRING,
+        description:
+          "The type of the existing prompt to version from (e.g. 'cold-email')",
+      },
+      prompt: {
+        type: Type.STRING,
+        description:
+          "The new prompt template text with {{variable}} placeholders. Must NOT contain company-specific data — only {{variables}}.",
+      },
+      variables: {
+        type: Type.ARRAY,
+        items: { type: Type.STRING },
+        description:
+          "List of variable names used in the prompt (e.g. ['leadFirstName', 'leadCompanyName'])",
+      },
+    },
+    required: ["sourceType", "prompt", "variables"],
+  },
+};
+
 export const BUILTIN_TOOLS: FunctionDeclaration[] = [
   REQUEST_USER_INPUT_TOOL,
   UPDATE_WORKFLOW_TOOL,
   VALIDATE_WORKFLOW_TOOL,
   GET_PROMPT_TEMPLATE_TOOL,
+  UPDATE_PROMPT_TEMPLATE_TOOL,
 ];
 
 export interface FunctionCall {

--- a/tests/unit/content-generation-client.test.ts
+++ b/tests/unit/content-generation-client.test.ts
@@ -131,3 +131,97 @@ describe("getPromptTemplate", () => {
     );
   });
 });
+
+describe("updatePromptTemplate", () => {
+  it("sends PUT with correct URL, headers, and body", async () => {
+    const mockResult = {
+      id: "p-2",
+      type: "cold-email-v2",
+      prompt: "New prompt for {{leadFirstName}}",
+      variables: ["leadFirstName"],
+      createdAt: "2026-03-18T00:00:00Z",
+      updatedAt: "2026-03-18T00:00:00Z",
+    };
+
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResult),
+    });
+
+    const { updatePromptTemplate } = await loadModule();
+    const result = await updatePromptTemplate(
+      {
+        sourceType: "cold-email",
+        prompt: "New prompt for {{leadFirstName}}",
+        variables: ["leadFirstName"],
+      },
+      { orgId: "org-1", userId: "user-1", runId: "run-1" },
+    );
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://content-generation.test.local/prompts",
+      expect.objectContaining({
+        method: "PUT",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          "x-api-key": "test-cg-key",
+          "x-org-id": "org-1",
+          "x-user-id": "user-1",
+          "x-run-id": "run-1",
+        }),
+        body: JSON.stringify({
+          sourceType: "cold-email",
+          prompt: "New prompt for {{leadFirstName}}",
+          variables: ["leadFirstName"],
+        }),
+      }),
+    );
+    expect(result).toEqual(mockResult);
+  });
+
+  it("forwards tracking headers", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: "p-2", type: "t-v2", prompt: "", variables: [], createdAt: "", updatedAt: "" }),
+    });
+
+    const { updatePromptTemplate } = await loadModule();
+    await updatePromptTemplate(
+      { sourceType: "cold-email", prompt: "test", variables: [] },
+      { orgId: "org-1", userId: "user-1", runId: "run-1", trackingHeaders: { "x-brand-id": "brand-1" } },
+    );
+
+    const callHeaders = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].headers;
+    expect(callHeaders["x-brand-id"]).toBe("brand-1");
+  });
+
+  it("throws on HTTP error", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: () => Promise.resolve("Invalid request"),
+    });
+
+    const { updatePromptTemplate } = await loadModule();
+    await expect(
+      updatePromptTemplate(
+        { sourceType: "bad", prompt: "", variables: [] },
+        { orgId: "o", userId: "u", runId: "r" },
+      ),
+    ).rejects.toThrow(/returned 400/);
+  });
+
+  it("throws when CONTENT_GENERATION_SERVICE_API_KEY is not set", async () => {
+    delete process.env.CONTENT_GENERATION_SERVICE_API_KEY;
+
+    const { updatePromptTemplate } = await loadModule();
+    await expect(
+      updatePromptTemplate(
+        { sourceType: "cold-email", prompt: "test", variables: [] },
+        { orgId: "o", userId: "u", runId: "r" },
+      ),
+    ).rejects.toThrow(/CONTENT_GENERATION_SERVICE_API_KEY is required/);
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/gemini.test.ts
+++ b/tests/unit/gemini.test.ts
@@ -721,7 +721,8 @@ describe("BUILTIN_TOOLS", () => {
     expect(names).toContain("update_workflow");
     expect(names).toContain("validate_workflow");
     expect(names).toContain("get_prompt_template");
-    expect(BUILTIN_TOOLS).toHaveLength(4);
+    expect(names).toContain("update_prompt_template");
+    expect(BUILTIN_TOOLS).toHaveLength(5);
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds `update_prompt_template` built-in tool that calls `PUT /prompts` on content-generation service
- Auto-versions prompts (e.g. `cold-email` → `cold-email-v2`) — the original is never modified
- Enables users to iterate on prompt quality directly through the chatbot instead of manual copy-paste

## Test plan
- [x] Unit tests for `updatePromptTemplate` client (4 new tests: PUT call, tracking headers, HTTP errors, missing API key)
- [x] Updated `BUILTIN_TOOLS` test to include new tool (now 5 tools)
- [x] All 152 unit tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)