### PR TITLE
fix: graceful shutdown for SSE streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,10 @@ docker run -p 3002:3002 --env-file .env chat-service
 
 Uses `node:20-alpine`. Requires Node >= 20.
 
+### Graceful Shutdown
+
+On `SIGTERM` / `SIGINT`, the server stops accepting new connections and waits up to 25 seconds for in-flight SSE streams to finish before exiting. This prevents active chat streams from being killed during Railway deployments.
+
 ## Architecture
 
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1148,9 +1148,28 @@ if (process.env.NODE_ENV !== "test") {
   migrate(db, { migrationsFolder: "./drizzle" })
     .then(() => {
       console.log("Migrations complete");
-      app.listen(Number(PORT), "::", () => {
+      const server = app.listen(Number(PORT), "::", () => {
         console.log(`Service running on port ${PORT}`);
       });
+
+      // Graceful shutdown: let in-flight SSE streams finish before exiting
+      const DRAIN_TIMEOUT_MS = 25_000; // Railway sends SIGKILL after 30s
+
+      const shutdown = (signal: string) => {
+        console.log(`[shutdown] Received ${signal}, draining connections…`);
+        server.close(() => {
+          console.log("[shutdown] All connections closed, exiting.");
+          process.exit(0);
+        });
+
+        setTimeout(() => {
+          console.log("[shutdown] Drain timeout reached, forcing exit.");
+          process.exit(0);
+        }, DRAIN_TIMEOUT_MS).unref();
+      };
+
+      process.on("SIGTERM", () => shutdown("SIGTERM"));
+      process.on("SIGINT", () => shutdown("SIGINT"));
     })
     .catch((err) => {
       console.error("Startup failed:", err);

--- a/tests/unit/graceful-shutdown.test.ts
+++ b/tests/unit/graceful-shutdown.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import http from "http";
+import express from "express";
+
+/**
+ * Tests for the graceful shutdown logic.
+ *
+ * Rather than spawning the real server (which needs a database), we replicate
+ * the shutdown wiring from src/index.ts on a lightweight Express server to
+ * verify the behaviour in isolation.
+ */
+
+function wireShutdown(server: http.Server, drainTimeoutMs: number) {
+  const logs: string[] = [];
+
+  const shutdown = (signal: string) => {
+    logs.push(`[shutdown] Received ${signal}, draining connections…`);
+    server.close(() => {
+      logs.push("[shutdown] All connections closed, exiting.");
+    });
+
+    setTimeout(() => {
+      logs.push("[shutdown] Drain timeout reached, forcing exit.");
+    }, drainTimeoutMs).unref();
+  };
+
+  return { shutdown, logs };
+}
+
+describe("graceful shutdown", () => {
+  let server: http.Server;
+
+  afterEach(() => {
+    try {
+      server?.close();
+    } catch {
+      /* already closed */
+    }
+  });
+
+  it("closes idle server immediately and logs drain message", async () => {
+    const app = express();
+    app.get("/health", (_req, res) => res.json({ status: "ok" }));
+
+    server = app.listen(0); // random port
+    const { shutdown, logs } = wireShutdown(server, 5_000);
+
+    // Trigger shutdown
+    shutdown("SIGTERM");
+
+    // Wait a tick for server.close callback
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(logs).toContain("[shutdown] Received SIGTERM, draining connections…");
+    expect(logs).toContain("[shutdown] All connections closed, exiting.");
+  });
+
+  it("waits for in-flight SSE connections before closing", async () => {
+    const app = express();
+
+    // Simulate an SSE endpoint that stays open
+    let sseRes: express.Response | null = null;
+    app.get("/stream", (_req, res) => {
+      res.writeHead(200, { "Content-Type": "text/event-stream" });
+      res.write("data: hello\n\n");
+      sseRes = res;
+    });
+
+    server = app.listen(0);
+    const addr = server.address() as { port: number };
+    const { shutdown, logs } = wireShutdown(server, 5_000);
+
+    // Open an SSE connection
+    const clientReq = http.get(`http://127.0.0.1:${addr.port}/stream`);
+    await new Promise<void>((resolve) => {
+      clientReq.on("response", () => resolve());
+    });
+
+    // Trigger shutdown — server should NOT close yet because the SSE stream is open
+    shutdown("SIGTERM");
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(logs).toContain("[shutdown] Received SIGTERM, draining connections…");
+    expect(logs).not.toContain("[shutdown] All connections closed, exiting.");
+
+    // Now close the SSE stream and destroy client socket — server should finish draining
+    sseRes!.end();
+    clientReq.destroy();
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(logs).toContain("[shutdown] All connections closed, exiting.");
+  });
+
+  it("force-exits after drain timeout when connections hang", async () => {
+    vi.useFakeTimers();
+
+    const app = express();
+    let sseRes: express.Response | null = null;
+    app.get("/stream", (_req, res) => {
+      res.writeHead(200, { "Content-Type": "text/event-stream" });
+      res.write("data: hello\n\n");
+      sseRes = res;
+    });
+
+    server = app.listen(0);
+    const addr = server.address() as { port: number };
+    const { shutdown, logs } = wireShutdown(server, 5_000);
+
+    // Open a hanging SSE connection
+    const clientReq = http.get(`http://127.0.0.1:${addr.port}/stream`);
+    await vi.advanceTimersByTimeAsync(50);
+
+    // Trigger shutdown
+    shutdown("SIGTERM");
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(logs).toContain("[shutdown] Received SIGTERM, draining connections…");
+    expect(logs).not.toContain("[shutdown] All connections closed, exiting.");
+
+    // Advance past drain timeout
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(logs).toContain("[shutdown] Drain timeout reached, forcing exit.");
+
+    // Cleanup
+    clientReq.destroy();
+    sseRes?.end();
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds SIGTERM/SIGINT handler that stops accepting new connections and waits up to 25s for in-flight SSE streams to finish before exiting
- Prevents active chat streams from being killed during Railway deployments
- Adds 3 unit tests covering idle shutdown, in-flight stream draining, and drain timeout behavior

## Test plan
- [x] Unit tests pass (3 new tests in `graceful-shutdown.test.ts`)
- [x] Full test suite passes (247 tests)
- [ ] Deploy and verify: during a deploy, active SSE streams should complete instead of being killed

🤖 Generated with [Claude Code](https://claude.com/claude-code)