### PR TITLE
feat: add upsert_feature tool for feature-creator context

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,15 @@ After a tool result, more `token` events follow with the AI's continuation.
 | `list_available_services` | Lists all available microservices and their API endpoints from api-registry `GET /llm-context`. Use before modifying DAGs to know valid `http.call` targets. |
 | `request_user_input` | Asks the user for structured input (see Input Request below) |
 
+**Context-specific tools:**
+
+When `context.type` is `"feature-creator"`, the standard workflow tools above are **replaced** by a focused toolset for designing features:
+
+| Tool | Description |
+|---|---|
+| `request_user_input` | Asks the user for structured input (same as above) |
+| `upsert_feature` | Creates or updates a feature definition in features-service. Accepts `slug`, `name`, `description`, `category`, `channel`, `audienceType`, `inputs` (array of `{key, label, description}`), and `outputs` (array of `{key, label, description}`). |
+
 ### 5. Input Request (optional)
 When the AI genuinely needs information it does not have, it emits an input request:
 ```
@@ -274,6 +283,8 @@ Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token st
 | `API_REGISTRY_SERVICE_URL` | No | API registry service endpoint (default: `https://api-registry.distribute.you`) |
 | `API_REGISTRY_SERVICE_API_KEY` | No | API key for api-registry service (list_available_services tool fails if unset) |
 | `BILLING_SERVICE_URL` | No | Billing-service endpoint (default: `https://billing.mcpfactory.org`) |
+| `FEATURES_SERVICE_URL` | No | Features-service endpoint (default: `https://features.distribute.you`) |
+| `FEATURES_SERVICE_API_KEY` | No | API key for features-service (upsert_feature tool fails if unset) |
 | `BILLING_SERVICE_API_KEY` | Yes | API key for billing-service — required for credit authorization on platform-key requests |
 | `PORT` | No | Server port (default: `3002`) |
 
@@ -348,6 +359,7 @@ src/
     runs-client.ts     # RunsService HTTP client for run tracking and cost reporting
     workflow-client.ts              # Workflow-service client for update_workflow and validate_workflow built-in tools
     content-generation-client.ts    # Content-generation service client for get_prompt_template built-in tool
+    features-client.ts              # Features-service client for upsert_feature tool (feature-creator context)
 scripts/
   generate-openapi.ts  # Generates openapi.json from zod schemas via OpenApiGeneratorV3
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
   createAnthropicClient,
   buildSystemPrompt,
   BUILTIN_TOOLS,
+  FEATURE_CREATOR_TOOLS,
   MODEL,
   COST_PREFIX,
 } from "./lib/anthropic.js";
@@ -26,6 +27,7 @@ import {
 import { getPromptTemplate, updatePromptTemplate } from "./lib/content-generation-client.js";
 import { listAvailableServices } from "./lib/api-registry-client.js";
 import { createRun, updateRunStatus, addRunCosts } from "./lib/runs-client.js";
+import { upsertFeature } from "./lib/features-client.js";
 import { formatToolError } from "./lib/tool-errors.js";
 import { resolveKey, type ResolvedKey } from "./lib/key-client.js";
 import { authorizeCredits } from "./lib/billing-client.js";
@@ -528,7 +530,9 @@ app.post("/chat", requireAuth, async (req, res) => {
       }
     }
 
-    const allTools = BUILTIN_TOOLS;
+    const allTools = context?.type === "feature-creator"
+      ? FEATURE_CREATOR_TOOLS
+      : BUILTIN_TOOLS;
 
     // Detect client disconnect to abort in-flight streams
     const abortController = new AbortController();
@@ -730,6 +734,32 @@ app.post("/chat", requireAuth, async (req, res) => {
         });
 
         toolCalls.push({ name: call.name, args: {}, result });
+        return { name: call.name, result };
+      }
+
+      // Built-in feature upsert tool (feature-creator context only)
+      if (call.name === "upsert_feature") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const result = await upsertFeature(
+          {
+            slug: args.slug as string,
+            name: args.name as string,
+            description: args.description as string,
+            category: args.category as string,
+            channel: args.channel as string,
+            audienceType: args.audienceType as string,
+            inputs: args.inputs as { key: string; label: string; description: string }[],
+            outputs: args.outputs as { key: string; label: string; description: string }[],
+          },
+          {
+            orgId,
+            userId,
+            runId: runId!,
+            trackingHeaders: Object.keys(trackingHeaders).length > 0 ? trackingHeaders as Record<string, string> : undefined,
+          },
+        );
+
+        toolCalls.push({ name: call.name, args, result });
         return { name: call.name, result };
       }
 

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -261,6 +261,69 @@ export const LIST_WORKFLOWS_TOOL: Anthropic.Tool = {
   },
 };
 
