### PR TITLE
feat: credit authorization before platform LLM calls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,4 +4,6 @@ KEY_SERVICE_API_KEY=your-key-service-api-key
 MCP_SERVER_URL=https://mcp.mcpfactory.org
 RUNS_SERVICE_URL=https://runs.mcpfactory.org
 RUNS_SERVICE_API_KEY=your-runs-service-api-key
+BILLING_SERVICE_URL=https://billing.mcpfactory.org
+BILLING_SERVICE_API_KEY=your-billing-service-api-key
 PORT=3002

--- a/README.md
+++ b/README.md
@@ -177,6 +177,21 @@ data: {"type":"buttons","buttons":[{"label":"Send Cold Emails","value":"Send Col
 ```
 Buttons are extracted from the AI response when it ends with lines formatted as `- [Button Text]`. The button `label` and `value` are both set to the text inside the brackets. Button lines are stripped from the token stream to prevent duplication.
 
+### Credit Authorization (402)
+
+Before streaming, the service checks credit authorization via billing-service for platform-key requests (`keySource: "platform"`). BYOK orgs (`keySource: "org"`) skip this check — they pay their provider directly.
+
+If the org has insufficient credits, the endpoint returns a **402 JSON response** (not SSE):
+```json
+{
+  "error": "Insufficient credits",
+  "balance_cents": 5,
+  "required_cents": 25
+}
+```
+
+If billing-service is unreachable, a **502 JSON response** is returned instead.
+
 ### 7. Error (optional)
 Sent when the AI model returns an empty response (context overflow, safety filter) or an unexpected error occurs:
 ```
@@ -216,6 +231,8 @@ Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token st
 | `CONTENT_GENERATION_SERVICE_API_KEY` | No | API key for content-generation service (get_prompt_template tool fails if unset) |
 | `API_REGISTRY_SERVICE_URL` | No | API registry service endpoint (default: `https://api-registry.distribute.you`) |
 | `API_REGISTRY_SERVICE_API_KEY` | No | API key for api-registry service (list_available_services tool fails if unset) |
+| `BILLING_SERVICE_URL` | No | Billing-service endpoint (default: `https://billing.mcpfactory.org`) |
+| `BILLING_SERVICE_API_KEY` | Yes | API key for billing-service — required for credit authorization on platform-key requests |
 | `PORT` | No | Server port (default: `3002`) |
 
 ## Database
@@ -284,6 +301,7 @@ src/
   lib/
     anthropic.ts       # Claude AI client (Sonnet 4.6), streaming + tool calling, adaptive thinking, context management (compaction), built-in tool declarations
     merge-messages.ts  # Ensures alternating user/assistant roles by merging orphaned consecutive same-role messages
+    billing-client.ts  # Billing-service client for credit authorization before platform-key operations
     key-client.ts      # Key-service client for resolving Anthropic keys (platform or BYOK per org)
     runs-client.ts     # RunsService HTTP client for run tracking and cost reporting
     workflow-client.ts              # Workflow-service client for update_workflow and validate_workflow built-in tools

--- a/openapi.json
+++ b/openapi.json
@@ -370,6 +370,30 @@
         ],
         "additionalProperties": false
       },
+      "InsufficientCreditsResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "enum": [
+              "Insufficient credits"
+            ]
+          },
+          "balance_cents": {
+            "type": "number",
+            "description": "Current credit balance in USD cents"
+          },
+          "required_cents": {
+            "type": "number",
+            "description": "Estimated cost of this request in USD cents"
+          }
+        },
+        "required": [
+          "error",
+          "balance_cents",
+          "required_cents"
+        ]
+      },
       "ChatRequest": {
         "type": "object",
         "properties": {
@@ -763,6 +787,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Insufficient credits — the org's credit balance is too low to cover this request. Only applies to platform-key usage (BYOK orgs are not charged).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsufficientCreditsResponse"
                 }
               }
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
   createAnthropicClient,
   buildSystemPrompt,
   BUILTIN_TOOLS,
