### PR TITLE
fix: billing auth sends costName+quantity, not cents

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ import { listAvailableServices } from "./lib/api-registry-client.js";
 import { createRun, updateRunStatus, addRunCosts } from "./lib/runs-client.js";
 import { formatToolError } from "./lib/tool-errors.js";
 import { resolveKey, type ResolvedKey } from "./lib/key-client.js";
-import { authorizeCredits, estimateChatCostCents } from "./lib/billing-client.js";
+import { authorizeCredits } from "./lib/billing-client.js";
 import { ChatRequestSchema, AppConfigRequestSchema, PlatformConfigRequestSchema } from "./schemas.js";
 import { requireAuth, requireInternalAuth, type AuthLocals } from "./middleware/auth.js";
 import type { ButtonRecord, ToolCallRecord } from "./db/schema.js";
@@ -194,10 +194,16 @@ app.post("/chat", requireAuth, async (req, res) => {
 
   // Credit authorization — only for platform keys (BYOK orgs pay their provider directly)
   if (resolvedKey.keySource === "platform") {
-    const estimatedCostCents = estimateChatCostCents(message.length);
+    // Estimate token quantities: input from message length (~4 chars/token, min 500),
+    // output from MAX_TOKENS budget (16 000)
+    const estimatedInputTokens = Math.max(Math.ceil(message.length / 4), 500);
+    const estimatedOutputTokens = 16_000;
     try {
       const authResult = await authorizeCredits({
-        requiredCents: estimatedCostCents,
+        items: [
+          { costName: `${MODEL}-tokens-input`, quantity: estimatedInputTokens },
+          { costName: `${MODEL}-tokens-output`, quantity: estimatedOutputTokens },
+        ],
         description: `chat — ${MODEL}`,
         orgId,
         userId,
@@ -208,7 +214,7 @@ app.post("/chat", requireAuth, async (req, res) => {
         return res.status(402).json({
           error: "Insufficient credits",
           balance_cents: authResult.balance_cents,
-          required_cents: estimatedCostCents,
+          required_cents: authResult.required_cents,
         });
       }
     } catch (billingErr) {

--- a/src/lib/billing-client.ts
+++ b/src/lib/billing-client.ts
@@ -2,8 +2,13 @@ const BILLING_SERVICE_URL =
   process.env.BILLING_SERVICE_URL || "https://billing.mcpfactory.org";
 const BILLING_SERVICE_API_KEY = process.env.BILLING_SERVICE_API_KEY;
 
+export interface CreditItem {
+  costName: string;
+  quantity: number;
+}
+
 export interface AuthorizeCreditParams {
-  requiredCents: number;
+  items: CreditItem[];
   description: string;
   orgId: string;
   userId: string;
@@ -14,31 +19,13 @@ export interface AuthorizeCreditParams {
 export interface AuthorizeCreditResult {
   sufficient: boolean;
   balance_cents: number;
-}
-
-/**
- * Estimate the cost in USD cents for a chat turn.
- *
- * Uses Claude Sonnet 4.6 pricing:
- *   Input:  $3  / 1M tokens → 0.0003 cents/token
- *   Output: $15 / 1M tokens → 0.0015 cents/token
- *
- * We estimate input tokens from the message length (~4 chars/token)
- * and use MAX_TOKENS (16 000) as the worst-case output budget.
- */
-export function estimateChatCostCents(messageLength: number): number {
-  const estimatedInputTokens = Math.max(Math.ceil(messageLength / 4), 500);
-  const maxOutputTokens = 16_000;
-
-  const inputCostCents = estimatedInputTokens * 0.0003;
-  const outputCostCents = maxOutputTokens * 0.0015;
-
-  return Math.ceil(inputCostCents + outputCostCents);
+  required_cents: number;
 }
 
 /**
  * Request credit authorization from billing-service.
- * Returns { sufficient, balance_cents }.
+ * Send costName + quantity items — billing-service resolves the price.
+ * Returns { sufficient, balance_cents, required_cents }.
  * Throws on network/server errors.
  */
 export async function authorizeCredits(
@@ -50,8 +37,7 @@ export async function authorizeCredits(
     );
   }
 
-  const { requiredCents, description, orgId, userId, runId, trackingHeaders } =
-    params;
+  const { items, description, orgId, userId, runId, trackingHeaders } = params;
 
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
@@ -69,10 +55,7 @@ export async function authorizeCredits(
   const res = await fetch(`${BILLING_SERVICE_URL}/v1/credits/authorize`, {
     method: "POST",
     headers,
-    body: JSON.stringify({
-      required_cents: requiredCents,
-      description,
-    }),
+    body: JSON.stringify({ items, description }),
   });
 
   if (!res.ok) {

--- a/tests/unit/billing-client.test.ts
+++ b/tests/unit/billing-client.test.ts
@@ -18,40 +18,20 @@ async function loadModule() {
   return import("../../src/lib/billing-client.js");
 }
 
-describe("estimateChatCostCents", () => {
-  it("returns a positive integer for a short message", async () => {
-    const { estimateChatCostCents } = await loadModule();
-    const cost = estimateChatCostCents(100);
-    expect(cost).toBeGreaterThan(0);
-    expect(Number.isInteger(cost)).toBe(true);
-  });
-
-  it("returns a higher estimate for longer messages", async () => {
-    const { estimateChatCostCents } = await loadModule();
-    const short = estimateChatCostCents(100);
-    const long = estimateChatCostCents(100_000);
-    expect(long).toBeGreaterThanOrEqual(short);
-  });
-
-  it("uses at least 500 input tokens even for tiny messages", async () => {
-    const { estimateChatCostCents } = await loadModule();
-    const tiny = estimateChatCostCents(4); // 1 token from length
-    const minInput = estimateChatCostCents(2000); // 500 tokens from length
-    // Both should use 500 input tokens minimum, so same cost
-    expect(tiny).toBe(minInput);
-  });
-});
-
 describe("authorizeCredits", () => {
-  it("sends POST with correct headers and body when sufficient", async () => {
+  it("sends POST with items array and correct headers", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ sufficient: true, balance_cents: 5000 }),
+      json: () =>
+        Promise.resolve({ sufficient: true, balance_cents: 5000, required_cents: 25 }),
     });
 
     const { authorizeCredits } = await loadModule();
     const result = await authorizeCredits({
-      requiredCents: 25,
+      items: [
+        { costName: "claude-sonnet-4-6-tokens-input", quantity: 1000 },
+        { costName: "claude-sonnet-4-6-tokens-output", quantity: 500 },
+      ],
       description: "chat — claude-sonnet-4-6",
       orgId: "org-123",
       userId: "user-456",
@@ -70,23 +50,27 @@ describe("authorizeCredits", () => {
           "x-run-id": "run-789",
         }),
         body: JSON.stringify({
-          required_cents: 25,
+          items: [
+            { costName: "claude-sonnet-4-6-tokens-input", quantity: 1000 },
+            { costName: "claude-sonnet-4-6-tokens-output", quantity: 500 },
+          ],
           description: "chat — claude-sonnet-4-6",
         }),
       }),
     );
-    expect(result).toEqual({ sufficient: true, balance_cents: 5000 });
+    expect(result).toEqual({ sufficient: true, balance_cents: 5000, required_cents: 25 });
   });
 
-  it("returns sufficient: false when balance is too low", async () => {
+  it("returns sufficient: false with required_cents when balance is too low", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ sufficient: false, balance_cents: 5 }),
+      json: () =>
+        Promise.resolve({ sufficient: false, balance_cents: 5, required_cents: 25 }),
     });
 
     const { authorizeCredits } = await loadModule();
     const result = await authorizeCredits({
-      requiredCents: 25,
+      items: [{ costName: "claude-sonnet-4-6-tokens-output", quantity: 16000 }],
       description: "chat — claude-sonnet-4-6",
       orgId: "org-123",
       userId: "user-456",
@@ -95,17 +79,19 @@ describe("authorizeCredits", () => {
 
     expect(result.sufficient).toBe(false);
     expect(result.balance_cents).toBe(5);
+    expect(result.required_cents).toBe(25);
   });
 
   it("forwards tracking headers when provided", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ sufficient: true, balance_cents: 5000 }),
+      json: () =>
+        Promise.resolve({ sufficient: true, balance_cents: 5000, required_cents: 10 }),
     });
 
     const { authorizeCredits } = await loadModule();
     await authorizeCredits({
-      requiredCents: 25,
+      items: [{ costName: "claude-sonnet-4-6-tokens-input", quantity: 500 }],
       description: "chat — claude-sonnet-4-6",
       orgId: "org-123",
       userId: "user-456",
@@ -134,7 +120,7 @@ describe("authorizeCredits", () => {
     const { authorizeCredits } = await loadModule();
     await expect(
       authorizeCredits({
-        requiredCents: 25,
+        items: [{ costName: "claude-sonnet-4-6-tokens-input", quantity: 500 }],
         description: "chat — claude-sonnet-4-6",
         orgId: "org-123",
         userId: "user-456",
@@ -151,7 +137,7 @@ describe("authorizeCredits", () => {
     const { authorizeCredits } = await loadModule();
     await expect(
       authorizeCredits({
-        requiredCents: 25,
+        items: [{ costName: "claude-sonnet-4-6-tokens-input", quantity: 500 }],
         description: "chat — claude-sonnet-4-6",
         orgId: "org-123",
         userId: "user-456",
@@ -166,7 +152,7 @@ describe("authorizeCredits", () => {
     const { authorizeCredits } = await loadModule();
     await expect(
       authorizeCredits({
-        requiredCents: 25,
+        items: [{ costName: "claude-sonnet-4-6-tokens-input", quantity: 500 }],
         description: "chat — claude-sonnet-4-6",
         orgId: "org-123",
         userId: "user-456",
@@ -181,12 +167,13 @@ describe("authorizeCredits", () => {
     delete process.env.BILLING_SERVICE_URL;
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ sufficient: true, balance_cents: 1000 }),
+      json: () =>
+        Promise.resolve({ sufficient: true, balance_cents: 1000, required_cents: 10 }),
     });
 
     const { authorizeCredits } = await loadModule();
     await authorizeCredits({
-      requiredCents: 25,
+      items: [{ costName: "claude-sonnet-4-6-tokens-input", quantity: 500 }],
       description: "chat — claude-sonnet-4-6",
       orgId: "org-123",
       userId: "user-456",


### PR DESCRIPTION
## Summary
- Updates billing authorization to send `items: [{ costName, quantity }]` instead of `required_cents` — billing-service resolves prices internally
- Removes `estimateChatCostCents()` — no longer needed since we don't estimate USD cents ourselves
- Uses the same `costName` format as runs-service cost recording (e.g. `claude-sonnet-4-6-tokens-input`)
- `required_cents` is now read from the billing-service response (not computed locally)

## Test plan
- [x] Updated all 7 billing-client unit tests to use `items` array contract
- [x] All 185 unit tests pass
- [x] Build + OpenAPI generation succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)