### PR TITLE
feat: adjust built-in tools per dashboard feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,9 @@ After a tool result, more `token` events follow with the AI's continuation.
 | Tool | Description |
 |---|---|
 | `get_workflow_details` | Fetches full workflow details (DAG, metadata, status) via workflow-service `GET /workflows/{id}` |
-| `generate_workflow` | Generates a new workflow from natural language description via workflow-service `POST /workflows/generate`. Auto-validates and deploys. |
-| `update_workflow` | Updates a workflow's metadata (name, description, tags) via workflow-service `PUT /workflows/{id}` |
+| `get_workflow_required_providers` | Returns BYOK providers needed to execute a workflow via `GET /workflows/{id}/required-providers`. Proactively warns about missing keys. |
+| `list_workflows` | Lists/searches workflows by category, channel, tags, or free-text search via `GET /workflows` |
+| `update_workflow` | Updates a workflow's metadata (name, description, tags) and/or DAG structure via workflow-service `PUT /workflows/{id}` |
 | `update_workflow_node_config` | Updates a specific node's config in a workflow's DAG (e.g. change prompt type on `email-generate` node). Fetches, merges, and saves. |
 | `validate_workflow` | Validates a workflow's DAG structure via workflow-service `POST /workflows/{id}/validate` |
 | `get_prompt_template` | Retrieves a stored prompt template by type from content-generation `GET /prompts?type=...` |

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,8 @@ import {
   validateWorkflow,
   updateWorkflowNodeConfig,
   getWorkflow,
-  generateWorkflow,
+  getWorkflowRequiredProviders,
+  listWorkflows,
 } from "./lib/workflow-client.js";
 import { getPromptTemplate, updatePromptTemplate } from "./lib/content-generation-client.js";
 import { listAvailableServices } from "./lib/api-registry-client.js";
