### PR TITLE
fix: use correct costs-service cost name convention

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import {
   buildSystemPrompt,
   BUILTIN_TOOLS,
   MODEL,
+  COST_PREFIX,
 } from "./lib/anthropic.js";
 import {
   updateWorkflow,
@@ -180,8 +181,8 @@ app.post("/complete", requireAuth, async (req, res) => {
     try {
       const authResult = await authorizeCredits({
         items: [
-          { costName: `${MODEL}-tokens-input`, quantity: estimatedInputTokens },
-          { costName: `${MODEL}-tokens-output`, quantity: estimatedOutputTokens },
+          { costName: `${COST_PREFIX}-tokens-input`, quantity: estimatedInputTokens },
+          { costName: `${COST_PREFIX}-tokens-output`, quantity: estimatedOutputTokens },
         ],
         description: `complete — ${MODEL}`,
         orgId,
@@ -273,10 +274,10 @@ app.post("/complete", requireAuth, async (req, res) => {
         resolvedKey.keySource === "org" ? "org" : "platform";
       const costItems = [
         ...(totalPromptTokens > 0
-          ? [{ costName: `${claudeModel}-tokens-input`, quantity: totalPromptTokens, costSource }]
+          ? [{ costName: `${COST_PREFIX}-tokens-input`, quantity: totalPromptTokens, costSource }]
           : []),
         ...(totalOutputTokens > 0
-          ? [{ costName: `${claudeModel}-tokens-output`, quantity: totalOutputTokens, costSource }]
+          ? [{ costName: `${COST_PREFIX}-tokens-output`, quantity: totalOutputTokens, costSource }]
           : []),
       ];
       const runIdentity = { orgId, userId, runId };
@@ -353,8 +354,8 @@ app.post("/chat", requireAuth, async (req, res) => {
     try {
       const authResult = await authorizeCredits({
         items: [
-          { costName: `${MODEL}-tokens-input`, quantity: estimatedInputTokens },
-          { costName: `${MODEL}-tokens-output`, quantity: estimatedOutputTokens },
+          { costName: `${COST_PREFIX}-tokens-input`, quantity: estimatedInputTokens },
+          { costName: `${COST_PREFIX}-tokens-output`, quantity: estimatedOutputTokens },
         ],
         description: `chat — ${MODEL}`,
         orgId,
@@ -937,7 +938,7 @@ app.post("/chat", requireAuth, async (req, res) => {
         ...(totalPromptTokens > 0
           ? [
               {
-                costName: `${claude.model}-tokens-input`,
+                costName: `${COST_PREFIX}-tokens-input`,
                 quantity: totalPromptTokens,
                 costSource,
               },
@@ -946,7 +947,7 @@ app.post("/chat", requireAuth, async (req, res) => {
         ...(totalOutputTokens > 0
           ? [
               {
-                costName: `${claude.model}-tokens-output`,
+                costName: `${COST_PREFIX}-tokens-output`,
                 quantity: totalOutputTokens,
                 costSource,
               },

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -1,6 +1,8 @@
 import Anthropic from "@anthropic-ai/sdk";
 
 export const MODEL = "claude-sonnet-4-6";
+/** Cost-name prefix used by costs-service: {provider}-{model} */
+export const COST_PREFIX = "anthropic-sonnet-4.6";
 const MAX_TOKENS = 16_000;
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/anthropic.test.ts
+++ b/tests/unit/anthropic.test.ts
@@ -30,6 +30,7 @@ import {
   createAnthropicClient,
   buildSystemPrompt,
   MODEL,
+  COST_PREFIX,
   REQUEST_USER_INPUT_TOOL,
   UPDATE_WORKFLOW_TOOL,
   VALIDATE_WORKFLOW_TOOL,
@@ -37,6 +38,17 @@ import {
 } from "../../src/lib/anthropic.js";
 
 const TEST_PROMPT = "You are a test assistant.";
+
+describe("COST_PREFIX", () => {
+  it("follows costs-service naming convention: {provider}-{model}-tokens-{direction}", () => {
+    // costs-service expects "anthropic-sonnet-4.6", not "claude-sonnet-4-6"
+    expect(COST_PREFIX).toBe("anthropic-sonnet-4.6");
+    // Must NOT match the Anthropic API model ID (which uses claude- prefix and hyphens)
+    expect(COST_PREFIX).not.toBe(MODEL);
+    expect(COST_PREFIX).not.toContain("claude-");
+    expect(COST_PREFIX).toMatch(/^anthropic-/);
+  });
+});
 
 describe("createAnthropicClient", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- Cost names were using the Anthropic API model ID (`claude-sonnet-4-6`) but costs-service expects the `{provider}-{model}` convention (`anthropic-sonnet-4.6`)
- This caused 404 "Price not found" errors on every billing authorization call, making credit checks fail with 502
- Added `COST_PREFIX` constant in `anthropic.ts` and updated all 6 cost name references in `index.ts`

## Test plan
- [x] Unit test verifying `COST_PREFIX` follows costs-service convention and differs from `MODEL`
- [x] All 21 unit test files pass
- [ ] Deploy and verify billing authorization succeeds for platform-key orgs

🤖 Generated with [Claude Code](https://claude.com/claude-code)