### PR TITLE
feat: add POST /complete synchronous LLM endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,47 @@ Response:
 }
 ```
 
+## Synchronous Completion
+
+`POST /complete` — one-shot, non-streaming LLM call for service-to-service use.
+
+Request body:
+```json
+{
+  "message": "Given this brand context, generate 10 Google search queries...",
+  "systemPrompt": "You are a PR research assistant...",
+  "responseFormat": "json",
+  "temperature": 0.3,
+  "maxTokens": 2000
+}
+```
+
+- `message` (required) — the prompt to send to the LLM
+- `systemPrompt` (required) — inline system prompt (no pre-registered config needed)
+- `responseFormat` (optional) — set to `"json"` to instruct the model to return valid JSON. The parsed result appears in the `json` field.
+- `temperature` (optional) — sampling temperature, 0–2 (default: model default)
+- `maxTokens` (optional) — max output tokens, 1–64000 (default: 16000)
+
+Response:
+```json
+{
+  "content": "...",
+  "json": { "queries": ["..."] },
+  "tokensInput": 450,
+  "tokensOutput": 800,
+  "model": "claude-sonnet-4-6"
+}
+```
+
+- `content` — raw text response (always present)
+- `json` — parsed JSON object (only when `responseFormat: "json"` and model returned valid JSON)
+- `tokensInput` / `tokensOutput` — token usage
+- `model` — model used
+
+Unlike POST /chat, this endpoint is **stateless** (no sessions), accepts an **inline systemPrompt**, and returns **JSON** instead of SSE. Run tracking and billing work identically to POST /chat.
+
+Error responses: 400 (validation), 401 (auth), 402 (insufficient credits), 502 (upstream failure).
+
 ## SSE Protocol
 
 `POST /chat` with headers `Content-Type: application/json`, `x-api-key`, `x-org-id`, `x-user-id`.
@@ -290,7 +331,7 @@ Uses `node:20-alpine`. Requires Node >= 20.
 
 ```
 src/
-  index.ts          # Express server, /chat, /config, /platform-config, /health, /openapi.json
+  index.ts          # Express server, /chat, /complete, /config, /platform-config, /health, /openapi.json
   types.ts          # SSE event TypeScript interfaces
   schemas.ts        # Zod schemas, OpenAPI registry, and request/response types
   middleware/
@@ -299,7 +340,7 @@ src/
     index.ts        # Drizzle client init
     schema.ts       # sessions + messages + app_configs + platform_configs table definitions
   lib/
-    anthropic.ts       # Claude AI client (Sonnet 4.6), streaming + tool calling, adaptive thinking, context management (compaction), built-in tool declarations
+    anthropic.ts       # Claude AI client (Sonnet 4.6), streaming + non-streaming, tool calling, adaptive thinking, context management (compaction), built-in tool declarations
     merge-messages.ts  # Ensures alternating user/assistant roles by merging orphaned consecutive same-role messages
     billing-client.ts  # Billing-service client for credit authorization before platform-key operations
     key-client.ts      # Key-service client for resolving Anthropic keys (platform or BYOK per org)

--- a/openapi.json
+++ b/openapi.json
@@ -370,6 +370,43 @@
         ],
         "additionalProperties": false
       },
