### PR TITLE
feat: add update_workflow_node_config built-in tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ After a tool result, more `token` events follow with the AI's continuation.
 | Tool | Description |
 |---|---|
 | `update_workflow` | Updates a workflow's metadata (name, description, tags) via workflow-service `PUT /workflows/{id}` |
+| `update_workflow_node_config` | Updates a specific node's config in a workflow's DAG (e.g. change prompt type on `email-generate` node). Fetches, merges, and saves. |
 | `validate_workflow` | Validates a workflow's DAG structure via workflow-service `POST /workflows/{id}/validate` |
 | `get_prompt_template` | Retrieves a stored prompt template by type from content-generation `GET /prompts?type=...` |
 | `update_prompt_template` | Creates a new version of an existing prompt template via content-generation `PUT /prompts` (auto-versions: e.g. `cold-email` → `cold-email-v2`) |

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import {
 import {
   updateWorkflow,
   validateWorkflow,
+  updateWorkflowNodeConfig,
 } from "./lib/workflow-client.js";
 import { getPromptTemplate, updatePromptTemplate } from "./lib/content-generation-client.js";
 import { createRun, updateRunStatus, addRunCosts } from "./lib/runs-client.js";
@@ -377,6 +378,25 @@ app.post("/chat", requireAuth, async (req, res) => {
             wfParams,
           );
         }
+
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
+      // Built-in workflow node config update tool
+      if (call.name === "update_workflow_node_config") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const result = await updateWorkflowNodeConfig(
+          args.workflowId as string,
+          args.nodeId as string,
+          args.configUpdates as Record<string, unknown>,
+          {
+            orgId,
+            userId,
+            runId: runId!,
+            trackingHeaders: Object.keys(trackingHeaders).length > 0 ? trackingHeaders as Record<string, string> : undefined,
+          },
+        );
 
         toolCalls.push({ name: call.name, args, result });
         return { name: call.name, result };

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -134,12 +134,40 @@ export const UPDATE_PROMPT_TEMPLATE_TOOL: FunctionDeclaration = {
   },
 };
 
