### PR TITLE
feat: split feature tools into create/update/list/get

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,10 @@ When `context.type` is `"feature-creator"`, the standard workflow tools above ar
 | Tool | Description |
 |---|---|
 | `request_user_input` | Asks the user for structured input (same as above) |
-| `upsert_feature` | Creates or updates a feature definition in features-service. Creates via `POST /features` (201), falls back to `PUT /features/:slug` on conflict (409). Accepts `slug`, `name`, `description`, `category`, `channel`, `audienceType`, `inputs` (array of `{key, label, description}`), and `outputs` (array of `{key, label, description}`). |
+| `create_feature` | Creates a new feature via `POST /features`. Slug is optional (auto-generated from name). Returns 409 on conflict. |
+| `update_feature` | Updates an existing feature by slug via `PUT /features/:slug`. Partial update — only provided fields change. |
+| `list_features` | Lists features via `GET /features` with optional filters (category, channel, audienceType, status, implemented). |
+| `get_feature` | Gets full feature details by slug via `GET /features/:slug`. |
 
 ### 5. Input Request (optional)
 When the AI genuinely needs information it does not have, it emits an input request:

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ import {
 import { getPromptTemplate, updatePromptTemplate } from "./lib/content-generation-client.js";
 import { listAvailableServices } from "./lib/api-registry-client.js";
 import { createRun, updateRunStatus, addRunCosts } from "./lib/runs-client.js";
-import { createFeature, updateFeature } from "./lib/features-client.js";
+import { createFeature, updateFeature, listFeatures, getFeature } from "./lib/features-client.js";
 import { formatToolError } from "./lib/tool-errors.js";
 import { resolveKey, type ResolvedKey } from "./lib/key-client.js";
 import { authorizeCredits } from "./lib/billing-client.js";
@@ -738,40 +738,63 @@ app.post("/chat", requireAuth, async (req, res) => {
       }
 
       // Built-in feature tools (feature-creator context only)
-      if (call.name === "upsert_feature") {
+      const featureCallParams = {
+        orgId,
+        userId,
+        runId: runId!,
+        trackingHeaders: Object.keys(trackingHeaders).length > 0 ? trackingHeaders as Record<string, string> : undefined,
+      };
+
+      if (call.name === "create_feature") {
         const args = (call.args as Record<string, unknown>) || {};
-        const featureParams = {
-          orgId,
-          userId,
-          runId: runId!,
-          trackingHeaders: Object.keys(trackingHeaders).length > 0 ? trackingHeaders as Record<string, string> : undefined,
-        };
-        const featureBody = {
-          slug: args.slug as string,
-          name: args.name as string,
-          description: args.description as string,
-          category: args.category as string,
-          channel: args.channel as string,
-          audienceType: args.audienceType as string,
-          inputs: args.inputs as { key: string; label: string; description: string }[],
-          outputs: args.outputs as { key: string; label: string; description: string }[],
-        };
+        const result = await createFeature(
+          {
+            slug: args.slug as string,
+            name: args.name as string,
+            description: args.description as string,
+            category: args.category as string,
+            channel: args.channel as string,
+            audienceType: args.audienceType as string,
+            inputs: args.inputs as { key: string; label: string; description: string }[],
+            outputs: args.outputs as { key: string; label: string; description: string }[],
+          },
+          featureCallParams,
+        );
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
 
-        let result: unknown;
-        try {
-          // Try creating first
-          result = await createFeature(featureBody, featureParams);
-        } catch (createErr: unknown) {
-          const msg = createErr instanceof Error ? createErr.message : String(createErr);
-          if (msg.includes("already exists")) {
-            // Feature exists — update it instead
-            const { slug, ...updateBody } = featureBody;
-            result = await updateFeature(slug, updateBody, featureParams);
-          } else {
-            throw createErr;
-          }
-        }
+      if (call.name === "update_feature") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const { slug, ...updateBody } = args;
+        const result = await updateFeature(
+          slug as string,
+          updateBody as Partial<{ name: string; description: string; category: string; channel: string; audienceType: string; inputs: { key: string; label: string; description: string }[]; outputs: { key: string; label: string; description: string }[] }>,
+          featureCallParams,
+        );
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
 
+      if (call.name === "list_features") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const result = await listFeatures(
+          {
+            category: args.category as string | undefined,
+            channel: args.channel as string | undefined,
+            audienceType: args.audienceType as string | undefined,
+            status: args.status as string | undefined,
+            implemented: args.implemented as string | undefined,
+          },
+          featureCallParams,
+        );
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
+      if (call.name === "get_feature") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const result = await getFeature(args.slug as string, featureCallParams);
         toolCalls.push({ name: call.name, args, result });
         return { name: call.name, result };
       }

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -261,17 +261,31 @@ export const LIST_WORKFLOWS_TOOL: Anthropic.Tool = {
   },
 };
 
-export const UPSERT_FEATURE_TOOL: Anthropic.Tool = {
-  name: "upsert_feature",
+// ---------------------------------------------------------------------------
+// Feature-creator tools (available only when context.type === "feature-creator")
+// ---------------------------------------------------------------------------
+
+const featureFieldItems = {
+  type: "object" as const,
+  properties: {
+    key: { type: "string", description: "Machine-readable key (e.g. 'targetCompanyUrl')" },
+    label: { type: "string", description: "Human-readable label (e.g. 'Target Company URL')" },
+    description: { type: "string", description: "What this field is for" },
+  },
+  required: ["key", "label", "description"],
+};
+
+export const CREATE_FEATURE_TOOL: Anthropic.Tool = {
+  name: "create_feature",
   description:
-    "Create or update a feature definition in the features catalogue. Use this when the user has confirmed the feature design (name, description, inputs, outputs) and wants to save it. Always confirm the feature details with the user before calling this tool.",
+    "Create a new feature definition in the features catalogue. Use this when the user has finished designing a feature and wants to save it. Always confirm the feature details with the user before calling this tool. Returns 409 if the slug or name already exists.",
   input_schema: {
     type: "object" as const,
     properties: {
       slug: {
         type: "string",
         description:
-          "URL-friendly identifier for the feature (e.g. 'cold-email-outreach'). Use lowercase kebab-case.",
+          "URL-friendly identifier for the feature (e.g. 'cold-email-outreach'). Use lowercase kebab-case. Optional — auto-generated from name if omitted.",
       },
       name: {
         type: "string",
@@ -295,32 +309,79 @@ export const UPSERT_FEATURE_TOOL: Anthropic.Tool = {
       },
       inputs: {
         type: "array",
-        items: {
-          type: "object",
-          properties: {
-            key: { type: "string", description: "Machine-readable input key (e.g. 'targetCompanyUrl')" },
-            label: { type: "string", description: "Human-readable label (e.g. 'Target Company URL')" },
-            description: { type: "string", description: "What this input is for" },
-          },
-          required: ["key", "label", "description"],
-        },
+        items: featureFieldItems,
         description: "Input fields the user must provide to run this feature",
       },
       outputs: {
         type: "array",
-        items: {
-          type: "object",
-          properties: {
-            key: { type: "string", description: "Machine-readable output key (e.g. 'generatedEmail')" },
-            label: { type: "string", description: "Human-readable label (e.g. 'Generated Email')" },
-            description: { type: "string", description: "What this output contains" },
-          },
-          required: ["key", "label", "description"],
-        },
+        items: featureFieldItems,
         description: "Output fields the feature produces",
       },
     },
-    required: ["slug", "name", "description", "category", "channel", "audienceType", "inputs", "outputs"],
+    required: ["name", "description", "category", "channel", "audienceType", "inputs", "outputs"],
+  },
+};
+
+export const UPDATE_FEATURE_TOOL: Anthropic.Tool = {
+  name: "update_feature",
+  description:
+    "Update an existing feature definition by slug. Only provided fields are modified — omit fields you don't want to change. If inputs or outputs change, the feature signature is recomputed automatically. Use this when iterating on an existing feature's design.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      slug: {
+        type: "string",
+        description: "The slug of the feature to update. If available in context, use it directly.",
+      },
+      name: { type: "string", description: "New feature name (optional)" },
+      description: { type: "string", description: "New feature description (optional)" },
+      category: { type: "string", description: "New category (optional)" },
+      channel: { type: "string", description: "New channel (optional)" },
+      audienceType: { type: "string", description: "New audience type (optional)" },
+      inputs: {
+        type: "array",
+        items: featureFieldItems,
+        description: "New input fields (replaces all existing inputs)",
+      },
+      outputs: {
+        type: "array",
+        items: featureFieldItems,
+        description: "New output fields (replaces all existing outputs)",
+      },
+    },
+    required: ["slug"],
+  },
+};
+
+export const LIST_FEATURES_TOOL: Anthropic.Tool = {
+  name: "list_features",
+  description:
+    "List features from the catalogue with optional filters. Use this to browse existing features, check for duplicates before creating, or find features by category/channel. The dashboard also sends features in context, but this tool fetches the latest from the database.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      category: { type: "string", description: "Filter by category (e.g. 'sales', 'pr')" },
+      channel: { type: "string", description: "Filter by channel (e.g. 'email', 'linkedin')" },
+      audienceType: { type: "string", description: "Filter by audience type" },
+      status: { type: "string", description: "Filter by status (e.g. 'active', 'draft')" },
+      implemented: { type: "string", description: "Filter by implementation status ('true' or 'false')" },
+    },
+  },
+};
+
+export const GET_FEATURE_TOOL: Anthropic.Tool = {
+  name: "get_feature",
+  description:
+    "Get full details of a single feature by its slug. Use this to inspect inputs, outputs, and metadata of an existing feature.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      slug: {
+        type: "string",
+        description: "The feature slug to look up. If available in context, use it directly.",
+      },
+    },
+    required: ["slug"],
   },
 };
 
