### PR TITLE
fix: reorder context_management edits — clear_thinking must be first

### DIFF
--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -352,6 +352,10 @@ export function createAnthropicClient({ apiKey, systemPrompt }: AnthropicOptions
         context_management: {
           edits: [
             {
+              type: "clear_thinking_20251015",
+              keep: { type: "thinking_turns", value: 2 },
+            },
+            {
               type: "compact_20260112",
               trigger: { type: "input_tokens", value: 100_000 },
               pause_after_compaction: false,
@@ -362,10 +366,6 @@ export function createAnthropicClient({ apiKey, systemPrompt }: AnthropicOptions
               keep: { type: "tool_uses", value: 5 },
               exclude_tools: ["request_user_input"],
               clear_tool_inputs: false,
-            },
-            {
-              type: "clear_thinking_20251015",
-              keep: { type: "thinking_turns", value: 2 },
             },
           ],
         },

--- a/tests/unit/anthropic.test.ts
+++ b/tests/unit/anthropic.test.ts
@@ -105,9 +105,12 @@ describe("createAnthropicClient", () => {
     const editTypes = callArgs.context_management.edits.map(
       (e: { type: string }) => e.type,
     );
-    expect(editTypes).toContain("compact_20260112");
-    expect(editTypes).toContain("clear_tool_uses_20250919");
-    expect(editTypes).toContain("clear_thinking_20251015");
+    // clear_thinking must be first per API requirement
+    expect(editTypes).toEqual([
+      "clear_thinking_20251015",
+      "compact_20260112",
+      "clear_tool_uses_20250919",
+    ]);
   });
 
   it("passes beta headers for compaction", () => {


### PR DESCRIPTION
## Summary

- Reorders `context_management.edits` array so `clear_thinking_20251015` is first, as required by the Anthropic API
- Fixes production 400 error: `"clear_thinking_20251015 must be the first strategy in context_management.edits when provided"`
- Updates test to assert correct ordering with `toEqual` instead of `toContain`

## Test plan

- [x] All 172 unit tests pass
- [x] Test explicitly verifies `clear_thinking` is first in the edits array

🤖 Generated with [Claude Code](https://claude.com/claude-code)