### PR TITLE
feat: add x-feature-slug header propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ All endpoints (except `/health` and `/openapi.json`) require these headers:
 | `x-campaign-id` | _(optional)_ Campaign ID — injected automatically by workflow-service |
 | `x-brand-id` | _(optional)_ Brand ID — injected automatically by workflow-service |
 | `x-workflow-name` | _(optional)_ Workflow name — injected automatically by workflow-service |
+| `x-feature-slug` | _(optional)_ Feature slug — propagated through the entire service chain |
 
 ## App Config Registration
 
@@ -281,7 +282,7 @@ Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token st
 Uses PostgreSQL via Drizzle ORM. Three tables:
 
 - **sessions** — conversation sessions scoped by `orgId` and `userId`
-- **messages** — chat messages with role, content, optional `toolCalls`, `buttons`, `contentBlocks` JSONB (stores full Anthropic content blocks for context management), `runId` linking to RunsService, and optional `campaign_id`, `brand_id`, `workflow_name` for workflow tracking
+- **messages** — chat messages with role, content, optional `toolCalls`, `buttons`, `contentBlocks` JSONB (stores full Anthropic content blocks for context management), `runId` linking to RunsService, and optional `campaign_id`, `brand_id`, `workflow_name`, `feature_slug` for workflow tracking
 - **app_configs** — per-org configuration (system prompt) with unique constraint on `orgId`
 - **platform_configs** — global platform-wide chat configuration (fallback when no per-org config exists)
 