@@ -337,10 +398,13 @@ export const BUILTIN_TOOLS: Anthropic.Tool[] = [
   LIST_WORKFLOWS_TOOL,
 ];
 
-/** Extra tools available only when context.type === "feature-creator" */
+/** Tools available when context.type === "feature-creator" */
 export const FEATURE_CREATOR_TOOLS: Anthropic.Tool[] = [
   REQUEST_USER_INPUT_TOOL,
-  UPSERT_FEATURE_TOOL,
+  CREATE_FEATURE_TOOL,
+  UPDATE_FEATURE_TOOL,
+  LIST_FEATURES_TOOL,
+  GET_FEATURE_TOOL,
 ];
 
 // ---------------------------------------------------------------------------

--- a/src/lib/features-client.ts
+++ b/src/lib/features-client.ts
@@ -119,3 +119,65 @@ export async function updateFeature(
 
   return (await res.json()) as FeatureResponse;
 }
+
+export interface ListFeaturesFilters {
+  status?: string;
+  category?: string;
+  channel?: string;
+  audienceType?: string;
+  implemented?: string;
+}
+
+/**
+ * List features via GET /features with optional filters.
+ */
+export async function listFeatures(
+  filters: ListFeaturesFilters,
+  params: FeaturesCallParams,
+): Promise<FeatureResponse[]> {
+  const query = new URLSearchParams();
+  if (filters.status) query.set("status", filters.status);
+  if (filters.category) query.set("category", filters.category);
+  if (filters.channel) query.set("channel", filters.channel);
+  if (filters.audienceType) query.set("audienceType", filters.audienceType);
+  if (filters.implemented) query.set("implemented", filters.implemented);
+
+  const qs = query.toString();
+  const url = `${FEATURES_SERVICE_URL}/features${qs ? `?${qs}` : ""}`;
+  const res = await fetch(url, {
+    method: "GET",
+    headers: buildHeaders(params),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `[features-client] GET /features returned ${res.status}: ${text}`,
+    );
+  }
+
+  return (await res.json()) as FeatureResponse[];
+}
+
+/**
+ * Get a single feature by slug via GET /features/:slug.
+ */
+export async function getFeature(
+  slug: string,
+  params: FeaturesCallParams,
+): Promise<FeatureResponse> {
+  const url = `${FEATURES_SERVICE_URL}/features/${encodeURIComponent(slug)}`;
+  const res = await fetch(url, {
+    method: "GET",
+    headers: buildHeaders(params),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `[features-client] GET /features/${slug} returned ${res.status}: ${text}`,
+    );
+  }
+
+  return (await res.json()) as FeatureResponse;
+}