+      "CompleteResponse": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string",
+            "description": "Raw text response from the model"
+          },
+          "json": {
+            "type": "object",
+            "additionalProperties": {
+              "nullable": true
+            },
+            "description": "Parsed JSON object — present only when responseFormat is \"json\" and the model returned valid JSON"
+          },
+          "tokensInput": {
+            "type": "number",
+            "description": "Number of input tokens consumed",
+            "example": 450
+          },
+          "tokensOutput": {
+            "type": "number",
+            "description": "Number of output tokens generated",
+            "example": 800
+          },
+          "model": {
+            "type": "string",
+            "description": "Model used for the completion",
+            "example": "claude-sonnet-4-6"
+          }
+        },
+        "required": [
+          "content",
+          "tokensInput",
+          "tokensOutput",
+          "model"
+        ]
+      },
       "InsufficientCreditsResponse": {
         "type": "object",
         "properties": {
@@ -392,6 +429,48 @@
           "error",
           "balance_cents",
           "required_cents"
+        ]
+      },
+      "CompleteRequest": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The prompt to send to the LLM",
+            "example": "Given this brand context, generate 10 Google search queries for PR outreach."
+          },
+          "systemPrompt": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Inline system prompt — no pre-registered config required",
+            "example": "You are a PR research assistant."
+          },
+          "responseFormat": {
+            "type": "string",
+            "enum": [
+              "json"
+            ],
+            "description": "Set to \"json\" to instruct the model to return valid JSON. The response will be parsed and returned in the `json` field."
+          },
+          "temperature": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 2,
+            "description": "Sampling temperature (0–2). Lower = more deterministic.",
+            "example": 0.3
+          },
+          "maxTokens": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 64000,
+            "description": "Maximum tokens in the response (default: 16000)",
+            "example": 2000
+          }
+        },
+        "required": [
+          "message",
+          "systemPrompt"
         ]
       },
       "ChatRequest": {
@@ -660,6 +739,149 @@
           },
           "401": {
             "description": "Missing or invalid x-api-key header",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/complete": {
+      "post": {
+        "tags": [
+          "Complete"
+        ],
+        "summary": "Synchronous LLM completion",
+        "description": "One-shot, non-streaming LLM call for service-to-service use. Returns a JSON response with the model output.\n\nUnlike POST /chat, this endpoint:\n- Does **not** create or use sessions (stateless, one-shot)\n- Accepts an inline `systemPrompt` (no pre-registered config required)\n- Returns JSON instead of SSE\n- Supports `responseFormat: \"json\"` to guarantee parsable JSON output\n- Supports optional `temperature` and `maxTokens` overrides\n\n**Use cases:** generating search queries, scoring/analyzing text, any service that needs a quick LLM call without conversation context.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Service-to-service API key"
+            },
+            "required": true,
+            "description": "Service-to-service API key",
+            "name": "x-api-key",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal org UUID from client-service"
+            },
+            "required": true,
+            "description": "Internal org UUID from client-service",
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal user UUID from client-service"
+            },
+            "required": true,
+            "description": "Internal user UUID from client-service",
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Caller's run ID"
+            },
+            "required": true,
+            "description": "Caller's run ID",
+            "name": "x-run-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID — injected automatically by workflow-service"
+            },
+            "required": false,
+            "description": "Campaign ID — injected automatically by workflow-service",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID — injected automatically by workflow-service"
+            },
+            "required": false,
+            "description": "Brand ID — injected automatically by workflow-service",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name — injected automatically by workflow-service"
+            },
+            "required": false,
+            "description": "Workflow name — injected automatically by workflow-service",
+            "name": "x-workflow-name",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompleteRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "LLM completion result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompleteResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid request fields",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid x-api-key header",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Insufficient credits (platform-key only)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsufficientCreditsResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream service unavailable (key-service, billing-service, runs-service, or LLM provider)",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ import { createRun, updateRunStatus, addRunCosts } from "./lib/runs-client.js";
 import { formatToolError } from "./lib/tool-errors.js";
 import { resolveKey, type ResolvedKey } from "./lib/key-client.js";
 import { authorizeCredits } from "./lib/billing-client.js";
-import { ChatRequestSchema, AppConfigRequestSchema, PlatformConfigRequestSchema } from "./schemas.js";
+import { ChatRequestSchema, CompleteRequestSchema, AppConfigRequestSchema, PlatformConfigRequestSchema } from "./schemas.js";
 import { requireAuth, requireInternalAuth, type AuthLocals } from "./middleware/auth.js";
 import type { ButtonRecord, ToolCallRecord } from "./db/schema.js";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