--- a/drizzle/0008_sparkling_the_twelve.sql
+++ b/drizzle/0008_sparkling_the_twelve.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "messages" ADD COLUMN "feature_slug" text;

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,286 @@
+{
+  "id": "478b9077-097c-4bc3-8bf0-d2e8b3b085c4",
+  "prevId": "836738b6-3931-4601-9796-d052db039fd6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_configs": {
+      "name": "app_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_configs_org_id_unique": {
+          "name": "app_configs_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_blocks": {
+          "name": "content_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buttons": {
+          "name": "buttons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_slug": {
+          "name": "feature_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platform_configs": {
+      "name": "platform_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "platform_configs_key_unique": {
+          "name": "platform_configs_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1774051200000,
       "tag": "0007_add_content_blocks",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1774318699055,
+      "tag": "0008_sparkling_the_twelve",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -643,6 +643,16 @@
             "description": "Workflow name — injected automatically by workflow-service",
             "name": "x-workflow-name",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug — propagated through the entire service chain"
+            },
+            "required": false,
+            "description": "Feature slug — propagated through the entire service chain",
+            "name": "x-feature-slug",
+            "in": "header"
           }
         ],
         "requestBody": {
@@ -828,6 +838,16 @@
             "description": "Workflow name — injected automatically by workflow-service",
             "name": "x-workflow-name",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug — propagated through the entire service chain"
+            },
+            "required": false,
+            "description": "Feature slug — propagated through the entire service chain",
+            "name": "x-feature-slug",
+            "in": "header"
           }
         ],
         "requestBody": {
@@ -970,6 +990,16 @@
             "required": false,
             "description": "Workflow name — injected automatically by workflow-service",
             "name": "x-workflow-name",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug — propagated through the entire service chain"
+            },
+            "required": false,
+            "description": "Feature slug — propagated through the entire service chain",
+            "name": "x-feature-slug",
             "in": "header"
           }
         ],

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -23,6 +23,7 @@ export const messages = pgTable("messages", {
   campaignId: text("campaign_id"),
   brandId: text("brand_id"),
   workflowName: text("workflow_name"),
+  featureSlug: text("feature_slug"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,6 +146,7 @@ app.post("/complete", requireAuth, async (req, res) => {
   if (workflowTracking.campaignId) trackingHeaders["x-campaign-id"] = workflowTracking.campaignId;
   if (workflowTracking.brandId) trackingHeaders["x-brand-id"] = workflowTracking.brandId;
   if (workflowTracking.workflowName) trackingHeaders["x-workflow-name"] = workflowTracking.workflowName;
+  if (workflowTracking.featureSlug) trackingHeaders["x-feature-slug"] = workflowTracking.featureSlug;
 
   const parsed = CompleteRequestSchema.safeParse(req.body);
   if (!parsed.success) {
@@ -302,6 +303,7 @@ app.post("/chat", requireAuth, async (req, res) => {
   if (workflowTracking.campaignId) trackingHeaders["x-campaign-id"] = workflowTracking.campaignId;
   if (workflowTracking.brandId) trackingHeaders["x-brand-id"] = workflowTracking.brandId;
   if (workflowTracking.workflowName) trackingHeaders["x-workflow-name"] = workflowTracking.workflowName;
+  if (workflowTracking.featureSlug) trackingHeaders["x-feature-slug"] = workflowTracking.featureSlug;
 
   const parsed = ChatRequestSchema.safeParse(req.body);
   if (!parsed.success) {
@@ -476,6 +478,7 @@ app.post("/chat", requireAuth, async (req, res) => {
       campaignId: workflowTracking.campaignId ?? null,
       brandId: workflowTracking.brandId ?? null,
       workflowName: workflowTracking.workflowName ?? null,
+      featureSlug: workflowTracking.featureSlug ?? null,
     });
 
     // Stream response from Claude
@@ -924,6 +927,7 @@ app.post("/chat", requireAuth, async (req, res) => {
       campaignId: workflowTracking.campaignId ?? null,
       brandId: workflowTracking.brandId ?? null,
       workflowName: workflowTracking.workflowName ?? null,
+      featureSlug: workflowTracking.featureSlug ?? null,
     });
 
     sendSSE(res, "[DONE]");

--- a/src/lib/key-client.ts
+++ b/src/lib/key-client.ts
@@ -13,6 +13,7 @@ export interface TrackingHeaders {
   "x-campaign-id"?: string;
   "x-brand-id"?: string;
   "x-workflow-name"?: string;
+  "x-feature-slug"?: string;
 }
 
 export interface KeyResolutionParams {

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -33,6 +33,7 @@ export interface TrackingHeaders {
   "x-campaign-id"?: string;
   "x-brand-id"?: string;
   "x-workflow-name"?: string;
+  "x-feature-slug"?: string;
 }
 
 function buildHeaders(

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -4,6 +4,7 @@ export interface WorkflowTrackingHeaders {
   campaignId?: string;
   brandId?: string;
   workflowName?: string;
+  featureSlug?: string;
 }
 
 export interface AuthLocals {
@@ -57,6 +58,8 @@ function extractWorkflowTracking(req: Request): WorkflowTrackingHeaders {
   if (typeof brandId === "string") tracking.brandId = brandId;
   const workflowName = req.headers["x-workflow-name"];
   if (typeof workflowName === "string") tracking.workflowName = workflowName;
+  const featureSlug = req.headers["x-feature-slug"];
+  if (typeof featureSlug === "string") tracking.featureSlug = featureSlug;
   return tracking;
 }
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -20,6 +20,9 @@ const workflowTrackingHeaders = {
   "x-workflow-name": z.string().optional().openapi({
     description: "Workflow name — injected automatically by workflow-service",
   }),
+  "x-feature-slug": z.string().optional().openapi({
+    description: "Feature slug — propagated through the entire service chain",
+  }),
 };
 
 // --- Shared schemas ---

--- a/tests/unit/workflow-tracking.test.ts
+++ b/tests/unit/workflow-tracking.test.ts
@@ -27,6 +27,7 @@ describe("workflow tracking headers in auth middleware", () => {
       "x-campaign-id": "camp-abc",
       "x-brand-id": "brand-xyz",
       "x-workflow-name": "outreach-v2",
+      "x-feature-slug": "pr-outreach",
     });
     requireAuth(req, res, next);
     expect(next).toHaveBeenCalled();
@@ -35,6 +36,7 @@ describe("workflow tracking headers in auth middleware", () => {
       campaignId: "camp-abc",
       brandId: "brand-xyz",
       workflowName: "outreach-v2",
+      featureSlug: "pr-outreach",
     });
   });
 
@@ -56,6 +58,19 @@ describe("workflow tracking headers in auth middleware", () => {
     const locals = res.locals as unknown as AuthLocals;
     expect(locals.workflowTracking).toEqual({
       campaignId: "camp-only",
+    });
+  });
+
+  it("extracts feature-slug when present alone", () => {
+    const { req, res, next } = mockReqRes({
+      ...BASE_HEADERS,
+      "x-feature-slug": "cold-email-v2",
+    });
+    requireAuth(req, res, next);
+    expect(next).toHaveBeenCalled();
+    const locals = res.locals as unknown as AuthLocals;
+    expect(locals.workflowTracking).toEqual({
+      featureSlug: "cold-email-v2",
     });
   });
 
@@ -102,7 +117,7 @@ describe("runs-client forwards tracking headers", () => {
     await createRun(
       { serviceName: "chat-service", taskName: "chat" },
       identity,
-      { "x-campaign-id": "camp-1", "x-brand-id": "brand-1", "x-workflow-name": "flow-1" },
+      { "x-campaign-id": "camp-1", "x-brand-id": "brand-1", "x-workflow-name": "flow-1", "x-feature-slug": "feat-1" },
     );
 
     expect(fetch).toHaveBeenCalledWith(
@@ -115,6 +130,7 @@ describe("runs-client forwards tracking headers", () => {
           "x-campaign-id": "camp-1",
           "x-brand-id": "brand-1",
           "x-workflow-name": "flow-1",
+          "x-feature-slug": "feat-1",
         }),
       }),
     );
@@ -133,6 +149,7 @@ describe("runs-client forwards tracking headers", () => {
     expect(callHeaders["x-campaign-id"]).toBeUndefined();
     expect(callHeaders["x-brand-id"]).toBeUndefined();
     expect(callHeaders["x-workflow-name"]).toBeUndefined();
+    expect(callHeaders["x-feature-slug"]).toBeUndefined();
   });
 
   it("forwards tracking headers on updateRunStatus", async () => {


### PR DESCRIPTION
## Summary
- Accept `x-feature-slug` header on all authenticated endpoints (auth middleware + Zod/OpenAPI schemas)
- Propagate it in all downstream service-to-service calls (runs-client, key-client, billing-client, workflow-client, content-generation-client)
- Store it in the `messages` table (`feature_slug` column) alongside existing tracking fields
- Includes DB migration, updated OpenAPI spec, and test coverage

## Test plan
- [x] Unit tests pass (202 passed, 6 skipped — DB integration tests require live DB)
- [x] Workflow-tracking test updated: verifies extraction, propagation, and partial scenarios for `x-feature-slug`
- [x] Build + OpenAPI generation succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)