### PR TITLE
feat: add get_workflow_details and generate_workflow tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ After a tool result, more `token` events follow with the AI's continuation.
 
 | Tool | Description |
 |---|---|
+| `get_workflow_details` | Fetches full workflow details (DAG, metadata, status) via workflow-service `GET /workflows/{id}` |
+| `generate_workflow` | Generates a new workflow from natural language description via workflow-service `POST /workflows/generate`. Auto-validates and deploys. |
 | `update_workflow` | Updates a workflow's metadata (name, description, tags) via workflow-service `PUT /workflows/{id}` |
 | `update_workflow_node_config` | Updates a specific node's config in a workflow's DAG (e.g. change prompt type on `email-generate` node). Fetches, merges, and saves. |
 | `validate_workflow` | Validates a workflow's DAG structure via workflow-service `POST /workflows/{id}/validate` |

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,8 @@ import {
   updateWorkflow,
   validateWorkflow,
   updateWorkflowNodeConfig,
+  getWorkflow,
+  generateWorkflow,
 } from "./lib/workflow-client.js";
 import { getPromptTemplate, updatePromptTemplate } from "./lib/content-generation-client.js";
 import { listAvailableServices } from "./lib/api-registry-client.js";
@@ -353,6 +355,43 @@ app.post("/chat", requireAuth, async (req, res) => {
         });
         emittedInputRequest = true;
         return "input_request";
+      }
+
+      // Built-in workflow read tool
+      if (call.name === "get_workflow_details") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const result = await getWorkflow(
+          args.workflowId as string,
+          {
+            orgId,
+            userId,
+            runId: runId!,
+            trackingHeaders: Object.keys(trackingHeaders).length > 0 ? trackingHeaders as Record<string, string> : undefined,
+          },
+        );
+
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
+      // Built-in workflow generate tool
+      if (call.name === "generate_workflow") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const result = await generateWorkflow(
+          {
+            description: args.description as string,
+            hints: args.hints as { services?: string[]; nodeTypes?: string[]; expectedInputs?: string[] } | undefined,
+          },
+          {
+            orgId,
+            userId,
+            runId: runId!,
+            trackingHeaders: Object.keys(trackingHeaders).length > 0 ? trackingHeaders as Record<string, string> : undefined,
+          },
+        );
+
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
       }
 
       // Built-in workflow tools

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -171,6 +171,45 @@ export const LIST_AVAILABLE_SERVICES_TOOL: FunctionDeclaration = {
   },
 };
 
+export const GET_WORKFLOW_DETAILS_TOOL: FunctionDeclaration = {
+  name: "get_workflow_details",
+  description:
+    "Fetch the full details of a workflow including its DAG, metadata, and status. Use this to inspect the current state of a workflow, especially after making changes via update_workflow or update_workflow_node_config.",
+  parameters: {
+    type: Type.OBJECT,
+    properties: {
+      workflowId: {
+        type: Type.STRING,
+        description:
+          "UUID of the workflow to fetch. If available in context, use it directly — do NOT ask the user for it.",
+      },
+    },
+    required: ["workflowId"],
+  },
+};
+
+export const GENERATE_WORKFLOW_TOOL: FunctionDeclaration = {
+  name: "generate_workflow",
+  description:
+    "Generate a new workflow from a natural language description. Uses an LLM to create a valid DAG, validates it, and deploys it automatically. Use this when the user wants to create a brand new workflow from scratch.",
+  parameters: {
+    type: Type.OBJECT,
+    properties: {
+      description: {
+        type: Type.STRING,
+        description:
+          "Natural language description of the desired workflow. Be specific about the steps, services, and data flow. Minimum 10 characters.",
+      },
+      hints: {
+        type: Type.OBJECT,
+        description:
+          "Optional hints to guide generation. Can include: services (array of service names to scope to), nodeTypes (suggested node types), expectedInputs (expected flow_input field names like 'campaignId').",
+      },
+    },
+    required: ["description"],
+  },
+};
+
 export const BUILTIN_TOOLS: FunctionDeclaration[] = [
   REQUEST_USER_INPUT_TOOL,
   UPDATE_WORKFLOW_TOOL,
@@ -179,6 +218,8 @@ export const BUILTIN_TOOLS: FunctionDeclaration[] = [
   UPDATE_PROMPT_TEMPLATE_TOOL,
   UPDATE_WORKFLOW_NODE_CONFIG_TOOL,
   LIST_AVAILABLE_SERVICES_TOOL,
+  GET_WORKFLOW_DETAILS_TOOL,
+  GENERATE_WORKFLOW_TOOL,
 ];
 
 export interface FunctionCall {

--- a/src/lib/workflow-client.ts
+++ b/src/lib/workflow-client.ts
@@ -125,6 +125,42 @@ export async function updateWorkflowNodeConfig(
   return updateWorkflow(workflowId, { dag: workflow.dag }, params);
 }
 
+export interface GenerateWorkflowBody {
+  description: string;
+  hints?: {
+    services?: string[];
+    nodeTypes?: string[];
+    expectedInputs?: string[];
+  };
+  style?: {
+    type: "human" | "brand";
+    humanId?: string;
+    brandId?: string;
+    name: string;
+  };
+}
+
+export async function generateWorkflow(
+  body: GenerateWorkflowBody,
+  params: WorkflowCallParams,
+): Promise<unknown> {
+  const url = `${WORKFLOW_SERVICE_URL}/workflows/generate`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: buildHeaders(params),
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `[workflow-client] POST /workflows/generate returned ${res.status}: ${text}`,
+    );
+  }
+
+  return await res.json();
+}
+
 export async function validateWorkflow(
   workflowId: string,
   params: WorkflowCallParams,

--- a/tests/unit/gemini.test.ts
+++ b/tests/unit/gemini.test.ts
@@ -724,7 +724,9 @@ describe("BUILTIN_TOOLS", () => {
     expect(names).toContain("update_prompt_template");
     expect(names).toContain("update_workflow_node_config");
     expect(names).toContain("list_available_services");
-    expect(BUILTIN_TOOLS).toHaveLength(7);
+    expect(names).toContain("get_workflow_details");
+    expect(names).toContain("generate_workflow");
+    expect(BUILTIN_TOOLS).toHaveLength(9);
   });
 });
 

