### PR TITLE
fix: prevent stream hang on consecutive user messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ src/
     schema.ts       # sessions + messages + app_configs + platform_configs table definitions
   lib/
     anthropic.ts       # Claude AI client (Sonnet 4.6), streaming + tool calling, adaptive thinking, context management (compaction), built-in tool declarations
+    merge-messages.ts  # Ensures alternating user/assistant roles by merging orphaned consecutive same-role messages
     key-client.ts      # Key-service client for resolving Anthropic keys (platform or BYOK per org)
     runs-client.ts     # RunsService HTTP client for run tracking and cost reporting
     workflow-client.ts              # Workflow-service client for update_workflow and validate_workflow built-in tools

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const openapiPath = join(__dirname, "..", "openapi.json");
 
+import { mergeConsecutiveMessages } from "./lib/merge-messages.js";
+
 const app = express();
 app.use(cors());
 app.use(express.json());
@@ -260,7 +262,8 @@ app.post("/chat", requireAuth, async (req, res) => {
     });
 
     // Build Anthropic message history — use contentBlocks if available (preserves compaction blocks)
-    const anthropicHistory: Anthropic.MessageParam[] = history
+    // Ensure alternating user/assistant roles (merge consecutive same-role messages)
+    const rawHistory: Anthropic.MessageParam[] = history
       .filter((m) => m.role !== "tool")
       .map((m) => ({
         role: m.role as "user" | "assistant",
@@ -268,6 +271,8 @@ app.post("/chat", requireAuth, async (req, res) => {
           ? m.contentBlocks as Anthropic.ContentBlockParam[]
           : m.content) as string | Anthropic.ContentBlockParam[],
       }));
+
+    const anthropicHistory = mergeConsecutiveMessages(rawHistory);
 
     // Save user message
     await db.insert(messages).values({
@@ -327,6 +332,15 @@ app.post("/chat", requireAuth, async (req, res) => {
     }
 
     const allTools = BUILTIN_TOOLS;
+
+    // Detect client disconnect to abort in-flight streams
+    const abortController = new AbortController();
+    res.on("close", () => {
+      if (!res.writableEnded) {
+        console.log(`[chat] session="${currentSessionId}" client disconnected — aborting stream`);
+        abortController.abort();
+      }
+    });
 
     /**
      * Execute a server-side tool (built-in) and return the result.
@@ -541,27 +555,42 @@ app.post("/chat", requireAuth, async (req, res) => {
 
     agenticLoop:
     while (depth <= MAX_TOOL_CHAIN_DEPTH) {
-      let currentBlockType: string | null = null;
-      const stream = claude.createStream(turnMessages, allTools);
+      // Abort early if client already disconnected
+      if (abortController.signal.aborted) {
+        console.log(`[chat] session="${currentSessionId}" aborted before depth=${depth}`);
+        break;
+      }
 
-      for await (const event of stream) {
-        if (event.type === "content_block_start") {
-          currentBlockType = event.content_block.type;
-          if (currentBlockType === "thinking") {
-            sendSSE(res, { type: "thinking_start" });
+      let currentBlockType: string | null = null;
+      const stream = claude.createStream(turnMessages, allTools, abortController.signal);
+
+      try {
+        for await (const event of stream) {
+          if (event.type === "content_block_start") {
+            currentBlockType = event.content_block.type;
+            if (currentBlockType === "thinking") {
+              sendSSE(res, { type: "thinking_start" });
+            }
+          } else if (event.type === "content_block_delta") {
+            if (event.delta.type === "thinking_delta") {
+              sendSSE(res, { type: "thinking_delta", thinking: event.delta.thinking });
+            } else if (event.delta.type === "text_delta") {
+              bufferToken(event.delta.text);
+            }
+          } else if (event.type === "content_block_stop") {
+            if (currentBlockType === "thinking") {
+              sendSSE(res, { type: "thinking_stop" });
+            }
+            currentBlockType = null;
           }
-        } else if (event.type === "content_block_delta") {
-          if (event.delta.type === "thinking_delta") {
-            sendSSE(res, { type: "thinking_delta", thinking: event.delta.thinking });
-          } else if (event.delta.type === "text_delta") {
-            bufferToken(event.delta.text);
-          }
-        } else if (event.type === "content_block_stop") {
-          if (currentBlockType === "thinking") {
-            sendSSE(res, { type: "thinking_stop" });
-          }
-          currentBlockType = null;
         }
+      } catch (streamErr) {
+        // If aborted due to client disconnect, exit cleanly
+        if (abortController.signal.aborted) {
+          console.log(`[chat] session="${currentSessionId}" stream aborted (client disconnect)`);
+          return;
+        }
+        throw streamErr; // Re-throw to outer catch for error SSE
       }
 
       const finalMessage = await stream.finalMessage();

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -333,6 +333,7 @@ export function createAnthropicClient({ apiKey, systemPrompt }: AnthropicOptions
     createStream(
       messages: Anthropic.MessageParam[],
       tools?: Anthropic.Tool[],
+      signal?: AbortSignal,
     ) {
       // Build params with beta context management for compaction
       const params = {
@@ -374,6 +375,7 @@ export function createAnthropicClient({ apiKey, systemPrompt }: AnthropicOptions
       return client.messages.stream(
         params as unknown as Anthropic.MessageCreateParamsStreaming,
         {
+          signal,
           headers: {
             "anthropic-beta": "compact-2026-01-12,context-management-2025-06-27",
           },

--- a/src/lib/merge-messages.ts
+++ b/src/lib/merge-messages.ts
@@ -1,0 +1,27 @@
+import type Anthropic from "@anthropic-ai/sdk";
+
+/**
+ * Merge consecutive same-role messages into one (Anthropic requires alternating roles).
+ * This can happen if a previous request errored after saving the user message
+ * but before saving the assistant response, leaving orphan user messages.
+ */
+export function mergeConsecutiveMessages(
+  msgs: Anthropic.MessageParam[],
+): Anthropic.MessageParam[] {
+  const result: Anthropic.MessageParam[] = [];
+  for (const msg of msgs) {
+    const prev = result[result.length - 1];
+    if (prev && prev.role === msg.role) {
+      const prevContent = Array.isArray(prev.content)
+        ? prev.content
+        : [{ type: "text" as const, text: prev.content }];
+      const curContent = Array.isArray(msg.content)
+        ? msg.content
+        : [{ type: "text" as const, text: msg.content }];
+      prev.content = [...prevContent, ...curContent];
+    } else {
+      result.push({ ...msg });
+    }
+  }
+  return result;
+}

--- a/tests/unit/anthropic.test.ts
+++ b/tests/unit/anthropic.test.ts
@@ -127,6 +127,18 @@ describe("createAnthropicClient", () => {
     );
   });
 
+  it("forwards abort signal to stream options", () => {
+    const client = createAnthropicClient({
+      apiKey: "test-key",
+      systemPrompt: TEST_PROMPT,
+    });
+    const ac = new AbortController();
+    client.createStream([{ role: "user", content: "hello" }], undefined, ac.signal);
+
+    const opts = mockStream.mock.calls.at(-1)?.[1];
+    expect(opts.signal).toBe(ac.signal);
+  });
+
   it("passes tools when provided", () => {
     const client = createAnthropicClient({
       apiKey: "test-key",

--- a/tests/unit/merge-messages.test.ts
+++ b/tests/unit/merge-messages.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import type Anthropic from "@anthropic-ai/sdk";
+
+import { mergeConsecutiveMessages } from "../../src/lib/merge-messages.js";
+
+describe("mergeConsecutiveMessages", () => {
+  it("passes through alternating messages unchanged", () => {
+    const msgs: Anthropic.MessageParam[] = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "how are you" },
+    ];
+    const result = mergeConsecutiveMessages(msgs);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ role: "user", content: "hello" });
+    expect(result[1]).toEqual({ role: "assistant", content: "hi" });
+    expect(result[2]).toEqual({ role: "user", content: "how are you" });
+  });
+
+  it("merges consecutive user messages (orphaned from failed requests)", () => {
+    const msgs: Anthropic.MessageParam[] = [
+      { role: "user", content: "first attempt" },
+      { role: "user", content: "second attempt" },
+      { role: "assistant", content: "response" },
+    ];
+    const result = mergeConsecutiveMessages(msgs);
+    expect(result).toHaveLength(2);
+    expect(result[0].role).toBe("user");
+    expect(result[0].content).toEqual([
+      { type: "text", text: "first attempt" },
+      { type: "text", text: "second attempt" },
+    ]);
+    expect(result[1]).toEqual({ role: "assistant", content: "response" });
+  });
+
+  it("merges three consecutive user messages", () => {
+    const msgs: Anthropic.MessageParam[] = [
+      { role: "user", content: "a" },
+      { role: "user", content: "b" },
+      { role: "user", content: "c" },
+    ];
+    const result = mergeConsecutiveMessages(msgs);
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toEqual([
+      { type: "text", text: "a" },
+      { type: "text", text: "b" },
+      { type: "text", text: "c" },
+    ]);
+  });
+
+  it("handles array content blocks (contentBlocks from assistant)", () => {
+    const msgs: Anthropic.MessageParam[] = [
+      { role: "user", content: "hello" },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "first part" },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "second part" },
+        ],
+      },
+    ];
+    const result = mergeConsecutiveMessages(msgs);
+    expect(result).toHaveLength(2);
+    expect(result[1].role).toBe("assistant");
+    expect(result[1].content).toEqual([
+      { type: "text", text: "first part" },
+      { type: "text", text: "second part" },
+    ]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(mergeConsecutiveMessages([])).toEqual([]);
+  });
+
+  it("does not mutate input array", () => {
+    const msgs: Anthropic.MessageParam[] = [
+      { role: "user", content: "a" },
+      { role: "user", content: "b" },
+    ];
+    const original = JSON.parse(JSON.stringify(msgs));
+    mergeConsecutiveMessages(msgs);
+    expect(msgs).toEqual(original);
+  });
+});


### PR DESCRIPTION
## Summary

- **Root cause**: When a previous request errors (e.g. the 400 from PR #77) after saving the user message but before saving the assistant response, orphan user messages accumulate in the DB. On the next request, Anthropic receives consecutive same-role messages which violates its alternating-messages requirement, causing the stream to hang indefinitely with no error logged.
- Extracts `mergeConsecutiveMessages()` utility that merges orphan same-role messages before sending to the API
- Adds `AbortController` + `res.on('close')` to detect client disconnect and abort in-flight Anthropic streams
- Passes abort signal through to the Anthropic SDK for clean cancellation
- Adds try/catch around stream iteration for clean abort handling

## Test plan

- [x] 6 new unit tests for `mergeConsecutiveMessages` (alternating passthrough, consecutive merge, triple merge, array content blocks, empty input, no input mutation)
- [x] 1 new test for abort signal forwarding to Anthropic SDK
- [x] All 179 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)