+export const UPSERT_FEATURE_TOOL: Anthropic.Tool = {
+  name: "upsert_feature",
+  description:
+    "Create or update a feature definition in the features catalogue. Use this when the user has confirmed the feature design (name, description, inputs, outputs) and wants to save it. Always confirm the feature details with the user before calling this tool.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      slug: {
+        type: "string",
+        description:
+          "URL-friendly identifier for the feature (e.g. 'cold-email-outreach'). Use lowercase kebab-case.",
+      },
+      name: {
+        type: "string",
+        description: "Human-readable feature name (e.g. 'Cold Email Outreach')",
+      },
+      description: {
+        type: "string",
+        description: "Brief description of what the feature does",
+      },
+      category: {
+        type: "string",
+        description: "Feature category (e.g. 'sales', 'pr', 'marketing')",
+      },
+      channel: {
+        type: "string",
+        description: "Communication channel (e.g. 'email', 'linkedin', 'phone')",
+      },
+      audienceType: {
+        type: "string",
+        description: "Target audience type (e.g. 'cold-outreach', 'warm-leads', 'existing-customers')",
+      },
+      inputs: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            key: { type: "string", description: "Machine-readable input key (e.g. 'targetCompanyUrl')" },
+            label: { type: "string", description: "Human-readable label (e.g. 'Target Company URL')" },
+            description: { type: "string", description: "What this input is for" },
+          },
+          required: ["key", "label", "description"],
+        },
+        description: "Input fields the user must provide to run this feature",
+      },
+      outputs: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            key: { type: "string", description: "Machine-readable output key (e.g. 'generatedEmail')" },
+            label: { type: "string", description: "Human-readable label (e.g. 'Generated Email')" },
+            description: { type: "string", description: "What this output contains" },
+          },
+          required: ["key", "label", "description"],
+        },
+        description: "Output fields the feature produces",
+      },
+    },
+    required: ["slug", "name", "description", "category", "channel", "audienceType", "inputs", "outputs"],
+  },
+};
+
 export const BUILTIN_TOOLS: Anthropic.Tool[] = [
   REQUEST_USER_INPUT_TOOL,
   UPDATE_WORKFLOW_TOOL,
@@ -272,6 +335,12 @@ export const BUILTIN_TOOLS: Anthropic.Tool[] = [
   GET_WORKFLOW_DETAILS_TOOL,
   GET_WORKFLOW_REQUIRED_PROVIDERS_TOOL,
   LIST_WORKFLOWS_TOOL,
+];
+
+/** Extra tools available only when context.type === "feature-creator" */
+export const FEATURE_CREATOR_TOOLS: Anthropic.Tool[] = [
+  REQUEST_USER_INPUT_TOOL,
+  UPSERT_FEATURE_TOOL,
 ];
 
 // ---------------------------------------------------------------------------

--- a/src/lib/features-client.ts
+++ b/src/lib/features-client.ts
@@ -1,0 +1,83 @@
+const FEATURES_SERVICE_URL =
+  process.env.FEATURES_SERVICE_URL || "https://features.distribute.you";
+const FEATURES_SERVICE_API_KEY = process.env.FEATURES_SERVICE_API_KEY;
+
+export interface FeaturesCallParams {
+  orgId: string;
+  userId: string;
+  runId: string;
+  trackingHeaders?: Record<string, string>;
+}
+
+function buildHeaders(params: FeaturesCallParams): Record<string, string> {
+  if (!FEATURES_SERVICE_API_KEY) {
+    throw new Error(
+      "[features-client] FEATURES_SERVICE_API_KEY is required",
+    );
+  }
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "x-api-key": FEATURES_SERVICE_API_KEY,
+    "x-org-id": params.orgId,
+    "x-user-id": params.userId,
+    "x-run-id": params.runId,
+  };
+  if (params.trackingHeaders) {
+    for (const [k, v] of Object.entries(params.trackingHeaders)) {
+      if (v) headers[k] = v;
+    }
+  }
+  return headers;
+}
+
+export interface FeatureFieldDef {
+  key: string;
+  label: string;
+  description: string;
+}
+
+export interface UpsertFeatureBody {
+  slug: string;
+  name: string;
+  description: string;
+  category: string;
+  channel: string;
+  audienceType: string;
+  inputs: FeatureFieldDef[];
+  outputs: FeatureFieldDef[];
+}
+
+export interface FeatureResponse {
+  slug: string;
+  name: string;
+  description: string;
+  category: string;
+  channel: string;
+  audienceType: string;
+  inputs: FeatureFieldDef[];
+  outputs: FeatureFieldDef[];
+  [key: string]: unknown;
+}
+
+export async function upsertFeature(
+  body: UpsertFeatureBody,
+  params: FeaturesCallParams,
+): Promise<FeatureResponse> {
+  const url = `${FEATURES_SERVICE_URL}/features`;
+  const res = await fetch(url, {
+    method: "PUT",
+    headers: buildHeaders(params),
+    body: JSON.stringify({ features: [body] }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `[features-client] PUT /features returned ${res.status}: ${text}`,
+    );
+  }
+
+  const result = (await res.json()) as { features: FeatureResponse[] };
+  return result.features[0];
+}

--- a/src/lib/tool-errors.ts
+++ b/src/lib/tool-errors.ts
@@ -58,6 +58,8 @@ const TOOL_HINTS: Record<string, string> = {
     "Pass sourceType (existing prompt type), prompt (template with {{variables}}), and variables (array of variable names).",
   list_available_services:
     "No parameters needed. Returns all services and their endpoints.",
+  upsert_feature:
+    "Pass slug (kebab-case), name, description, category, channel, audienceType, inputs (array of {key, label, description}), and outputs (array of {key, label, description}). All fields are required.",
 };
 
 export function formatToolError(toolName: string, rawError: string): ToolErrorResult {

--- a/tests/unit/anthropic.test.ts
+++ b/tests/unit/anthropic.test.ts
@@ -34,7 +34,9 @@ import {
   REQUEST_USER_INPUT_TOOL,
   UPDATE_WORKFLOW_TOOL,
   VALIDATE_WORKFLOW_TOOL,
+  UPSERT_FEATURE_TOOL,
   BUILTIN_TOOLS,
+  FEATURE_CREATOR_TOOLS,
 } from "../../src/lib/anthropic.js";
 
 const TEST_PROMPT = "You are a test assistant.";
@@ -462,6 +464,43 @@ describe("BUILTIN_TOOLS", () => {
       expect(tool).toHaveProperty("name");
       expect(tool).toHaveProperty("description");
     }
+  });
+});
+
+describe("UPSERT_FEATURE_TOOL", () => {
+  it("has correct name and all required parameters", () => {
+    expect(UPSERT_FEATURE_TOOL.name).toBe("upsert_feature");
+    const schema = UPSERT_FEATURE_TOOL.input_schema as {
+      properties: Record<string, unknown>;
+      required: string[];
+    };
+    expect(schema.properties).toHaveProperty("slug");
+    expect(schema.properties).toHaveProperty("name");
+    expect(schema.properties).toHaveProperty("description");
+    expect(schema.properties).toHaveProperty("category");
+    expect(schema.properties).toHaveProperty("channel");
+    expect(schema.properties).toHaveProperty("audienceType");
+    expect(schema.properties).toHaveProperty("inputs");
+    expect(schema.properties).toHaveProperty("outputs");
+    expect(schema.required).toEqual([
+      "slug", "name", "description", "category", "channel", "audienceType", "inputs", "outputs",
+    ]);
+  });
+});
+
+describe("FEATURE_CREATOR_TOOLS", () => {
+  it("includes only request_user_input and upsert_feature", () => {
+    const names = FEATURE_CREATOR_TOOLS.map((t) => t.name);
+    expect(names).toContain("request_user_input");
+    expect(names).toContain("upsert_feature");
+    expect(FEATURE_CREATOR_TOOLS).toHaveLength(2);
+  });
+
+  it("does not include workflow tools", () => {
+    const names = FEATURE_CREATOR_TOOLS.map((t) => t.name);
+    expect(names).not.toContain("update_workflow");
+    expect(names).not.toContain("list_workflows");
+    expect(names).not.toContain("get_workflow_details");
   });
 });
 

