### PR TITLE
fix: strip tool_use blocks from history to prevent 400 errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const openapiPath = join(__dirname, "..", "openapi.json");
 
-import { mergeConsecutiveMessages } from "./lib/merge-messages.js";
+import { mergeConsecutiveMessages, stripToolUseBlocks } from "./lib/merge-messages.js";
 
 const app = express();
 app.use(cors());
@@ -467,15 +467,26 @@ app.post("/chat", requireAuth, async (req, res) => {
     });
 
     // Build Anthropic message history — use contentBlocks if available (preserves compaction blocks)
+    // Strip tool_use blocks: intermediate tool calls are ephemeral and not persisted with
+    // matching tool_result messages, so including them causes Anthropic API validation errors.
     // Ensure alternating user/assistant roles (merge consecutive same-role messages)
     const rawHistory: Anthropic.MessageParam[] = history
       .filter((m) => m.role !== "tool")
-      .map((m) => ({
-        role: m.role as "user" | "assistant",
-        content: (m.role === "assistant" && m.contentBlocks
-          ? m.contentBlocks as Anthropic.ContentBlockParam[]
-          : m.content) as string | Anthropic.ContentBlockParam[],
-      }));
+      .map((m) => {
+        if (m.role === "assistant" && m.contentBlocks) {
+          const blocks = stripToolUseBlocks(
+            m.contentBlocks as Anthropic.ContentBlockParam[],
+          );
+          return {
+            role: "assistant" as const,
+            content: blocks.length > 0 ? blocks : (m.content as string),
+          };
+        }
+        return {
+          role: m.role as "user" | "assistant",
+          content: m.content as string | Anthropic.ContentBlockParam[],
+        };
+      });
 
     const anthropicHistory = mergeConsecutiveMessages(rawHistory);
 
@@ -1050,13 +1061,18 @@ app.post("/chat", requireAuth, async (req, res) => {
     }
 
     // Save assistant message with cleaned response + content blocks for compaction
+    // Strip tool_use blocks — they are ephemeral (tool results aren't saved as separate
+    // messages), so persisting them causes missing tool_result errors on next load.
     const cleanedResponse =
       buttons.length > 0 ? stripButtons(fullResponse) : fullResponse;
+    const persistBlocks = stripToolUseBlocks(
+      lastContentBlocks as Anthropic.ContentBlockParam[],
+    );
     await db.insert(messages).values({
       sessionId: currentSessionId,
       role: "assistant",
       content: cleanedResponse,
-      contentBlocks: lastContentBlocks.length > 0 ? lastContentBlocks : null,
+      contentBlocks: persistBlocks.length > 0 ? persistBlocks : null,
       toolCalls: toolCalls.length > 0 ? toolCalls : null,
       buttons: buttons.length > 0 ? buttons : null,
       tokenCount: totalPromptTokens + totalOutputTokens || null,

--- a/src/lib/merge-messages.ts
+++ b/src/lib/merge-messages.ts
@@ -25,3 +25,16 @@ export function mergeConsecutiveMessages(
   }
   return result;
 }
+
+/**
+ * Strip tool_use blocks from content blocks.
+ * Tool calls are ephemeral within a single request's agentic loop — their
+ * matching tool_result messages are never persisted. Including orphaned
+ * tool_use blocks in history causes Anthropic to reject the request with
+ * "tool_use ids were found without tool_result blocks immediately after".
+ */
+export function stripToolUseBlocks(
+  blocks: Anthropic.ContentBlockParam[],
+): Anthropic.ContentBlockParam[] {
+  return blocks.filter((b) => b.type !== "tool_use");
+}

--- a/tests/unit/strip-tool-use.test.ts
+++ b/tests/unit/strip-tool-use.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import type Anthropic from "@anthropic-ai/sdk";
+
+import { stripToolUseBlocks } from "../../src/lib/merge-messages.js";
+
+describe("stripToolUseBlocks", () => {
+  it("removes tool_use blocks from content", () => {
+    const blocks: Anthropic.ContentBlockParam[] = [
+      { type: "text", text: "Let me check that." },
+      {
+        type: "tool_use",
+        id: "toolu_01ECkCYdeGo3aYJUiVXNzGru",
+        name: "get_workflow_details",
+        input: { workflowId: "abc-123" },
+      },
+      {
+        type: "tool_use",
+        id: "toolu_01GBCV9Ja2yqZb2m2WXHcHeQ",
+        name: "request_user_input",
+        input: { input_type: "text", label: "URL?", field: "url" },
+      },
+    ];
+
+    const result = stripToolUseBlocks(blocks);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ type: "text", text: "Let me check that." });
+  });
+
+  it("returns all blocks when none are tool_use", () => {
+    const blocks: Anthropic.ContentBlockParam[] = [
+      { type: "text", text: "Hello" },
+      { type: "text", text: "World" },
+    ];
+
+    const result = stripToolUseBlocks(blocks);
+    expect(result).toEqual(blocks);
+  });
+
+  it("returns empty array when all blocks are tool_use", () => {
+    const blocks: Anthropic.ContentBlockParam[] = [
+      {
+        type: "tool_use",
+        id: "toolu_abc",
+        name: "some_tool",
+        input: {},
+      },
+    ];
+
+    const result = stripToolUseBlocks(blocks);
+    expect(result).toHaveLength(0);
+  });
+
+  it("preserves thinking blocks alongside text", () => {
+    const blocks: Anthropic.ContentBlockParam[] = [
+      { type: "thinking", thinking: "reasoning here" } as Anthropic.ContentBlockParam,
+      { type: "text", text: "My response" },
+      {
+        type: "tool_use",
+        id: "toolu_xyz",
+        name: "request_user_input",
+        input: { input_type: "url", label: "Enter URL", field: "url" },
+      },
+    ];
+
+    const result = stripToolUseBlocks(blocks);
+    expect(result).toHaveLength(2);
+    expect(result[0].type).toBe("thinking");
+    expect(result[1].type).toBe("text");
+  });
+});


### PR DESCRIPTION
## Summary
- Strips `tool_use` blocks from assistant messages when saving to DB and when loading history
- Fixes Anthropic API 400 error: "tool_use ids were found without tool_result blocks immediately after"
- Root cause: when `request_user_input` breaks the agentic loop, orphaned `tool_use` blocks are persisted without matching `tool_result` messages

## Test plan
- [x] New unit tests in `tests/unit/strip-tool-use.test.ts` covering all cases
- [x] Existing tests pass
- [ ] Verify in prod: sessions that previously hit this error should now work on retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)