### PR TITLE
fix: align feature tool schemas with features-service API

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,8 +204,8 @@ When `context.type` is `"feature-creator"`, the standard workflow tools above ar
 | Tool | Description |
 |---|---|
 | `request_user_input` | Asks the user for structured input (same as above) |
-| `create_feature` | Creates a new feature via `POST /features`. Slug is optional (auto-generated from name). Returns 409 on conflict. |
-| `update_feature` | Updates an existing feature by slug via `PUT /features/:slug`. Partial update — only provided fields change. |
+| `create_feature` | Creates a new feature via `POST /features`. Required: name, description, **icon**, category, channel, audienceType, inputs (with key/label/**type**/**placeholder**/description/**extractKey**), outputs (with key/label/**type**/**displayOrder**/**showInCampaignRow**/**showInFunnel**). Slug optional. Returns 409 on conflict. |
+| `update_feature` | Updates an existing feature by slug via `PUT /features/:slug`. Partial update — only provided fields change. Input/output items must include all required sub-fields when provided. |
 | `list_features` | Lists features via `GET /features` with optional filters (category, channel, audienceType, status, implemented). |
 | `get_feature` | Gets full feature details by slug via `GET /features/:slug`. |
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -748,16 +748,7 @@ app.post("/chat", requireAuth, async (req, res) => {
       if (call.name === "create_feature") {
         const args = (call.args as Record<string, unknown>) || {};
         const result = await createFeature(
-          {
-            slug: args.slug as string,
-            name: args.name as string,
-            description: args.description as string,
-            category: args.category as string,
-            channel: args.channel as string,
-            audienceType: args.audienceType as string,
-            inputs: args.inputs as { key: string; label: string; description: string }[],
-            outputs: args.outputs as { key: string; label: string; description: string }[],
-          },
+          args as unknown as import("./lib/features-client.js").CreateFeatureBody,
           featureCallParams,
         );
         toolCalls.push({ name: call.name, args, result });
@@ -769,7 +760,7 @@ app.post("/chat", requireAuth, async (req, res) => {
         const { slug, ...updateBody } = args;
         const result = await updateFeature(
           slug as string,
-          updateBody as Partial<{ name: string; description: string; category: string; channel: string; audienceType: string; inputs: { key: string; label: string; description: string }[]; outputs: { key: string; label: string; description: string }[] }>,
+          updateBody as Partial<Omit<import("./lib/features-client.js").CreateFeatureBody, "slug">>,
           featureCallParams,
         );
         toolCalls.push({ name: call.name, args, result });

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -265,14 +265,34 @@ export const LIST_WORKFLOWS_TOOL: Anthropic.Tool = {
 // Feature-creator tools (available only when context.type === "feature-creator")
 // ---------------------------------------------------------------------------
 
-const featureFieldItems = {
+const featureInputItems = {
   type: "object" as const,
   properties: {
-    key: { type: "string", description: "Machine-readable key (e.g. 'targetCompanyUrl')" },
+    key: { type: "string", description: "Machine-readable input key (e.g. 'targetCompanyUrl')" },
     label: { type: "string", description: "Human-readable label (e.g. 'Target Company URL')" },
-    description: { type: "string", description: "What this field is for" },
+    type: { type: "string", enum: ["text", "textarea", "number", "select"], description: "Input field type" },
+    placeholder: { type: "string", description: "Placeholder text shown in the input (e.g. 'https://example.com')" },
+    description: { type: "string", description: "What this input is for" },
+    extractKey: { type: "string", description: "Key used to extract this value from enrichment data (e.g. 'company_url')" },
+    options: { type: "array", items: { type: "string" }, description: "Options for select-type inputs (only when type is 'select')" },
   },
-  required: ["key", "label", "description"],
+  required: ["key", "label", "type", "placeholder", "description", "extractKey"],
+};
+
+const featureOutputItems = {
+  type: "object" as const,
+  properties: {
+    key: { type: "string", description: "Machine-readable output key (e.g. 'emailsSent')" },
+    label: { type: "string", description: "Human-readable label (e.g. 'Emails Sent')" },
+    type: { type: "string", enum: ["count", "rate", "currency", "percentage"], description: "Output metric type" },
+    displayOrder: { type: "integer", description: "Order in which this output appears in the UI (0-based)" },
+    showInCampaignRow: { type: "boolean", description: "Whether to show this metric in the campaign list row" },
+    showInFunnel: { type: "boolean", description: "Whether to include this metric in the funnel visualization" },
+    funnelOrder: { type: "integer", description: "Order in the funnel (optional, only when showInFunnel is true)" },
+    numeratorKey: { type: "string", description: "For rate metrics: key of the numerator output (optional)" },
+    denominatorKey: { type: "string", description: "For rate metrics: key of the denominator output (optional)" },
+  },
+  required: ["key", "label", "type", "displayOrder", "showInCampaignRow", "showInFunnel"],
 };
 
 export const CREATE_FEATURE_TOOL: Anthropic.Tool = {
@@ -295,6 +315,10 @@ export const CREATE_FEATURE_TOOL: Anthropic.Tool = {
         type: "string",
         description: "Brief description of what the feature does",
       },
+      icon: {
+        type: "string",
+        description: "Icon identifier for the feature (e.g. 'mail', 'linkedin', 'phone')",
+      },
       category: {
         type: "string",
         description: "Feature category (e.g. 'sales', 'pr', 'marketing')",
@@ -309,16 +333,16 @@ export const CREATE_FEATURE_TOOL: Anthropic.Tool = {
       },
       inputs: {
         type: "array",
-        items: featureFieldItems,
-        description: "Input fields the user must provide to run this feature",
+        items: featureInputItems,
+        description: "Input fields the user must provide to run this feature (min 1)",
       },
       outputs: {
         type: "array",
-        items: featureFieldItems,
-        description: "Output fields the feature produces",
+        items: featureOutputItems,
+        description: "Output metrics the feature produces (min 1)",
       },
     },
-    required: ["name", "description", "category", "channel", "audienceType", "inputs", "outputs"],
+    required: ["name", "description", "icon", "category", "channel", "audienceType", "inputs", "outputs"],
   },
 };
 
@@ -331,21 +355,22 @@ export const UPDATE_FEATURE_TOOL: Anthropic.Tool = {
     properties: {
       slug: {
         type: "string",
-        description: "The slug of the feature to update. If available in context, use it directly.",
+        description: "The slug of the feature to update.",
       },
       name: { type: "string", description: "New feature name (optional)" },
       description: { type: "string", description: "New feature description (optional)" },
+      icon: { type: "string", description: "New icon identifier (optional)" },
       category: { type: "string", description: "New category (optional)" },
       channel: { type: "string", description: "New channel (optional)" },
       audienceType: { type: "string", description: "New audience type (optional)" },
       inputs: {
         type: "array",
-        items: featureFieldItems,
+        items: featureInputItems,
         description: "New input fields (replaces all existing inputs)",
       },
       outputs: {
         type: "array",
-        items: featureFieldItems,
+        items: featureOutputItems,
         description: "New output fields (replaces all existing outputs)",
       },
     },

--- a/src/lib/features-client.ts
+++ b/src/lib/features-client.ts
@@ -31,32 +31,50 @@ function buildHeaders(params: FeaturesCallParams): Record<string, string> {
   return headers;
 }
 
-export interface FeatureFieldDef {
+export interface FeatureInputDef {
   key: string;
   label: string;
+  type: "text" | "textarea" | "number" | "select";
+  placeholder: string;
   description: string;
+  extractKey: string;
+  options?: string[];
 }
 
-export interface UpsertFeatureBody {
-  slug: string;
+export interface FeatureOutputDef {
+  key: string;
+  label: string;
+  type: "count" | "rate" | "currency" | "percentage";
+  displayOrder: number;
+  showInCampaignRow: boolean;
+  showInFunnel: boolean;
+  funnelOrder?: number;
+  numeratorKey?: string;
+  denominatorKey?: string;
+}
+
+export interface CreateFeatureBody {
+  slug?: string;
   name: string;
   description: string;
+  icon: string;
   category: string;
   channel: string;
   audienceType: string;
-  inputs: FeatureFieldDef[];
-  outputs: FeatureFieldDef[];
+  inputs: FeatureInputDef[];
+  outputs: FeatureOutputDef[];
 }
 
 export interface FeatureResponse {
   slug: string;
   name: string;
   description: string;
+  icon: string;
   category: string;
   channel: string;
   audienceType: string;
-  inputs: FeatureFieldDef[];
-  outputs: FeatureFieldDef[];
+  inputs: FeatureInputDef[];
+  outputs: FeatureOutputDef[];
   [key: string]: unknown;
 }
 
@@ -66,7 +84,7 @@ export interface FeatureResponse {
  * Returns 201 on success, throws on 409 (conflict) or other errors.
  */
 export async function createFeature(
-  body: UpsertFeatureBody,
+  body: CreateFeatureBody,
   params: FeaturesCallParams,
 ): Promise<FeatureResponse> {
   const url = `${FEATURES_SERVICE_URL}/features`;
@@ -100,7 +118,7 @@ export async function createFeature(
  */
 export async function updateFeature(
   slug: string,
-  body: Partial<Omit<UpsertFeatureBody, "slug">>,
+  body: Partial<Omit<CreateFeatureBody, "slug">>,
   params: FeaturesCallParams,
 ): Promise<FeatureResponse> {
   const url = `${FEATURES_SERVICE_URL}/features/${encodeURIComponent(slug)}`;

--- a/src/lib/tool-errors.ts
+++ b/src/lib/tool-errors.ts
@@ -59,9 +59,9 @@ const TOOL_HINTS: Record<string, string> = {
   list_available_services:
     "No parameters needed. Returns all services and their endpoints.",
   create_feature:
-    "Pass name, description, category, channel, audienceType, inputs (array of {key, label, description}), and outputs (array of {key, label, description}). Slug is optional (auto-generated from name). Returns 409 if slug/name already exists.",
+    "Pass name, description, icon, category, channel, audienceType, inputs (array of {key, label, type, placeholder, description, extractKey}), and outputs (array of {key, label, type, displayOrder, showInCampaignRow, showInFunnel}). Slug is optional. Returns 409 if slug/name already exists.",
   update_feature:
-    "Pass slug (required) and any fields to update: name, description, category, channel, audienceType, inputs, outputs. Only provided fields are changed.",
+    "Pass slug (required) and any fields to update: name, description, icon, category, channel, audienceType, inputs, outputs. Only provided fields are changed. Input/output items must include all required fields when provided.",
   list_features:
     "All parameters are optional: category, channel, audienceType, status, implemented ('true'/'false').",
   get_feature:

--- a/tests/unit/anthropic.test.ts
+++ b/tests/unit/anthropic.test.ts
@@ -471,24 +471,35 @@ describe("BUILTIN_TOOLS", () => {
 });
 
 describe("Feature-creator tools", () => {
-  it("CREATE_FEATURE_TOOL has correct name and required parameters (slug optional)", () => {
+  it("CREATE_FEATURE_TOOL has icon required and full input/output schemas", () => {
     expect(CREATE_FEATURE_TOOL.name).toBe("create_feature");
     const schema = CREATE_FEATURE_TOOL.input_schema as {
-      properties: Record<string, unknown>;
+      properties: Record<string, { items?: { required?: string[]; properties?: Record<string, unknown> } }>;
       required: string[];
     };
     expect(schema.properties).toHaveProperty("slug");
-    expect(schema.properties).toHaveProperty("name");
-    expect(schema.properties).toHaveProperty("inputs");
-    expect(schema.properties).toHaveProperty("outputs");
-    // slug is optional (auto-generated from name)
+    expect(schema.properties).toHaveProperty("icon");
+    // slug optional, icon required
     expect(schema.required).not.toContain("slug");
+    expect(schema.required).toContain("icon");
     expect(schema.required).toContain("name");
     expect(schema.required).toContain("inputs");
     expect(schema.required).toContain("outputs");
+
+    // Input items: 6 required fields
+    const inputItems = schema.properties.inputs.items!;
+    expect(inputItems.required).toEqual(["key", "label", "type", "placeholder", "description", "extractKey"]);
+    expect(inputItems.properties).toHaveProperty("options");
+
+    // Output items: 6 required fields
+    const outputItems = schema.properties.outputs.items!;
+    expect(outputItems.required).toEqual(["key", "label", "type", "displayOrder", "showInCampaignRow", "showInFunnel"]);
+    expect(outputItems.properties).toHaveProperty("funnelOrder");
+    expect(outputItems.properties).toHaveProperty("numeratorKey");
+    expect(outputItems.properties).toHaveProperty("denominatorKey");
   });
 
-  it("UPDATE_FEATURE_TOOL requires only slug", () => {
+  it("UPDATE_FEATURE_TOOL requires only slug, has icon field", () => {
     expect(UPDATE_FEATURE_TOOL.name).toBe("update_feature");
     const schema = UPDATE_FEATURE_TOOL.input_schema as {
       properties: Record<string, unknown>;
@@ -496,6 +507,7 @@ describe("Feature-creator tools", () => {
     };
     expect(schema.required).toEqual(["slug"]);
     expect(schema.properties).toHaveProperty("name");
+    expect(schema.properties).toHaveProperty("icon");
     expect(schema.properties).toHaveProperty("inputs");
   });
 

--- a/tests/unit/features-client.test.ts
+++ b/tests/unit/features-client.test.ts
@@ -22,14 +22,15 @@ const sampleFeature = {
   slug: "cold-email-outreach",
   name: "Cold Email Outreach",
   description: "Automated cold email outreach campaign",
+  icon: "mail",
   category: "sales",
   channel: "email",
   audienceType: "cold-outreach",
   inputs: [
-    { key: "targetCompanyUrl", label: "Target Company URL", description: "URL of the company to prospect" },
+    { key: "targetCompanyUrl", label: "Target Company URL", type: "text" as const, placeholder: "https://example.com", description: "URL of the company to prospect", extractKey: "company_url" },
   ],
   outputs: [
-    { key: "generatedEmail", label: "Generated Email", description: "The generated cold email" },
+    { key: "emailsSent", label: "Emails Sent", type: "count" as const, displayOrder: 0, showInCampaignRow: true, showInFunnel: true },
   ],
 };
 


### PR DESCRIPTION
## Summary
- Add missing `icon` field (required on create, optional on update)
- Fix `inputs` schema: add `type` (text/textarea/number/select), `placeholder`, `extractKey` — all required by features-service
- Fix `outputs` schema: add `type` (count/rate/currency/percentage), `displayOrder`, `showInCampaignRow`, `showInFunnel` — all required by features-service
- Also add optional fields: `options` (inputs), `funnelOrder`/`numeratorKey`/`denominatorKey` (outputs)
- Update `features-client.ts` interfaces (`FeatureInputDef`, `FeatureOutputDef`, `CreateFeatureBody`) to match real API types

## Test plan
- [x] Tool definition tests verify all required fields in input/output item schemas
- [x] features-client tests use realistic sample data matching the real API
- [x] All 224 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)