--- a/src/lib/tool-errors.ts
+++ b/src/lib/tool-errors.ts
@@ -58,9 +58,14 @@ const TOOL_HINTS: Record<string, string> = {
     "Pass sourceType (existing prompt type), prompt (template with {{variables}}), and variables (array of variable names).",
   list_available_services:
     "No parameters needed. Returns all services and their endpoints.",
-  upsert_feature:
-    "Pass slug (kebab-case), name, description, category, channel, audienceType, inputs (array of {key, label, description}), and outputs (array of {key, label, description}). All fields are required. " +
-    "Creates the feature if it doesn't exist, updates it if the slug already exists.",
+  create_feature:
+    "Pass name, description, category, channel, audienceType, inputs (array of {key, label, description}), and outputs (array of {key, label, description}). Slug is optional (auto-generated from name). Returns 409 if slug/name already exists.",
+  update_feature:
+    "Pass slug (required) and any fields to update: name, description, category, channel, audienceType, inputs, outputs. Only provided fields are changed.",
+  list_features:
+    "All parameters are optional: category, channel, audienceType, status, implemented ('true'/'false').",
+  get_feature:
+    "Pass slug as a string. Returns the full feature definition.",
 };
 
 export function formatToolError(toolName: string, rawError: string): ToolErrorResult {

--- a/tests/unit/anthropic.test.ts
+++ b/tests/unit/anthropic.test.ts
@@ -34,7 +34,10 @@ import {
   REQUEST_USER_INPUT_TOOL,
   UPDATE_WORKFLOW_TOOL,
   VALIDATE_WORKFLOW_TOOL,
-  UPSERT_FEATURE_TOOL,
+  CREATE_FEATURE_TOOL,
+  UPDATE_FEATURE_TOOL,
+  LIST_FEATURES_TOOL,
+  GET_FEATURE_TOOL,
   BUILTIN_TOOLS,
   FEATURE_CREATOR_TOOLS,
 } from "../../src/lib/anthropic.js";
@@ -467,33 +470,65 @@ describe("BUILTIN_TOOLS", () => {
   });
 });
 