+export const UPDATE_WORKFLOW_NODE_CONFIG_TOOL: FunctionDeclaration = {
+  name: "update_workflow_node_config",
+  description:
+    "Update the static config of a specific node in a workflow's DAG. Fetches the current DAG, merges your config changes into the target node, and saves. Use this to change node parameters like prompt type, target URL, call-to-action, etc.",
+  parameters: {
+    type: Type.OBJECT,
+    properties: {
+      workflowId: {
+        type: Type.STRING,
+        description:
+          "UUID of the workflow to update. If available in context, use it directly.",
+      },
+      nodeId: {
+        type: Type.STRING,
+        description:
+          "ID of the node to update (e.g. 'email-generate', 'email-send')",
+      },
+      configUpdates: {
+        type: Type.OBJECT,
+        description:
+          "Key-value pairs to merge into the node's config. Only specified keys are changed; others are preserved. Example: {\"body\": {\"type\": \"cold-email-v3\"}}",
+      },
+    },
+    required: ["workflowId", "nodeId", "configUpdates"],
+  },
+};
+
 export const BUILTIN_TOOLS: FunctionDeclaration[] = [
   REQUEST_USER_INPUT_TOOL,
   UPDATE_WORKFLOW_TOOL,
   VALIDATE_WORKFLOW_TOOL,
   GET_PROMPT_TEMPLATE_TOOL,
   UPDATE_PROMPT_TEMPLATE_TOOL,
+  UPDATE_WORKFLOW_NODE_CONFIG_TOOL,
 ];
 
 export interface FunctionCall {

--- a/src/lib/workflow-client.ts
+++ b/src/lib/workflow-client.ts
@@ -31,10 +31,47 @@ function buildHeaders(params: WorkflowCallParams): Record<string, string> {
   return headers;
 }
 
+export interface WorkflowResponse {
+  id: string;
+  dag: {
+    nodes: Array<{
+      id: string;
+      type: string;
+      config?: Record<string, unknown>;
+      inputMapping?: Record<string, string>;
+      retries?: number;
+    }>;
+    edges: Array<{ from: string; to: string; condition?: string }>;
+    onError?: string;
+  };
+  [key: string]: unknown;
+}
+
+export async function getWorkflow(
+  workflowId: string,
+  params: WorkflowCallParams,
+): Promise<WorkflowResponse> {
+  const url = `${WORKFLOW_SERVICE_URL}/workflows/${encodeURIComponent(workflowId)}`;
+  const res = await fetch(url, {
+    method: "GET",
+    headers: buildHeaders(params),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `[workflow-client] GET /workflows/${workflowId} returned ${res.status}: ${text}`,
+    );
+  }
+
+  return (await res.json()) as WorkflowResponse;
+}
+
 export interface UpdateWorkflowBody {
   name?: string;
   description?: string;
   tags?: string[];
+  dag?: WorkflowResponse["dag"];
 }
 
 export async function updateWorkflow(
@@ -57,6 +94,35 @@ export async function updateWorkflow(
   }
 
   return await res.json();
+}
+
+export async function updateWorkflowNodeConfig(
+  workflowId: string,
+  nodeId: string,
+  configUpdates: Record<string, unknown>,
+  params: WorkflowCallParams,
+): Promise<unknown> {
+  // 1. Fetch the current workflow to get the full DAG
+  const workflow = await getWorkflow(workflowId, params);
+
+  if (!workflow.dag) {
+    throw new Error(`[workflow-client] Workflow ${workflowId} has no DAG`);
+  }
+
+  // 2. Find the target node
+  const nodeIndex = workflow.dag.nodes.findIndex((n) => n.id === nodeId);
+  if (nodeIndex === -1) {
+    throw new Error(
+      `[workflow-client] Node "${nodeId}" not found in workflow ${workflowId}. Available nodes: ${workflow.dag.nodes.map((n) => n.id).join(", ")}`,
+    );
+  }
+
+  // 3. Merge config updates into the node's existing config
+  const node = workflow.dag.nodes[nodeIndex];
+  node.config = { ...node.config, ...configUpdates };
+
+  // 4. PUT the updated DAG back
+  return updateWorkflow(workflowId, { dag: workflow.dag }, params);
 }
 
 export async function validateWorkflow(

--- a/tests/unit/gemini.test.ts
+++ b/tests/unit/gemini.test.ts
@@ -722,7 +722,8 @@ describe("BUILTIN_TOOLS", () => {
     expect(names).toContain("validate_workflow");
     expect(names).toContain("get_prompt_template");
     expect(names).toContain("update_prompt_template");
-    expect(BUILTIN_TOOLS).toHaveLength(5);
+    expect(names).toContain("update_workflow_node_config");
+    expect(BUILTIN_TOOLS).toHaveLength(6);
   });
 });
 

--- a/tests/unit/workflow-client.test.ts
+++ b/tests/unit/workflow-client.test.ts
@@ -174,3 +174,122 @@ describe("validateWorkflow", () => {
     );
   });
 });