@@ -134,6 +134,158 @@ app.put("/platform-config", requireInternalAuth, async (req, res) => {
     createdAt: config.createdAt.toISOString(),
     updatedAt: config.updatedAt.toISOString(),
   });
+});
+
+// --- Complete (synchronous LLM call) ---
+
+app.post("/complete", requireAuth, async (req, res) => {
+  const { orgId, userId, runId: callerRunId, workflowTracking } = res.locals as AuthLocals;
+
+  const trackingHeaders: Record<string, string> = {};
+  if (workflowTracking.campaignId) trackingHeaders["x-campaign-id"] = workflowTracking.campaignId;
+  if (workflowTracking.brandId) trackingHeaders["x-brand-id"] = workflowTracking.brandId;
+  if (workflowTracking.workflowName) trackingHeaders["x-workflow-name"] = workflowTracking.workflowName;
+
+  const parsed = CompleteRequestSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res
+      .status(400)
+      .json({ error: "Invalid request", details: parsed.error.flatten() });
+  }
+
+  const { message, systemPrompt, responseFormat, temperature, maxTokens } = parsed.data;
+
+  // Resolve Anthropic API key per-request
+  let resolvedKey: ResolvedKey;
+  try {
+    resolvedKey = await resolveKey({
+      provider: "anthropic",
+      orgId,
+      userId,
+      runId: callerRunId,
+      caller: { method: "POST", path: "/complete" },
+      trackingHeaders,
+    });
+  } catch (err) {
+    console.error(`[complete] Failed to resolve Anthropic key for org="${orgId}":`, err);
+    return res.status(502).json({
+      error: "Failed to resolve Anthropic API key. Ensure the key is configured in key-service.",
+    });
+  }
+
+  // Credit authorization for platform keys
+  if (resolvedKey.keySource === "platform") {
+    const estimatedInputTokens = Math.max(Math.ceil(message.length / 4), 500);
+    const estimatedOutputTokens = maxTokens ?? 16_000;
+    try {
+      const authResult = await authorizeCredits({
+        items: [
+          { costName: `${MODEL}-tokens-input`, quantity: estimatedInputTokens },
+          { costName: `${MODEL}-tokens-output`, quantity: estimatedOutputTokens },
+        ],
+        description: `complete — ${MODEL}`,
+        orgId,
+        userId,
+        runId: callerRunId,
+        trackingHeaders: Object.keys(trackingHeaders).length > 0 ? trackingHeaders : undefined,
+      });
+      if (!authResult.sufficient) {
+        return res.status(402).json({
+          error: "Insufficient credits",
+          balance_cents: authResult.balance_cents,
+          required_cents: authResult.required_cents,
+        });
+      }
+    } catch (billingErr) {
+      console.error(`[complete] billing authorization failed for org="${orgId}":`, billingErr);
+      return res.status(502).json({
+        error: "Billing service unavailable. Please try again.",
+      });
+    }
+  }
+
+  // Register run (mandatory)
+  let runId: string | null = null;
+  try {
+    const run = await createRun(
+      { serviceName: "chat-service", taskName: "complete" },
+      { orgId, userId, runId: callerRunId },
+      trackingHeaders,
+    );
+    runId = run.id;
+    console.log(`[complete] org="${orgId}" run="${runId}" created`);
+  } catch (runErr) {
+    console.error(`[complete] org="${orgId}" run creation failed:`, runErr);
+    return res.status(502).json({
+      error: "Service temporarily unavailable (run tracking). Please try again.",
+    });
+  }
+
+  let completeFailed = false;
+  let totalPromptTokens = 0;
+  let totalOutputTokens = 0;
+  const claudeModel = MODEL;
+  try {
+    // Build prompt — for JSON mode, prepend instruction to system prompt
+    const effectiveSystemPrompt = responseFormat === "json"
+      ? `${systemPrompt}\n\nIMPORTANT: You MUST respond with valid JSON only. No markdown, no code fences, no extra text — just a single JSON object or array.`
+      : systemPrompt;
+
+    const claude = createAnthropicClient({ apiKey: resolvedKey.key, systemPrompt: effectiveSystemPrompt });
+
+    const result = await claude.complete(message, {
+      responseFormat,
+      temperature,
+      maxTokens,
+    });
+
+    totalPromptTokens = result.tokensInput;
+    totalOutputTokens = result.tokensOutput;
+
+    // Build response
+    const response: Record<string, unknown> = {
+      content: result.content,
+      tokensInput: result.tokensInput,
+      tokensOutput: result.tokensOutput,
+      model: claude.model,
+    };
+
+    // Parse JSON if requested
+    if (responseFormat === "json") {
+      try {
+        response.json = JSON.parse(result.content);
+      } catch {
+        // Model returned non-parsable content despite JSON mode — return raw content only
+      }
+    }
+
+    res.json(response);
+  } catch (err) {
+    completeFailed = true;
+    console.error(`[complete] org="${orgId}" error:`, err);
+    res.status(502).json({
+      error: "LLM call failed. Please try again.",
+    });
+  } finally {
+    // Report run status and costs (fire-and-forget)
+    if (runId) {
+      const costSource: "platform" | "org" =
+        resolvedKey.keySource === "org" ? "org" : "platform";
+      const costItems = [
+        ...(totalPromptTokens > 0
+          ? [{ costName: `${claudeModel}-tokens-input`, quantity: totalPromptTokens, costSource }]
+          : []),
+        ...(totalOutputTokens > 0
+          ? [{ costName: `${claudeModel}-tokens-output`, quantity: totalOutputTokens, costSource }]
+          : []),
+      ];
+      const runIdentity = { orgId, userId, runId };
+      Promise.all([
+        updateRunStatus(runId, completeFailed ? "failed" : "completed", runIdentity, trackingHeaders),
+        addRunCosts(runId, costItems, runIdentity, trackingHeaders),
+      ]).catch(() => {});
+    }
+  }
 });
 
 // --- Chat ---

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -382,5 +382,44 @@ export function createAnthropicClient({ apiKey, systemPrompt }: AnthropicOptions
         },
       );
     },