@@ -374,26 +375,6 @@ app.post("/chat", requireAuth, async (req, res) => {
         return { name: call.name, result };
       }
 
-      // Built-in workflow generate tool
-      if (call.name === "generate_workflow") {
-        const args = (call.args as Record<string, unknown>) || {};
-        const result = await generateWorkflow(
-          {
-            description: args.description as string,
-            hints: args.hints as { services?: string[]; nodeTypes?: string[]; expectedInputs?: string[] } | undefined,
-          },
-          {
-            orgId,
-            userId,
-            runId: runId!,
-            trackingHeaders: Object.keys(trackingHeaders).length > 0 ? trackingHeaders as Record<string, string> : undefined,
-          },
-        );
-
-        toolCalls.push({ name: call.name, args, result });
-        return { name: call.name, result };
-      }
-
       // Built-in workflow tools
       if (call.name === "update_workflow" || call.name === "validate_workflow") {
         const wfParams = {
@@ -409,7 +390,7 @@ app.post("/chat", requireAuth, async (req, res) => {
           const { workflowId, ...updateBody } = args;
           result = await updateWorkflow(
             workflowId as string,
-            updateBody as { name?: string; description?: string; tags?: string[] },
+            updateBody as import("./lib/workflow-client.js").UpdateWorkflowBody,
             wfParams,
           );
         } else {
@@ -418,6 +399,45 @@ app.post("/chat", requireAuth, async (req, res) => {
             wfParams,
           );
         }
+
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
+      // Built-in workflow required providers tool
+      if (call.name === "get_workflow_required_providers") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const result = await getWorkflowRequiredProviders(
+          args.workflowId as string,
+          {
+            orgId,
+            userId,
+            runId: runId!,
+            trackingHeaders: Object.keys(trackingHeaders).length > 0 ? trackingHeaders as Record<string, string> : undefined,
+          },
+        );
+
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
+      // Built-in list workflows tool
+      if (call.name === "list_workflows") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const result = await listWorkflows(
+          {
+            category: args.category as string | undefined,
+            channel: args.channel as string | undefined,
+            tags: args.tags as string[] | undefined,
+            search: args.search as string | undefined,
+          },
+          {
+            orgId,
+            userId,
+            runId: runId!,
+            trackingHeaders: Object.keys(trackingHeaders).length > 0 ? trackingHeaders as Record<string, string> : undefined,
+          },
+        );
 
         toolCalls.push({ name: call.name, args, result });
         return { name: call.name, result };

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -45,7 +45,7 @@ export const REQUEST_USER_INPUT_TOOL: FunctionDeclaration = {
 export const UPDATE_WORKFLOW_TOOL: FunctionDeclaration = {
   name: "update_workflow",
   description:
-    "Update a workflow's metadata (name, description, tags). Use this to directly modify a workflow when the user asks — do not use input_request to confirm values you already know.",
+    "Update a workflow's metadata (name, description, tags) and/or its DAG structure. Use this to directly modify a workflow when the user asks — do not use input_request to confirm values you already know. For structural changes (adding/removing nodes or edges), pass the full dag object.",
   parameters: {
     type: Type.OBJECT,
     properties: {
@@ -66,6 +66,11 @@ export const UPDATE_WORKFLOW_TOOL: FunctionDeclaration = {
         type: Type.ARRAY,
         items: { type: Type.STRING },
         description: "New tags for the workflow (optional)",
+      },
+      dag: {
+        type: Type.OBJECT,
+        description:
+          "Full DAG definition with nodes and edges. Use for structural changes like adding/removing nodes or edges. Must include the complete DAG — partial updates are not supported. Use get_workflow_details first to read the current DAG, then modify and pass the full result.",
       },
     },
     required: ["workflowId"],
@@ -210,6 +215,51 @@ export const GENERATE_WORKFLOW_TOOL: FunctionDeclaration = {
   },
 };
 
+export const GET_WORKFLOW_REQUIRED_PROVIDERS_TOOL: FunctionDeclaration = {
+  name: "get_workflow_required_providers",
+  description:
+    "Get the BYOK (Bring Your Own Key) providers required to execute a workflow. Returns which external API keys the user needs to configure before running the workflow (e.g. Stripe, Anthropic). Use this proactively to warn users about missing keys before they try to execute.",
+  parameters: {
+    type: Type.OBJECT,
+    properties: {
+      workflowId: {
+        type: Type.STRING,
+        description:
+          "UUID of the workflow. If available in context, use it directly — do NOT ask the user for it.",
+      },
+    },
+    required: ["workflowId"],
+  },
+};
+
+export const LIST_WORKFLOWS_TOOL: FunctionDeclaration = {
+  name: "list_workflows",
+  description:
+    "List or search existing workflows. Use this when the user asks to see their workflows, find a specific workflow, or check if a workflow already exists for a given purpose.",
+  parameters: {
+    type: Type.OBJECT,
+    properties: {
+      category: {
+        type: Type.STRING,
+        description: "Filter by category: 'sales' or 'pr' (optional)",
+      },
+      channel: {
+        type: Type.STRING,
+        description: "Filter by channel: 'email' (optional)",
+      },
+      tags: {
+        type: Type.ARRAY,
+        items: { type: Type.STRING },
+        description: "Filter by tags (optional)",
+      },
+      search: {
+        type: Type.STRING,
+        description: "Free-text search across workflow names and descriptions (optional)",
+      },
+    },
+  },
+};
+
 export const BUILTIN_TOOLS: FunctionDeclaration[] = [
   REQUEST_USER_INPUT_TOOL,
   UPDATE_WORKFLOW_TOOL,
@@ -219,7 +269,8 @@ export const BUILTIN_TOOLS: FunctionDeclaration[] = [
   UPDATE_WORKFLOW_NODE_CONFIG_TOOL,
   LIST_AVAILABLE_SERVICES_TOOL,
   GET_WORKFLOW_DETAILS_TOOL,
-  GENERATE_WORKFLOW_TOOL,
+  GET_WORKFLOW_REQUIRED_PROVIDERS_TOOL,
+  LIST_WORKFLOWS_TOOL,
 ];
 
 export interface FunctionCall {

--- a/src/lib/workflow-client.ts
+++ b/src/lib/workflow-client.ts
@@ -161,6 +161,62 @@ export async function generateWorkflow(
   return await res.json();
 }
 
+export async function getWorkflowRequiredProviders(
+  workflowId: string,
+  params: WorkflowCallParams,
+): Promise<unknown> {
+  const url = `${WORKFLOW_SERVICE_URL}/workflows/${encodeURIComponent(workflowId)}/required-providers`;
+  const res = await fetch(url, {
+    method: "GET",
+    headers: buildHeaders(params),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `[workflow-client] GET /workflows/${workflowId}/required-providers returned ${res.status}: ${text}`,
+    );
+  }
+
+  return await res.json();
+}
+
+export interface ListWorkflowsParams {
+  category?: string;
+  channel?: string;
+  tags?: string[];
+  search?: string;
+}
+
+export async function listWorkflows(
+  filters: ListWorkflowsParams,
+  params: WorkflowCallParams,
+): Promise<unknown> {
+  const query = new URLSearchParams();
+  if (filters.category) query.set("category", filters.category);
+  if (filters.channel) query.set("channel", filters.channel);
+  if (filters.tags?.length) {
+    for (const tag of filters.tags) query.append("tags", tag);
+  }
+  if (filters.search) query.set("search", filters.search);
+
+  const qs = query.toString();
+  const url = `${WORKFLOW_SERVICE_URL}/workflows${qs ? `?${qs}` : ""}`;
+  const res = await fetch(url, {
+    method: "GET",
+    headers: buildHeaders(params),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `[workflow-client] GET /workflows returned ${res.status}: ${text}`,
+    );
+  }
+
+  return await res.json();
+}
+
 export async function validateWorkflow(
   workflowId: string,
   params: WorkflowCallParams,

--- a/tests/unit/gemini.test.ts
+++ b/tests/unit/gemini.test.ts
@@ -725,8 +725,10 @@ describe("BUILTIN_TOOLS", () => {
     expect(names).toContain("update_workflow_node_config");
     expect(names).toContain("list_available_services");
     expect(names).toContain("get_workflow_details");
-    expect(names).toContain("generate_workflow");
-    expect(BUILTIN_TOOLS).toHaveLength(9);
+    expect(names).toContain("get_workflow_required_providers");
+    expect(names).toContain("list_workflows");
+    expect(names).not.toContain("generate_workflow");
+    expect(BUILTIN_TOOLS).toHaveLength(10);
   });
 });
 

--- a/tests/unit/workflow-client.test.ts
+++ b/tests/unit/workflow-client.test.ts
@@ -370,3 +370,96 @@ describe("generateWorkflow", () => {
     expect(body.hints).toBeUndefined();
   });
 });
+
+describe("getWorkflowRequiredProviders", () => {
+  it("sends GET to /workflows/{id}/required-providers", async () => {
+    const mockProviders = { providers: ["stripe", "anthropic"] };
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockProviders),
+    });
+
+    const { getWorkflowRequiredProviders } = await loadModule();
+    const result = await getWorkflowRequiredProviders("wf-1", {
+      orgId: "org-1",
+      userId: "user-1",
+      runId: "run-1",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://workflow.test.local/workflows/wf-1/required-providers",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          "x-api-key": "test-wf-key",
+          "x-org-id": "org-1",
+        }),
+      }),
+    );
+    expect(result).toEqual(mockProviders);
+  });
+
+  it("throws on HTTP error", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve("Not found"),
+    });
+
+    const { getWorkflowRequiredProviders } = await loadModule();
+    await expect(
+      getWorkflowRequiredProviders("wf-bad", { orgId: "o", userId: "u", runId: "r" }),
+    ).rejects.toThrow(/returned 404/);
+  });
+});
+
+describe("listWorkflows", () => {
+  it("sends GET /workflows with query params", async () => {
+    const mockWorkflows = [{ id: "wf-1", name: "sales-email" }];
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockWorkflows),
+    });
+
+    const { listWorkflows } = await loadModule();
+    const result = await listWorkflows(
+      { category: "sales", channel: "email", tags: ["cold", "outreach"], search: "lead" },
+      { orgId: "org-1", userId: "user-1", runId: "run-1" },
+    );
+
+    const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(calledUrl).toContain("/workflows?");
+    expect(calledUrl).toContain("category=sales");
+    expect(calledUrl).toContain("channel=email");
+    expect(calledUrl).toContain("tags=cold");
+    expect(calledUrl).toContain("tags=outreach");
+    expect(calledUrl).toContain("search=lead");
+    expect(result).toEqual(mockWorkflows);
+  });
+
+  it("sends GET /workflows without query params when no filters", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+    });
+
+    const { listWorkflows } = await loadModule();
+    await listWorkflows({}, { orgId: "o", userId: "u", runId: "r" });
+
+    const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(calledUrl).toBe("https://workflow.test.local/workflows");
+  });
+
+  it("throws on HTTP error", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("Server error"),
+    });
+
+    const { listWorkflows } = await loadModule();
+    await expect(
+      listWorkflows({ category: "sales" }, { orgId: "o", userId: "u", runId: "r" }),
+    ).rejects.toThrow(/returned 500/);
+  });
+});


### PR DESCRIPTION
## Summary
- Remove `generate_workflow` from exposed tools (not ready for chat)
- Add `get_workflow_required_providers`: returns BYOK providers needed before executing (proactive key warnings)
- Add `list_workflows`: search/filter workflows by category, channel, tags, or free-text
- `update_workflow` now accepts `dag` field for structural changes (add/remove nodes/edges)
- Confirmed `list_available_services` already uses `GET /llm-context` (no change needed)

Total: 10 built-in tools.

## Test plan
- [x] Unit tests for `getWorkflowRequiredProviders` (2 tests)
- [x] Unit tests for `listWorkflows` (3 tests: with filters, no filters, HTTP error)
- [x] `generate_workflow` excluded from BUILTIN_TOOLS
- [x] All 169 unit tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)