### PR TITLE
fix: disable requestTimeout for long SSE streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,10 @@ Uses `node:20-alpine`. Requires Node >= 20.
 
 On `SIGTERM` / `SIGINT`, the server stops accepting new connections and waits up to 25 seconds for in-flight SSE streams to finish before exiting. This prevents active chat streams from being killed during Railway deployments.
 
+### SSE Stream Timeouts
+
+Node 20 defaults `requestTimeout` to 300s (5 min), which would kill long-running SSE streams. The server disables `requestTimeout` entirely (`0`) since chat streams can run for 30–60 min when the LLM makes many tool calls. `headersTimeout` stays at 60s to reject slow/malformed initial requests. `keepAliveTimeout` is set to 120s.
+
 ## Architecture
 
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1152,6 +1152,14 @@ if (process.env.NODE_ENV !== "test") {
         console.log(`Service running on port ${PORT}`);
       });
 
+      // Node 20 defaults requestTimeout to 300s (5 min). SSE chat streams
+      // can run for 30–60 min when the LLM makes many tool calls, so we
+      // disable the request timeout entirely. Headers timeout stays at 60s
+      // to reject slow/malformed initial requests.
+      server.requestTimeout = 0;
+      server.headersTimeout = 60_000;
+      server.keepAliveTimeout = 120_000;
+
       // Graceful shutdown: let in-flight SSE streams finish before exiting
       const DRAIN_TIMEOUT_MS = 25_000; // Railway sends SIGKILL after 30s
 

--- a/tests/unit/graceful-shutdown.test.ts
+++ b/tests/unit/graceful-shutdown.test.ts
@@ -27,6 +27,48 @@ function wireShutdown(server: http.Server, drainTimeoutMs: number) {
   return { shutdown, logs };
 }
 
+function wireServerTimeouts(server: http.Server) {
+  server.requestTimeout = 0;
+  server.headersTimeout = 60_000;
+  server.keepAliveTimeout = 120_000;
+}
+
+describe("server timeouts", () => {
+  let server: http.Server;
+
+  afterEach(() => {
+    try {
+      server?.close();
+    } catch {
+      /* already closed */
+    }
+  });
+
+  it("disables requestTimeout so long-running SSE streams are not killed", () => {
+    const app = express();
+    server = app.listen(0);
+    wireServerTimeouts(server);
+
+    expect(server.requestTimeout).toBe(0);
+  });
+
+  it("keeps headersTimeout at 60s to reject slow initial requests", () => {
+    const app = express();
+    server = app.listen(0);
+    wireServerTimeouts(server);
+
+    expect(server.headersTimeout).toBe(60_000);
+  });
+
+  it("sets keepAliveTimeout to 120s", () => {
+    const app = express();
+    server = app.listen(0);
+    wireServerTimeouts(server);
+
+    expect(server.keepAliveTimeout).toBe(120_000);
+  });
+});
+
 describe("graceful shutdown", () => {
   let server: http.Server;
 


### PR DESCRIPTION
## Summary
- Node 20 defaults `server.requestTimeout` to 300s (5 min), which silently kills long-running SSE chat streams
- Chat sessions with many LLM tool calls can run 30–60 min — the 5-min timeout was cutting them off
- Sets `requestTimeout=0` (disabled), `headersTimeout=60s`, `keepAliveTimeout=120s`
- Adds 3 new unit tests for timeout configuration

## Test plan
- [x] 6 unit tests pass in `graceful-shutdown.test.ts` (3 shutdown + 3 timeout)
- [x] Full suite passes (250 tests)
- [ ] Deploy and verify long-running chat sessions are no longer interrupted

🤖 Generated with [Claude Code](https://claude.com/claude-code)