### PR TITLE
feat: add list_available_services built-in tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ After a tool result, more `token` events follow with the AI's continuation.
 | `validate_workflow` | Validates a workflow's DAG structure via workflow-service `POST /workflows/{id}/validate` |
 | `get_prompt_template` | Retrieves a stored prompt template by type from content-generation `GET /prompts?type=...` |
 | `update_prompt_template` | Creates a new version of an existing prompt template via content-generation `PUT /prompts` (auto-versions: e.g. `cold-email` → `cold-email-v2`) |
+| `list_available_services` | Lists all available microservices and their API endpoints from api-registry `GET /llm-context`. Use before modifying DAGs to know valid `http.call` targets. |
 | `request_user_input` | Asks the user for structured input (see Input Request below) |
 
 **Native Gemini tools** (always enabled, invoked automatically by the model):
@@ -219,6 +220,8 @@ Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token st
 | `WORKFLOW_SERVICE_API_KEY` | No | API key for workflow-service (built-in workflow tools fail if unset) |
 | `CONTENT_GENERATION_SERVICE_URL` | No | Content-generation service endpoint (default: `https://content-generation.distribute.you`) |
 | `CONTENT_GENERATION_SERVICE_API_KEY` | No | API key for content-generation service (get_prompt_template tool fails if unset) |
+| `API_REGISTRY_SERVICE_URL` | No | API registry service endpoint (default: `https://api-registry.distribute.you`) |
+| `API_REGISTRY_SERVICE_API_KEY` | No | API key for api-registry service (list_available_services tool fails if unset) |
 | `PORT` | No | Server port (default: `3002`) |
 
 ## Database

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import {
   updateWorkflowNodeConfig,
 } from "./lib/workflow-client.js";
 import { getPromptTemplate, updatePromptTemplate } from "./lib/content-generation-client.js";
+import { listAvailableServices } from "./lib/api-registry-client.js";
 import { createRun, updateRunStatus, addRunCosts } from "./lib/runs-client.js";
 import { resolveKey, type ResolvedKey } from "./lib/key-client.js";
 import { ChatRequestSchema, AppConfigRequestSchema, PlatformConfigRequestSchema } from "./schemas.js";
@@ -437,6 +438,18 @@ app.post("/chat", requireAuth, async (req, res) => {
         );
 
         toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
+      // Built-in api-registry tool
+      if (call.name === "list_available_services") {
+        const result = await listAvailableServices({
+          orgId,
+          userId,
+          runId: runId!,
+        });
+
+        toolCalls.push({ name: call.name, args: {}, result });
         return { name: call.name, result };
       }
 

--- a/src/lib/api-registry-client.ts
+++ b/src/lib/api-registry-client.ts
@@ -1,0 +1,62 @@
+const API_REGISTRY_SERVICE_URL =
+  process.env.API_REGISTRY_SERVICE_URL || "https://api-registry.distribute.you";
+const API_REGISTRY_SERVICE_API_KEY = process.env.API_REGISTRY_SERVICE_API_KEY;
+
+export interface ApiRegistryCallParams {
+  orgId: string;
+  userId: string;
+  runId: string;
+}
+
+export interface EndpointSummary {
+  method: string;
+  path: string;
+  summary: string;
+  params?: Array<{ name: string; in: string; required: boolean; type?: string }>;
+  bodyFields?: string[];
+}
+
+export interface ServiceSummary {
+  service: string;
+  baseUrl: string;
+  title?: string;
+  description?: string;
+  error?: string;
+  endpoints: EndpointSummary[];
+}
+
+export interface LlmContextResponse {
+  _description: string;
+  _usage: string;
+  services: ServiceSummary[];
+}
+
+export async function listAvailableServices(
+  params: ApiRegistryCallParams,
+): Promise<LlmContextResponse> {
+  if (!API_REGISTRY_SERVICE_API_KEY) {
+    throw new Error(
+      "[api-registry-client] API_REGISTRY_SERVICE_API_KEY is required",
+    );
+  }
+
+  const url = `${API_REGISTRY_SERVICE_URL}/llm-context`;
+  const res = await fetch(url, {
+    method: "GET",
+    headers: {
+      "x-api-key": API_REGISTRY_SERVICE_API_KEY,
+      "x-org-id": params.orgId,
+      "x-user-id": params.userId,
+      "x-run-id": params.runId,
+    },
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `[api-registry-client] GET /llm-context returned ${res.status}: ${text}`,
+    );
+  }
+
+  return (await res.json()) as LlmContextResponse;
+}

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -161,6 +161,16 @@ export const UPDATE_WORKFLOW_NODE_CONFIG_TOOL: FunctionDeclaration = {
   },
 };
 
