### PR TITLE
fix: feed tool errors back to Gemini for self-correction

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -616,9 +616,44 @@ app.post("/chat", requireAuth, async (req, res) => {
             const rawMsg = toolErr instanceof Error ? toolErr.message : String(toolErr);
             console.error(`Tool call ${call.name} failed:`, rawMsg);
             const friendly = formatToolError(call.name, rawMsg);
-            const errorContent = ` (Tool call failed: ${friendly.error})`;
-            fullResponse += errorContent;
             sendSSE(res, { type: "tool_result", id: toolCallId, name: call.name, result: friendly });
+
+            // Feed the error back to Gemini so it can self-correct
+            if (depth < MAX_TOOL_CHAIN_DEPTH) {
+              const functionCallPart: Record<string, unknown> = {
+                functionCall: { name: call.name, args: call.args || {} },
+              };
+              if (call.thoughtSignature) {
+                functionCallPart.thoughtSignature = call.thoughtSignature;
+              }
+
+              turnParts.push({
+                role: "model",
+                parts: [functionCallPart as Part],
+              });
+
+              const contStream = gemini.sendFunctionResult(
+                [...geminiHistory, { role: "user", parts: [{ text: message.trim() }] }, ...turnParts],
+                call.name,
+                friendly,
+                allTools,
+              );
+
+              turnParts.push({
+                role: "user",
+                parts: [
+                  {
+                    functionResponse: {
+                      name: call.name,
+                      response: { result: friendly },
+                    },
+                  } as Part,
+                ],
+              });
+
+              await processStream(contStream, depth + 1);
+              return;
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary
- When a tool call fails, the error was sent to the client (SSE) but NOT fed back to Gemini — the stream just ended
- Now the catch block mirrors the happy path: error result is sent to Gemini via `sendFunctionResult`
- Gemini receives the structured `{ error, tool, suggestion }` from PR #73 and can emit a corrected tool call or explain the issue

## Root cause
The catch block at line 615 was a dead end — it called `sendSSE` (client-facing) but did NOT call `sendFunctionResult` (model-facing). The `for...of` loop just continued to the next call or ended the stream.

## Before vs After

**Before:** Tool fails → error SSE sent to client → stream ends → user must manually retry
**After:** Tool fails → error SSE sent to client → error fed back to Gemini → model self-corrects (retry with fixed params or explain to user)

## Test plan
- [x] Build passes
- [x] All 181 unit tests passing
- [x] Manual verification: the catch block now follows the same pattern as the success path (lines 576-614)

🤖 Generated with [Claude Code](https://claude.com/claude-code)