+  MODEL,
 } from "./lib/anthropic.js";
 import {
   updateWorkflow,
@@ -26,6 +27,7 @@ import { listAvailableServices } from "./lib/api-registry-client.js";
 import { createRun, updateRunStatus, addRunCosts } from "./lib/runs-client.js";
 import { formatToolError } from "./lib/tool-errors.js";
 import { resolveKey, type ResolvedKey } from "./lib/key-client.js";
+import { authorizeCredits, estimateChatCostCents } from "./lib/billing-client.js";
 import { ChatRequestSchema, AppConfigRequestSchema, PlatformConfigRequestSchema } from "./schemas.js";
 import { requireAuth, requireInternalAuth, type AuthLocals } from "./middleware/auth.js";
 import type { ButtonRecord, ToolCallRecord } from "./db/schema.js";
@@ -188,6 +190,33 @@ app.post("/chat", requireAuth, async (req, res) => {
     return res.status(502).json({
       error: `Failed to resolve Anthropic API key. Ensure the key is configured in key-service.`,
     });
+  }
+
+  // Credit authorization — only for platform keys (BYOK orgs pay their provider directly)
+  if (resolvedKey.keySource === "platform") {
+    const estimatedCostCents = estimateChatCostCents(message.length);
+    try {
+      const authResult = await authorizeCredits({
+        requiredCents: estimatedCostCents,
+        description: `chat — ${MODEL}`,
+        orgId,
+        userId,
+        runId: callerRunId,
+        trackingHeaders: Object.keys(trackingHeaders).length > 0 ? trackingHeaders : undefined,
+      });
+      if (!authResult.sufficient) {
+        return res.status(402).json({
+          error: "Insufficient credits",
+          balance_cents: authResult.balance_cents,
+          required_cents: estimatedCostCents,
+        });
+      }
+    } catch (billingErr) {
+      console.error(`[chat] billing authorization failed for org="${orgId}":`, billingErr);
+      return res.status(502).json({
+        error: "Billing service unavailable. Please try again.",
+      });
+    }
   }
 
   // SSE headers — disable proxy buffering so tokens stream immediately

--- a/src/lib/billing-client.ts
+++ b/src/lib/billing-client.ts
@@ -1,0 +1,86 @@
+const BILLING_SERVICE_URL =
+  process.env.BILLING_SERVICE_URL || "https://billing.mcpfactory.org";
+const BILLING_SERVICE_API_KEY = process.env.BILLING_SERVICE_API_KEY;
+
+export interface AuthorizeCreditParams {
+  requiredCents: number;
+  description: string;
+  orgId: string;
+  userId: string;
+  runId: string;
+  trackingHeaders?: Record<string, string>;
+}
+
+export interface AuthorizeCreditResult {
+  sufficient: boolean;
+  balance_cents: number;
+}
+
+/**
+ * Estimate the cost in USD cents for a chat turn.
+ *
+ * Uses Claude Sonnet 4.6 pricing:
+ *   Input:  $3  / 1M tokens → 0.0003 cents/token
+ *   Output: $15 / 1M tokens → 0.0015 cents/token
+ *
+ * We estimate input tokens from the message length (~4 chars/token)
+ * and use MAX_TOKENS (16 000) as the worst-case output budget.
+ */
+export function estimateChatCostCents(messageLength: number): number {
+  const estimatedInputTokens = Math.max(Math.ceil(messageLength / 4), 500);
+  const maxOutputTokens = 16_000;
+
+  const inputCostCents = estimatedInputTokens * 0.0003;
+  const outputCostCents = maxOutputTokens * 0.0015;
+
+  return Math.ceil(inputCostCents + outputCostCents);
+}
+
+/**
+ * Request credit authorization from billing-service.
+ * Returns { sufficient, balance_cents }.
+ * Throws on network/server errors.
+ */
+export async function authorizeCredits(
+  params: AuthorizeCreditParams,
+): Promise<AuthorizeCreditResult> {
+  if (!BILLING_SERVICE_API_KEY) {
+    throw new Error(
+      "[billing-client] BILLING_SERVICE_API_KEY is required for credit authorization",
+    );
+  }
+
+  const { requiredCents, description, orgId, userId, runId, trackingHeaders } =
+    params;
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "X-API-Key": BILLING_SERVICE_API_KEY,
+    "x-org-id": orgId,
+    "x-user-id": userId,
+    "x-run-id": runId,
+  };
+  if (trackingHeaders) {
+    for (const [k, v] of Object.entries(trackingHeaders)) {
+      if (v) headers[k] = v;
+    }
+  }
+
+  const res = await fetch(`${BILLING_SERVICE_URL}/v1/credits/authorize`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      required_cents: requiredCents,
+      description,
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `[billing-client] POST /v1/credits/authorize returned ${res.status}: ${text}`,
+    );
+  }
+
+  return (await res.json()) as AuthorizeCreditResult;
+}

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -37,6 +37,18 @@ export const ValidationErrorResponseSchema = z
   })
   .openapi("ValidationErrorResponse");
 