+export const LIST_AVAILABLE_SERVICES_TOOL: FunctionDeclaration = {
+  name: "list_available_services",
+  description:
+    "List all available microservices and their API endpoints. Returns a compact summary of every service (name, base URL, description) and each endpoint (method, path, summary, parameters). Use this before modifying a workflow DAG to know which services and endpoints can be used in http.call nodes.",
+  parameters: {
+    type: Type.OBJECT,
+    properties: {},
+  },
+};
+
 export const BUILTIN_TOOLS: FunctionDeclaration[] = [
   REQUEST_USER_INPUT_TOOL,
   UPDATE_WORKFLOW_TOOL,
@@ -168,6 +178,7 @@ export const BUILTIN_TOOLS: FunctionDeclaration[] = [
   GET_PROMPT_TEMPLATE_TOOL,
   UPDATE_PROMPT_TEMPLATE_TOOL,
   UPDATE_WORKFLOW_NODE_CONFIG_TOOL,
+  LIST_AVAILABLE_SERVICES_TOOL,
 ];
 
 export interface FunctionCall {

--- a/tests/unit/api-registry-client.test.ts
+++ b/tests/unit/api-registry-client.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.stubGlobal("fetch", vi.fn());
+
+async function loadModule() {
+  vi.resetModules();
+  process.env.API_REGISTRY_SERVICE_URL = "https://api-registry.test.local";
+  process.env.API_REGISTRY_SERVICE_API_KEY = "test-registry-key";
+  return import("../../src/lib/api-registry-client.js");
+}
+
+describe("listAvailableServices", () => {
+  beforeEach(() => {
+    vi.mocked(fetch).mockReset();
+  });
+
+  it("calls GET /llm-context with correct headers", async () => {
+    const mockResponse = {
+      _description: "API registry",
+      _usage: "Use service names in http.call nodes",
+      services: [
+        {
+          service: "content-generation",
+          baseUrl: "https://content-generation.distribute.you",
+          title: "Content Generation",
+          description: "Generates content",
+          endpoints: [
+            { method: "GET", path: "/prompts", summary: "Get prompts" },
+            { method: "POST", path: "/generate", summary: "Generate content" },
+          ],
+        },
+      ],
+    };
+
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    } as Response);
+
+    const { listAvailableServices } = await loadModule();
+    const result = await listAvailableServices({
+      orgId: "org-1",
+      userId: "user-1",
+      runId: "run-1",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api-registry.test.local/llm-context",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          "x-api-key": "test-registry-key",
+          "x-org-id": "org-1",
+          "x-user-id": "user-1",
+          "x-run-id": "run-1",
+        }),
+      }),
+    );
+    expect(result.services).toHaveLength(1);
+    expect(result.services[0].service).toBe("content-generation");
+    expect(result.services[0].endpoints).toHaveLength(2);
+  });
+
+  it("throws on HTTP error", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: () => Promise.resolve("Unauthorized"),
+    } as Response);
+
+    const { listAvailableServices } = await loadModule();
+    await expect(
+      listAvailableServices({ orgId: "o", userId: "u", runId: "r" }),
+    ).rejects.toThrow(/returned 401/);
+  });
+
+  it("throws when API key is missing", async () => {
+    vi.resetModules();
+    process.env.API_REGISTRY_SERVICE_URL = "https://api-registry.test.local";
+    delete process.env.API_REGISTRY_SERVICE_API_KEY;
+
+    const { listAvailableServices } = await import(
+      "../../src/lib/api-registry-client.js"
+    );
+    await expect(
+      listAvailableServices({ orgId: "o", userId: "u", runId: "r" }),
+    ).rejects.toThrow(/API_REGISTRY_SERVICE_API_KEY is required/);
+  });
+
+  it("uses default URL when env var is not set", async () => {
+    vi.resetModules();
+    delete process.env.API_REGISTRY_SERVICE_URL;
+    process.env.API_REGISTRY_SERVICE_API_KEY = "test-key";
+
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ services: [] }),
+    } as Response);
+
+    const { listAvailableServices } = await import(
+      "../../src/lib/api-registry-client.js"
+    );
+    await listAvailableServices({ orgId: "o", userId: "u", runId: "r" });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api-registry.distribute.you/llm-context",
+      expect.anything(),
+    );
+  });
+});

--- a/tests/unit/gemini.test.ts
+++ b/tests/unit/gemini.test.ts
@@ -723,7 +723,8 @@ describe("BUILTIN_TOOLS", () => {
     expect(names).toContain("get_prompt_template");
     expect(names).toContain("update_prompt_template");
     expect(names).toContain("update_workflow_node_config");
-    expect(BUILTIN_TOOLS).toHaveLength(6);
+    expect(names).toContain("list_available_services");
+    expect(BUILTIN_TOOLS).toHaveLength(7);
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds `list_available_services` tool that calls api-registry `GET /llm-context` to return all microservices and their API endpoints
- New `api-registry-client.ts` with `listAvailableServices()` function
- Enables the chatbot to know which services/endpoints are valid `http.call` targets before modifying workflow DAGs

## Test plan
- [x] Unit tests for `listAvailableServices` (4 tests: happy path, HTTP error, missing API key, default URL)
- [x] Updated `BUILTIN_TOOLS` test (now 7 tools)
- [x] All 161 unit tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)