+
+describe("getWorkflow", () => {
+  it("sends GET with correct URL and headers", async () => {
+    const mockWorkflow = { id: "wf-1", dag: { nodes: [], edges: [] } };
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockWorkflow),
+    });
+
+    const { getWorkflow } = await loadModule();
+    const result = await getWorkflow("wf-1", { orgId: "org-1", userId: "user-1", runId: "run-1" });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://workflow.test.local/workflows/wf-1",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          "x-api-key": "test-wf-key",
+          "x-org-id": "org-1",
+        }),
+      }),
+    );
+    expect(result).toEqual(mockWorkflow);
+  });
+
+  it("throws on HTTP error", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve("Not found"),
+    });
+
+    const { getWorkflow } = await loadModule();
+    await expect(
+      getWorkflow("wf-bad", { orgId: "o", userId: "u", runId: "r" }),
+    ).rejects.toThrow(/returned 404/);
+  });
+});
+
+describe("updateWorkflowNodeConfig", () => {
+  it("fetches workflow, merges config, and PUTs the updated DAG", async () => {
+    const existingWorkflow = {
+      id: "wf-1",
+      dag: {
+        nodes: [
+          { id: "email-generate", type: "http.call", config: { body: { type: "cold-email" }, path: "/generate", method: "POST", service: "content-generation" } },
+          { id: "email-send", type: "http.call", config: { path: "/send", method: "POST", service: "email-gateway" } },
+        ],
+        edges: [{ from: "email-generate", to: "email-send" }],
+      },
+    };
+
+    const updatedWorkflow = { ...existingWorkflow, updatedAt: "2026-03-18T00:00:00Z" };
+
+    (fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(existingWorkflow) }) // GET
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(updatedWorkflow) }); // PUT
+
+    const { updateWorkflowNodeConfig } = await loadModule();
+    const result = await updateWorkflowNodeConfig(
+      "wf-1",
+      "email-generate",
+      { body: { type: "cold-email-v3" } },
+      { orgId: "org-1", userId: "user-1", runId: "run-1" },
+    );
+
+    // Verify GET was called first
+    expect((fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe("https://workflow.test.local/workflows/wf-1");
+    expect((fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].method).toBe("GET");
+
+    // Verify PUT was called with merged config
+    const putBody = JSON.parse((fetch as ReturnType<typeof vi.fn>).mock.calls[1][1].body);
+    expect(putBody.dag.nodes[0].config.body.type).toBe("cold-email-v3");
+    // Preserved other config keys
+    expect(putBody.dag.nodes[0].config.path).toBe("/generate");
+    expect(putBody.dag.nodes[0].config.service).toBe("content-generation");
+    // Other nodes unchanged
+    expect(putBody.dag.nodes[1].id).toBe("email-send");
+
+    expect(result).toEqual(updatedWorkflow);
+  });
+
+  it("throws when node is not found in DAG", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        id: "wf-1",
+        dag: { nodes: [{ id: "step-1", type: "http.call" }], edges: [] },
+      }),
+    });
+
+    const { updateWorkflowNodeConfig } = await loadModule();
+    await expect(
+      updateWorkflowNodeConfig(
+        "wf-1",
+        "nonexistent-node",
+        { body: { type: "v2" } },
+        { orgId: "o", userId: "u", runId: "r" },
+      ),
+    ).rejects.toThrow(/Node "nonexistent-node" not found/);
+  });
+
+  it("throws when workflow has no DAG", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: "wf-1", dag: null }),
+    });
+
+    const { updateWorkflowNodeConfig } = await loadModule();
+    await expect(
+      updateWorkflowNodeConfig(
+        "wf-1",
+        "step-1",
+        { body: {} },
+        { orgId: "o", userId: "u", runId: "r" },
+      ),
+    ).rejects.toThrow(/has no DAG/);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `update_workflow_node_config` tool: fetches a workflow's DAG, merges config updates into a specific node, and PUTs the updated DAG back
- Adds `getWorkflow` helper to workflow-client for fetching workflow details
- Extends `UpdateWorkflowBody` to accept `dag` for full DAG updates
- Enables end-to-end prompt iteration: chatbot can now create a new prompt version AND wire it into the workflow automatically

## Example use case
User asks chatbot to improve cold-email prompt → chatbot creates `cold-email-v3` via `update_prompt_template` → chatbot updates the `email-generate` node config to use `cold-email-v3` via `update_workflow_node_config`

## Test plan
- [x] Unit tests for `getWorkflow` (2 tests)
- [x] Unit tests for `updateWorkflowNodeConfig` (3 tests: merge config, node not found, no DAG)
- [x] Updated `BUILTIN_TOOLS` test (now 6 tools)
- [x] All 157 unit tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)