--- a/tests/unit/workflow-client.test.ts
+++ b/tests/unit/workflow-client.test.ts
@@ -293,3 +293,80 @@ describe("updateWorkflowNodeConfig", () => {
     ).rejects.toThrow(/has no DAG/);
   });
 });
+
+describe("generateWorkflow", () => {
+  it("sends POST /workflows/generate with description and hints", async () => {
+    const mockResponse = {
+      workflow: { id: "wf-new", name: "sales-email-cold-outreach-nova" },
+      dag: { nodes: [{ id: "step-1", type: "http.call" }], edges: [] },
+      category: "sales",
+      channel: "email",
+      audienceType: "cold-outreach",
+      generatedDescription: "A cold email workflow",
+    };
+
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    });
+
+    const { generateWorkflow } = await loadModule();
+    const result = await generateWorkflow(
+      {
+        description: "Create a cold email workflow that fetches a lead, generates an email, and sends it",
+        hints: { services: ["lead", "content-generation", "email-gateway"] },
+      },
+      { orgId: "org-1", userId: "user-1", runId: "run-1" },
+    );
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://workflow.test.local/workflows/generate",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "x-api-key": "test-wf-key",
+          "x-org-id": "org-1",
+        }),
+      }),
+    );
+
+    const body = JSON.parse((fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
+    expect(body.description).toContain("cold email workflow");
+    expect(body.hints.services).toContain("lead");
+
+    expect(result).toEqual(mockResponse);
+  });
+
+  it("throws on HTTP error", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 422,
+      text: () => Promise.resolve("Invalid DAG"),
+    });
+
+    const { generateWorkflow } = await loadModule();
+    await expect(
+      generateWorkflow(
+        { description: "bad workflow" },
+        { orgId: "o", userId: "u", runId: "r" },
+      ),
+    ).rejects.toThrow(/returned 422/);
+  });
+
+  it("works without hints", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ workflow: { id: "wf-1" } }),
+    });
+
+    const { generateWorkflow } = await loadModule();
+    await generateWorkflow(
+      { description: "Simple workflow that sends an email" },
+      { orgId: "o", userId: "u", runId: "r" },
+    );
+
+    const body = JSON.parse((fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
+    expect(body.description).toBe("Simple workflow that sends an email");
+    expect(body.hints).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `get_workflow_details` tool: fetches full workflow (DAG, metadata, status) via `GET /workflows/{id}`
- Adds `generate_workflow` tool: creates a new workflow from natural language via `POST /workflows/generate` with optional hints (services, nodeTypes, expectedInputs)
- Adds `generateWorkflow` function to workflow-client with `GenerateWorkflowBody` interface
- Chat-service now has 9 built-in tools covering the full workflow lifecycle

## Test plan
- [x] Unit tests for `generateWorkflow` (3 tests: with hints, HTTP error, without hints)
- [x] Updated `BUILTIN_TOOLS` test (now 9 tools)
- [x] All 164 unit tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)