+export const InsufficientCreditsResponseSchema = z
+  .object({
+    error: z.literal("Insufficient credits"),
+    balance_cents: z.number().openapi({
+      description: "Current credit balance in USD cents",
+    }),
+    required_cents: z.number().openapi({
+      description: "Estimated cost of this request in USD cents",
+    }),
+  })
+  .openapi("InsufficientCreditsResponse");
+
 // --- Health ---
 
 export const HealthResponseSchema = z
@@ -448,6 +460,14 @@ Requires app config to be registered first via PUT /config (or platform config v
     401: {
       description: "Missing or invalid x-api-key header",
       content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    402: {
+      description:
+        "Insufficient credits — the org's credit balance is too low to cover this request. " +
+        "Only applies to platform-key usage (BYOK orgs are not charged).",
+      content: {
+        "application/json": { schema: InsufficientCreditsResponseSchema },
+      },
     },
     404: {
       description:

--- a/tests/unit/billing-client.test.ts
+++ b/tests/unit/billing-client.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  process.env.BILLING_SERVICE_API_KEY = "test-billing-key";
+  process.env.BILLING_SERVICE_URL = "https://billing.test.local";
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.restoreAllMocks();
+});
+
+async function loadModule() {
+  vi.resetModules();
+  return import("../../src/lib/billing-client.js");
+}
+
+describe("estimateChatCostCents", () => {
+  it("returns a positive integer for a short message", async () => {
+    const { estimateChatCostCents } = await loadModule();
+    const cost = estimateChatCostCents(100);
+    expect(cost).toBeGreaterThan(0);
+    expect(Number.isInteger(cost)).toBe(true);
+  });
+
+  it("returns a higher estimate for longer messages", async () => {
+    const { estimateChatCostCents } = await loadModule();
+    const short = estimateChatCostCents(100);
+    const long = estimateChatCostCents(100_000);
+    expect(long).toBeGreaterThanOrEqual(short);
+  });
+
+  it("uses at least 500 input tokens even for tiny messages", async () => {
+    const { estimateChatCostCents } = await loadModule();
+    const tiny = estimateChatCostCents(4); // 1 token from length
+    const minInput = estimateChatCostCents(2000); // 500 tokens from length
+    // Both should use 500 input tokens minimum, so same cost
+    expect(tiny).toBe(minInput);
+  });
+});
+
+describe("authorizeCredits", () => {
+  it("sends POST with correct headers and body when sufficient", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ sufficient: true, balance_cents: 5000 }),
+    });
+
+    const { authorizeCredits } = await loadModule();
+    const result = await authorizeCredits({
+      requiredCents: 25,
+      description: "chat — claude-sonnet-4-6",
+      orgId: "org-123",
+      userId: "user-456",
+      runId: "run-789",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://billing.test.local/v1/credits/authorize",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          "X-API-Key": "test-billing-key",
+          "x-org-id": "org-123",
+          "x-user-id": "user-456",
+          "x-run-id": "run-789",
+        }),
+        body: JSON.stringify({
+          required_cents: 25,
+          description: "chat — claude-sonnet-4-6",
+        }),
+      }),
+    );
+    expect(result).toEqual({ sufficient: true, balance_cents: 5000 });
+  });
+
+  it("returns sufficient: false when balance is too low", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ sufficient: false, balance_cents: 5 }),
+    });
+
+    const { authorizeCredits } = await loadModule();
+    const result = await authorizeCredits({
+      requiredCents: 25,
+      description: "chat — claude-sonnet-4-6",
+      orgId: "org-123",
+      userId: "user-456",
+      runId: "run-789",
+    });
+
+    expect(result.sufficient).toBe(false);
+    expect(result.balance_cents).toBe(5);
+  });
+
+  it("forwards tracking headers when provided", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ sufficient: true, balance_cents: 5000 }),
+    });
+
+    const { authorizeCredits } = await loadModule();
+    await authorizeCredits({
+      requiredCents: 25,
+      description: "chat — claude-sonnet-4-6",
+      orgId: "org-123",
+      userId: "user-456",
+      runId: "run-789",
+      trackingHeaders: {
+        "x-campaign-id": "camp-1",
+        "x-brand-id": "brand-2",
+        "x-workflow-name": "wf-3",
+      },
+    });
+
+    const callArgs = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const headers = callArgs[1].headers;
+    expect(headers["x-campaign-id"]).toBe("camp-1");
+    expect(headers["x-brand-id"]).toBe("brand-2");
+    expect(headers["x-workflow-name"]).toBe("wf-3");
+  });
+
+  it("throws on HTTP error from billing-service", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("Internal Server Error"),
+    });
+
+    const { authorizeCredits } = await loadModule();
+    await expect(
+      authorizeCredits({
+        requiredCents: 25,
+        description: "chat — claude-sonnet-4-6",
+        orgId: "org-123",
+        userId: "user-456",
+        runId: "run-789",
+      }),
+    ).rejects.toThrow(/returned 500/);
+  });
+
+  it("throws on network error", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("ECONNREFUSED"),
+    );
+
+    const { authorizeCredits } = await loadModule();
+    await expect(
+      authorizeCredits({
+        requiredCents: 25,
+        description: "chat — claude-sonnet-4-6",
+        orgId: "org-123",
+        userId: "user-456",
+        runId: "run-789",
+      }),
+    ).rejects.toThrow("ECONNREFUSED");
+  });
+
+  it("throws when BILLING_SERVICE_API_KEY is not set", async () => {
+    delete process.env.BILLING_SERVICE_API_KEY;
+
+    const { authorizeCredits } = await loadModule();
+    await expect(
+      authorizeCredits({
+        requiredCents: 25,
+        description: "chat — claude-sonnet-4-6",
+        orgId: "org-123",
+        userId: "user-456",
+        runId: "run-789",
+      }),
+    ).rejects.toThrow(/BILLING_SERVICE_API_KEY is required/);
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("uses default BILLING_SERVICE_URL when not set", async () => {
+    delete process.env.BILLING_SERVICE_URL;
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ sufficient: true, balance_cents: 1000 }),
+    });
+
+    const { authorizeCredits } = await loadModule();
+    await authorizeCredits({
+      requiredCents: 25,
+      description: "chat — claude-sonnet-4-6",
+      orgId: "org-123",
+      userId: "user-456",
+      runId: "run-789",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://billing.mcpfactory.org/v1/credits/authorize",
+      expect.anything(),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `src/lib/billing-client.ts` with `authorizeCredits()` and `estimateChatCostCents()` for pre-flight credit checks via billing-service
- In `/chat`, after key resolution: if `keySource === "platform"`, calls `POST /v1/credits/authorize` with estimated cost. Returns **402** with `{ balance_cents, required_cents }` if insufficient. BYOK orgs (`keySource: "org"`) skip entirely.
- Authorization happens **before** SSE headers are set, so the 402 is a clean JSON response (not mid-stream)
- Adds `InsufficientCreditsResponse` schema to OpenAPI spec (402 on `/chat`)

## Test plan
- [x] 10 new unit tests in `tests/unit/billing-client.test.ts` covering:
  - Cost estimation (positive, proportional to message length, minimum input tokens)
  - Successful authorization (sufficient: true)
  - Insufficient credits (sufficient: false)
  - Tracking header forwarding
  - HTTP error handling (500, network errors)
  - Missing API key guard
  - Default URL fallback
- [x] All 188 unit tests pass
- [x] Build + OpenAPI generation succeeds
- [ ] Integration: verify 402 response with real billing-service when balance is low
- [ ] Integration: verify BYOK requests skip billing check entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)