--- a/tests/unit/features-client.test.ts
+++ b/tests/unit/features-client.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  process.env.FEATURES_SERVICE_API_KEY = "test-feat-key";
+  process.env.FEATURES_SERVICE_URL = "https://features.test.local";
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.restoreAllMocks();
+});
+
+async function loadModule() {
+  vi.resetModules();
+  return import("../../src/lib/features-client.js");
+}
+
+const sampleFeature = {
+  slug: "cold-email-outreach",
+  name: "Cold Email Outreach",
+  description: "Automated cold email outreach campaign",
+  category: "sales",
+  channel: "email",
+  audienceType: "cold-outreach",
+  inputs: [
+    { key: "targetCompanyUrl", label: "Target Company URL", description: "URL of the company to prospect" },
+  ],
+  outputs: [
+    { key: "generatedEmail", label: "Generated Email", description: "The generated cold email" },
+  ],
+};
+
+describe("upsertFeature", () => {
+  it("sends PUT /features with correct URL, headers, and body", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ features: [{ ...sampleFeature, id: "feat-1" }] }),
+    });
+
+    const { upsertFeature } = await loadModule();
+    const result = await upsertFeature(sampleFeature, {
+      orgId: "org-1",
+      userId: "user-1",
+      runId: "run-1",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://features.test.local/features",
+      expect.objectContaining({
+        method: "PUT",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          "x-api-key": "test-feat-key",
+          "x-org-id": "org-1",
+          "x-user-id": "user-1",
+          "x-run-id": "run-1",
+        }),
+      }),
+    );
+
+    const sentBody = JSON.parse((fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
+    expect(sentBody.features).toHaveLength(1);
+    expect(sentBody.features[0].slug).toBe("cold-email-outreach");
+    expect(sentBody.features[0].inputs).toHaveLength(1);
+    expect(sentBody.features[0].outputs).toHaveLength(1);
+
+    expect(result.slug).toBe("cold-email-outreach");
+    expect(result.id).toBe("feat-1");
+  });
+
+  it("forwards tracking headers", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ features: [sampleFeature] }),
+    });
+
+    const { upsertFeature } = await loadModule();
+    await upsertFeature(sampleFeature, {
+      orgId: "org-1",
+      userId: "user-1",
+      runId: "run-1",
+      trackingHeaders: { "x-campaign-id": "camp-1", "x-feature-slug": "cold-email-outreach" },
+    });
+
+    const callHeaders = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].headers;
+    expect(callHeaders["x-campaign-id"]).toBe("camp-1");
+    expect(callHeaders["x-feature-slug"]).toBe("cold-email-outreach");
+  });
+
+  it("throws on HTTP error", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 422,
+      text: () => Promise.resolve("Validation failed"),
+    });
+
+    const { upsertFeature } = await loadModule();
+    await expect(
+      upsertFeature(sampleFeature, { orgId: "o", userId: "u", runId: "r" }),
+    ).rejects.toThrow(/returned 422/);
+  });
+
+  it("throws when FEATURES_SERVICE_API_KEY is not set", async () => {
+    delete process.env.FEATURES_SERVICE_API_KEY;
+
+    const { upsertFeature } = await loadModule();
+    await expect(
+      upsertFeature(sampleFeature, { orgId: "o", userId: "u", runId: "r" }),
+    ).rejects.toThrow(/FEATURES_SERVICE_API_KEY is required/);
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("uses default FEATURES_SERVICE_URL when not set", async () => {
+    delete process.env.FEATURES_SERVICE_URL;
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ features: [sampleFeature] }),
+    });
+
+    const { upsertFeature } = await loadModule();
+    await upsertFeature(sampleFeature, { orgId: "o", userId: "u", runId: "r" });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://features.distribute.you/features",
+      expect.anything(),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add `upsert_feature` LLM tool that calls features-service `PUT /features` to persist feature definitions (slug, name, description, category, channel, audienceType, inputs, outputs)
- When `context.type === "feature-creator"`, the chat uses a focused toolset (`request_user_input` + `upsert_feature`) instead of the default workflow tools
- New `src/lib/features-client.ts` HTTP client following the same pattern as workflow-client and content-generation-client

## Test plan
- [x] Unit tests for features-client (headers, body, error handling, missing API key, default URL)
- [x] Unit tests for UPSERT_FEATURE_TOOL schema and FEATURE_CREATOR_TOOLS export
- [x] All 209 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)