+
+    /**
+     * Non-streaming completion — single request/response.
+     * Used by POST /complete for service-to-service calls.
+     */
+    async complete(
+      message: string,
+      options?: {
+        responseFormat?: "json";
+        temperature?: number;
+        maxTokens?: number;
+      },
+    ): Promise<{
+      content: string;
+      tokensInput: number;
+      tokensOutput: number;
+    }> {
+      const params: Anthropic.MessageCreateParamsNonStreaming = {
+        model: MODEL,
+        max_tokens: options?.maxTokens ?? MAX_TOKENS,
+        system: systemPrompt,
+        messages: [{ role: "user", content: message }],
+        ...(options?.temperature != null ? { temperature: options.temperature } : {}),
+      };
+
+      const response = await client.messages.create(params);
+
+      // Extract text from content blocks
+      const textBlocks = response.content.filter(
+        (b): b is Anthropic.TextBlock => b.type === "text",
+      );
+      const content = textBlocks.map((b) => b.text).join("");
+
+      return {
+        content,
+        tokensInput: response.usage.input_tokens,
+        tokensOutput: response.usage.output_tokens,
+      };
+    },
   };
 }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -214,6 +214,122 @@ registry.registerPath({
   },
 });
 
+// --- Complete (synchronous LLM call) ---
+
+export const CompleteRequestSchema = z
+  .object({
+    message: z.string().min(1, "message is required").openapi({
+      description: "The prompt to send to the LLM",
+      example: "Given this brand context, generate 10 Google search queries for PR outreach.",
+    }),
+    systemPrompt: z.string().min(1).openapi({
+      description: "Inline system prompt — no pre-registered config required",
+      example: "You are a PR research assistant.",
+    }),
+    responseFormat: z.literal("json").optional().openapi({
+      description: 'Set to "json" to instruct the model to return valid JSON. The response will be parsed and returned in the `json` field.',
+    }),
+    temperature: z.number().min(0).max(2).optional().openapi({
+      description: "Sampling temperature (0–2). Lower = more deterministic.",
+      example: 0.3,
+    }),
+    maxTokens: z.number().int().min(1).max(64000).optional().openapi({
+      description: "Maximum tokens in the response (default: 16000)",
+      example: 2000,
+    }),
+  })
+  .openapi("CompleteRequest");
+
+export const CompleteResponseSchema = z
+  .object({
+    content: z.string().openapi({
+      description: "Raw text response from the model",
+    }),
+    json: z.record(z.string(), z.unknown()).optional().openapi({
+      description: "Parsed JSON object — present only when responseFormat is \"json\" and the model returned valid JSON",
+    }),
+    tokensInput: z.number().openapi({
+      description: "Number of input tokens consumed",
+      example: 450,
+    }),
+    tokensOutput: z.number().openapi({
+      description: "Number of output tokens generated",
+      example: 800,
+    }),
+    model: z.string().openapi({
+      description: "Model used for the completion",
+      example: "claude-sonnet-4-6",
+    }),
+  })
+  .openapi("CompleteResponse");
+
+export type CompleteRequest = z.infer<typeof CompleteRequestSchema>;
+
+registry.registerPath({
+  method: "post",
+  path: "/complete",
+  tags: ["Complete"],
+  summary: "Synchronous LLM completion",
+  description: `One-shot, non-streaming LLM call for service-to-service use. Returns a JSON response with the model output.
+
+Unlike POST /chat, this endpoint:
+- Does **not** create or use sessions (stateless, one-shot)
+- Accepts an inline \`systemPrompt\` (no pre-registered config required)
+- Returns JSON instead of SSE
+- Supports \`responseFormat: "json"\` to guarantee parsable JSON output
+- Supports optional \`temperature\` and \`maxTokens\` overrides
+
+**Use cases:** generating search queries, scoring/analyzing text, any service that needs a quick LLM call without conversation context.`,
+  request: {
+    headers: z.object({
+      "x-api-key": z.string().openapi({
+        description: "Service-to-service API key",
+      }),
+      "x-org-id": z.string().openapi({
+        description: "Internal org UUID from client-service",
+      }),
+      "x-user-id": z.string().openapi({
+        description: "Internal user UUID from client-service",
+      }),
+      "x-run-id": z.string().uuid().openapi({
+        description: "Caller's run ID",
+      }),
+      ...workflowTrackingHeaders,
+    }),
+    body: {
+      content: { "application/json": { schema: CompleteRequestSchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "LLM completion result",
+      content: {
+        "application/json": { schema: CompleteResponseSchema },
+      },
+    },
+    400: {
+      description: "Missing or invalid request fields",
+      content: {
+        "application/json": { schema: ValidationErrorResponseSchema },
+      },
+    },
+    401: {
+      description: "Missing or invalid x-api-key header",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    402: {
+      description: "Insufficient credits (platform-key only)",
+      content: {
+        "application/json": { schema: InsufficientCreditsResponseSchema },
+      },
+    },
+    502: {
+      description: "Upstream service unavailable (key-service, billing-service, runs-service, or LLM provider)",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
 // --- Chat ---
 
 export const ChatRequestSchema = z

--- a/tests/unit/complete.test.ts
+++ b/tests/unit/complete.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import { CompleteRequestSchema } from "../../src/schemas.js";
+
+describe("CompleteRequestSchema", () => {
+  it("accepts valid request with message and systemPrompt", () => {
+    const result = CompleteRequestSchema.safeParse({
+      message: "Generate 10 search queries",
+      systemPrompt: "You are a PR research assistant.",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts all optional fields", () => {
+    const result = CompleteRequestSchema.safeParse({
+      message: "Generate queries",
+      systemPrompt: "You are helpful.",
+      responseFormat: "json",
+      temperature: 0.3,
+      maxTokens: 2000,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.responseFormat).toBe("json");
+      expect(result.data.temperature).toBe(0.3);
+      expect(result.data.maxTokens).toBe(2000);
+    }
+  });
+
+  it("rejects missing message", () => {
+    const result = CompleteRequestSchema.safeParse({
+      systemPrompt: "You are helpful.",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty message", () => {
+    const result = CompleteRequestSchema.safeParse({
+      message: "",
+      systemPrompt: "You are helpful.",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing systemPrompt", () => {
+    const result = CompleteRequestSchema.safeParse({
+      message: "Hello",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty systemPrompt", () => {
+    const result = CompleteRequestSchema.safeParse({
+      message: "Hello",
+      systemPrompt: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid responseFormat", () => {
+    const result = CompleteRequestSchema.safeParse({
+      message: "Hello",
+      systemPrompt: "You are helpful.",
+      responseFormat: "xml",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects temperature out of range", () => {
+    const below = CompleteRequestSchema.safeParse({
+      message: "Hello",
+      systemPrompt: "You are helpful.",
+      temperature: -0.1,
+    });
+    expect(below.success).toBe(false);
+
+    const above = CompleteRequestSchema.safeParse({
+      message: "Hello",
+      systemPrompt: "You are helpful.",
+      temperature: 2.1,
+    });
+    expect(above.success).toBe(false);
+  });
+
+  it("rejects maxTokens out of range", () => {
+    const zero = CompleteRequestSchema.safeParse({
+      message: "Hello",
+      systemPrompt: "You are helpful.",
+      maxTokens: 0,
+    });
+    expect(zero.success).toBe(false);
+
+    const tooHigh = CompleteRequestSchema.safeParse({
+      message: "Hello",
+      systemPrompt: "You are helpful.",
+      maxTokens: 65000,
+    });
+    expect(tooHigh.success).toBe(false);
+  });
+
+  it("rejects non-integer maxTokens", () => {
+    const result = CompleteRequestSchema.safeParse({
+      message: "Hello",
+      systemPrompt: "You are helpful.",
+      maxTokens: 1000.5,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts temperature at boundaries (0 and 2)", () => {
+    const atZero = CompleteRequestSchema.safeParse({
+      message: "Hello",
+      systemPrompt: "You are helpful.",
+      temperature: 0,
+    });
+    expect(atZero.success).toBe(true);
+
+    const atTwo = CompleteRequestSchema.safeParse({
+      message: "Hello",
+      systemPrompt: "You are helpful.",
+      temperature: 2,
+    });
+    expect(atTwo.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `POST /complete` — a stateless, non-streaming LLM endpoint for service-to-service calls
- Accepts inline `systemPrompt`, optional `responseFormat: "json"`, `temperature`, and `maxTokens`
- Returns JSON with `content`, optional parsed `json`, token counts, and model name
- Full run tracking + billing authorization + cost reporting (same as POST /chat)
- No sessions, no history — one-shot completion

## Why
outlets-service needs to call the LLM for search query generation and result scoring. This endpoint turns chat-service into a reusable LLM service for the whole platform (journalists-service, articles-service, etc.)

## Changes
- `src/schemas.ts` — `CompleteRequestSchema`, `CompleteResponseSchema` with OpenAPI registration
- `src/lib/anthropic.ts` — added `complete()` non-streaming method to the client
- `src/index.ts` — `POST /complete` route handler
- `tests/unit/complete.test.ts` — 11 schema validation tests
- `README.md` — documented the new endpoint
- `openapi.json` — regenerated

## Test plan
- [x] All 196 unit tests pass
- [ ] CI runs (unit + integration)
- [ ] Manual test with curl after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)