-describe("UPSERT_FEATURE_TOOL", () => {
-  it("has correct name and all required parameters", () => {
-    expect(UPSERT_FEATURE_TOOL.name).toBe("upsert_feature");
-    const schema = UPSERT_FEATURE_TOOL.input_schema as {
+describe("Feature-creator tools", () => {
+  it("CREATE_FEATURE_TOOL has correct name and required parameters (slug optional)", () => {
+    expect(CREATE_FEATURE_TOOL.name).toBe("create_feature");
+    const schema = CREATE_FEATURE_TOOL.input_schema as {
       properties: Record<string, unknown>;
       required: string[];
     };
     expect(schema.properties).toHaveProperty("slug");
     expect(schema.properties).toHaveProperty("name");
-    expect(schema.properties).toHaveProperty("description");
-    expect(schema.properties).toHaveProperty("category");
-    expect(schema.properties).toHaveProperty("channel");
-    expect(schema.properties).toHaveProperty("audienceType");
     expect(schema.properties).toHaveProperty("inputs");
     expect(schema.properties).toHaveProperty("outputs");
-    expect(schema.required).toEqual([
-      "slug", "name", "description", "category", "channel", "audienceType", "inputs", "outputs",
-    ]);
+    // slug is optional (auto-generated from name)
+    expect(schema.required).not.toContain("slug");
+    expect(schema.required).toContain("name");
+    expect(schema.required).toContain("inputs");
+    expect(schema.required).toContain("outputs");
+  });
+
+  it("UPDATE_FEATURE_TOOL requires only slug", () => {
+    expect(UPDATE_FEATURE_TOOL.name).toBe("update_feature");
+    const schema = UPDATE_FEATURE_TOOL.input_schema as {
+      properties: Record<string, unknown>;
+      required: string[];
+    };
+    expect(schema.required).toEqual(["slug"]);
+    expect(schema.properties).toHaveProperty("name");
+    expect(schema.properties).toHaveProperty("inputs");
+  });
+
+  it("LIST_FEATURES_TOOL has no required parameters", () => {
+    expect(LIST_FEATURES_TOOL.name).toBe("list_features");
+    const schema = LIST_FEATURES_TOOL.input_schema as {
+      properties: Record<string, unknown>;
+      required?: string[];
+    };
+    expect(schema.required).toBeUndefined();
+    expect(schema.properties).toHaveProperty("category");
+    expect(schema.properties).toHaveProperty("channel");
+  });
+
+  it("GET_FEATURE_TOOL requires slug", () => {
+    expect(GET_FEATURE_TOOL.name).toBe("get_feature");
+    const schema = GET_FEATURE_TOOL.input_schema as {
+      properties: Record<string, unknown>;
+      required: string[];
+    };
+    expect(schema.required).toEqual(["slug"]);
   });
 });
 
 describe("FEATURE_CREATOR_TOOLS", () => {
-  it("includes only request_user_input and upsert_feature", () => {
+  it("includes all 5 feature-creator tools", () => {
     const names = FEATURE_CREATOR_TOOLS.map((t) => t.name);
     expect(names).toContain("request_user_input");
-    expect(names).toContain("upsert_feature");
-    expect(FEATURE_CREATOR_TOOLS).toHaveLength(2);
+    expect(names).toContain("create_feature");
+    expect(names).toContain("update_feature");
+    expect(names).toContain("list_features");
+    expect(names).toContain("get_feature");
+    expect(FEATURE_CREATOR_TOOLS).toHaveLength(5);
   });
 
   it("does not include workflow tools", () => {

--- a/tests/unit/features-client.test.ts
+++ b/tests/unit/features-client.test.ts
@@ -239,3 +239,106 @@ describe("updateFeature", () => {
     expect(calledUrl).toContain("slug%20with%20spaces");
   });
 });
+
+describe("listFeatures", () => {
+  it("sends GET /features with query params", async () => {
+    const mockFeatures = [sampleFeature];
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockFeatures),
+    });
+
+    const { listFeatures } = await loadModule();
+    const result = await listFeatures(
+      { category: "sales", channel: "email", audienceType: "cold-outreach" },
+      { orgId: "org-1", userId: "user-1", runId: "run-1" },
+    );
+
+    const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(calledUrl).toContain("/features?");
+    expect(calledUrl).toContain("category=sales");
+    expect(calledUrl).toContain("channel=email");
+    expect(calledUrl).toContain("audienceType=cold-outreach");
+    expect(result).toEqual(mockFeatures);
+  });
+
+  it("sends GET /features without query params when no filters", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+    });
+
+    const { listFeatures } = await loadModule();
+    await listFeatures({}, { orgId: "o", userId: "u", runId: "r" });
+
+    const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(calledUrl).toBe("https://features.test.local/features");
+  });
+
+  it("throws on HTTP error", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("Server error"),
+    });
+
+    const { listFeatures } = await loadModule();
+    await expect(
+      listFeatures({ category: "sales" }, { orgId: "o", userId: "u", runId: "r" }),
+    ).rejects.toThrow(/returned 500/);
+  });
+});
+
+describe("getFeature", () => {
+  it("sends GET /features/:slug with correct URL and headers", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(sampleFeature),
+    });
+
+    const { getFeature } = await loadModule();
+    const result = await getFeature("cold-email-outreach", {
+      orgId: "org-1",
+      userId: "user-1",
+      runId: "run-1",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://features.test.local/features/cold-email-outreach",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          "x-api-key": "test-feat-key",
+          "x-org-id": "org-1",
+        }),
+      }),
+    );
+    expect(result.slug).toBe("cold-email-outreach");
+  });
+
+  it("throws on HTTP 404", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve("Not found"),
+    });
+
+    const { getFeature } = await loadModule();
+    await expect(
+      getFeature("nonexistent", { orgId: "o", userId: "u", runId: "r" }),
+    ).rejects.toThrow(/returned 404/);
+  });
+
+  it("URL-encodes the slug", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(sampleFeature),
+    });
+
+    const { getFeature } = await loadModule();
+    await getFeature("slug with spaces", { orgId: "o", userId: "u", runId: "r" });
+
+    const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(calledUrl).toContain("slug%20with%20spaces");
+  });
+});


### PR DESCRIPTION
## Summary
- Replace single `upsert_feature` tool with 4 separate tools matching features-service PR #13 endpoints:
  - `create_feature` → `POST /features` (201, 409 on conflict)
  - `update_feature` → `PUT /features/:slug` (partial update)
  - `list_features` → `GET /features` (with category/channel/audienceType/status/implemented filters)
  - `get_feature` → `GET /features/:slug`
- Feature-creator context now has 5 tools: `request_user_input` + the 4 feature tools
- Added `listFeatures()` and `getFeature()` to features-client

## Test plan
- [x] Unit tests for all 4 client functions (createFeature, updateFeature, listFeatures, getFeature)
- [x] Unit tests for all 4 tool definitions (schema, required params)
- [x] FEATURE_CREATOR_TOOLS export includes all 5 tools
- [x] All 224 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)