### PR TITLE
fix: add charts and entities to feature tool schemas

### DIFF
--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -458,8 +458,66 @@ export const CREATE_FEATURE_TOOL: Anthropic.Tool = {
         items: featureOutputItems,
         description: "Output metrics the feature produces (min 1)",
       },
+      charts: {
+        type: "array",
+        description: "Chart definitions for the feature dashboard. At least one chart required. Two types: funnel-bar (sequential conversion steps, min 2 steps) and breakdown-bar (categorical segments, min 2 segments).",
+        items: {
+          oneOf: [
+            {
+              type: "object",
+              properties: {
+                key: { type: "string", description: "Unique chart key (e.g. 'outreach-funnel')" },
+                type: { type: "string", enum: ["funnel-bar"], description: "Funnel bar chart — shows conversion through sequential steps" },
+                title: { type: "string", description: "Chart title (e.g. 'Outreach Funnel')" },
+                displayOrder: { type: "integer", description: "Order in which the chart appears (0-based)" },
+                steps: {
+                  type: "array",
+                  description: "Funnel steps — each key must reference an output key. Min 2 steps.",
+                  minItems: 2,
+                  items: {
+                    type: "object",
+                    properties: { key: { type: "string", description: "Output key this step represents" } },
+                    required: ["key"],
+                  },
+                },
+              },
+              required: ["key", "type", "title", "displayOrder", "steps"],
+            },
+            {
+              type: "object",
+              properties: {
+                key: { type: "string", description: "Unique chart key (e.g. 'reply-sentiment')" },
+                type: { type: "string", enum: ["breakdown-bar"], description: "Breakdown bar chart — shows categorical distribution" },
+                title: { type: "string", description: "Chart title (e.g. 'Reply Sentiment')" },
+                displayOrder: { type: "integer", description: "Order in which the chart appears (0-based)" },
+                segments: {
+                  type: "array",
+                  description: "Breakdown segments — each key must reference an output key. Min 2 segments.",
+                  minItems: 2,
+                  items: {
+                    type: "object",
+                    properties: {
+                      key: { type: "string", description: "Output key this segment represents" },
+                      color: { type: "string", enum: ["green", "blue", "red", "gray", "orange"], description: "Segment color" },
+                      sentiment: { type: "string", enum: ["positive", "neutral", "negative"], description: "Sentiment category" },
+                    },
+                    required: ["key", "color", "sentiment"],
+                  },
+                },
+              },
+              required: ["key", "type", "title", "displayOrder", "segments"],
+            },
+          ],
+        },
+      },
+      entities: {
+        type: "array",
+        description: "Entity types shown in campaign detail sidebar (e.g. ['leads', 'companies', 'emails']). At least one required.",
+        items: { type: "string" },
+        minItems: 1,
+      },
     },
-    required: ["name", "description", "icon", "category", "channel", "audienceType", "inputs", "outputs"],
+    required: ["name", "description", "icon", "category", "channel", "audienceType", "inputs", "outputs", "charts", "entities"],
   },
 };
 
@@ -489,6 +547,61 @@ export const UPDATE_FEATURE_TOOL: Anthropic.Tool = {
         type: "array",
         items: featureOutputItems,
         description: "New output fields (replaces all existing outputs)",
+      },
+      charts: {
+        type: "array",
+        description: "New chart definitions (replaces all existing charts). Two types: funnel-bar and breakdown-bar.",
+        items: {
+          oneOf: [
+            {
+              type: "object",
+              properties: {
+                key: { type: "string" },
+                type: { type: "string", enum: ["funnel-bar"] },
+                title: { type: "string" },
+                displayOrder: { type: "integer" },
+                steps: {
+                  type: "array",
+                  minItems: 2,
+                  items: {
+                    type: "object",
+                    properties: { key: { type: "string" } },
+                    required: ["key"],
+                  },
+                },
+              },
+              required: ["key", "type", "title", "displayOrder", "steps"],
+            },
+            {
+              type: "object",
+              properties: {
+                key: { type: "string" },
+                type: { type: "string", enum: ["breakdown-bar"] },
+                title: { type: "string" },
+                displayOrder: { type: "integer" },
+                segments: {
+                  type: "array",
+                  minItems: 2,
+                  items: {
+                    type: "object",
+                    properties: {
+                      key: { type: "string" },
+                      color: { type: "string", enum: ["green", "blue", "red", "gray", "orange"] },
+                      sentiment: { type: "string", enum: ["positive", "neutral", "negative"] },
+                    },
+                    required: ["key", "color", "sentiment"],
+                  },
+                },
+              },
+              required: ["key", "type", "title", "displayOrder", "segments"],
+            },
+          ],
+        },
+      },
+      entities: {
+        type: "array",
+        description: "New entity types (replaces all existing entities)",
+        items: { type: "string" },
       },
     },
     required: ["slug"],

--- a/src/lib/features-client.ts
+++ b/src/lib/features-client.ts
@@ -53,6 +53,24 @@ export interface FeatureOutputDef {
   denominatorKey?: string;
 }
 
+export interface FunnelBarChart {
+  key: string;
+  type: "funnel-bar";
+  title: string;
+  displayOrder: number;
+  steps: { key: string }[];
+}
+
+export interface BreakdownBarChart {
+  key: string;
+  type: "breakdown-bar";
+  title: string;
+  displayOrder: number;
+  segments: { key: string; color: "green" | "blue" | "red" | "gray" | "orange"; sentiment: "positive" | "neutral" | "negative" }[];
+}
+
+export type FeatureChartDef = FunnelBarChart | BreakdownBarChart;
+
 export interface CreateFeatureBody {
   slug?: string;
   name: string;
@@ -63,6 +81,8 @@ export interface CreateFeatureBody {
   audienceType: string;
   inputs: FeatureInputDef[];
   outputs: FeatureOutputDef[];
+  charts: FeatureChartDef[];
+  entities: string[];
 }
 
 export interface FeatureResponse {

--- a/tests/unit/anthropic.test.ts
+++ b/tests/unit/anthropic.test.ts
@@ -558,6 +558,25 @@ describe("Feature-creator tools", () => {
     expect(schema.required).toContain("name");
     expect(schema.required).toContain("inputs");
     expect(schema.required).toContain("outputs");
+    expect(schema.required).toContain("charts");
+    expect(schema.required).toContain("entities");
+
+    // Charts: array with oneOf (funnel-bar, breakdown-bar)
+    const chartsSchema = schema.properties.charts as { type: string; items: { oneOf: { properties: Record<string, unknown>; required: string[] }[] } };
+    expect(chartsSchema.type).toBe("array");
+    const chartVariants = chartsSchema.items.oneOf;
+    expect(chartVariants).toHaveLength(2);
+    // funnel-bar variant
+    const funnelVariant = chartVariants.find((v) => (v.properties.type as { enum: string[] }).enum[0] === "funnel-bar")!;
+    expect(funnelVariant.required).toContain("steps");
+    // breakdown-bar variant
+    const breakdownVariant = chartVariants.find((v) => (v.properties.type as { enum: string[] }).enum[0] === "breakdown-bar")!;
+    expect(breakdownVariant.required).toContain("segments");
+
+    // Entities: array of strings
+    const entitiesSchema = schema.properties.entities as { type: string; items: { type: string } };
+    expect(entitiesSchema.type).toBe("array");
+    expect(entitiesSchema.items.type).toBe("string");
 
     // Input items: 6 required fields
     const inputItems = schema.properties.inputs.items!;
@@ -582,6 +601,11 @@ describe("Feature-creator tools", () => {
     expect(schema.properties).toHaveProperty("name");
     expect(schema.properties).toHaveProperty("icon");
     expect(schema.properties).toHaveProperty("inputs");
+    expect(schema.properties).toHaveProperty("charts");
+    expect(schema.properties).toHaveProperty("entities");
+    // charts and entities are optional for updates
+    expect(schema.required).not.toContain("charts");
+    expect(schema.required).not.toContain("entities");
   });
 
   it("LIST_FEATURES_TOOL has no required parameters", () => {


### PR DESCRIPTION
## Summary
- The `create_feature` and `update_feature` LLM tool schemas were missing `charts` and `entities` parameters
- The features-service `POST /features` requires both as mandatory fields
- Without them in the schema, the LLM could never include them → every `create_feature` call failed with 400
- Added both fields to `CREATE_FEATURE_TOOL` (required) and `UPDATE_FEATURE_TOOL` (optional)
- Updated `CreateFeatureBody` interface in `features-client.ts` to match
- Added regression tests

## Test plan
- [x] `npm run build` passes
- [x] All anthropic tool schema tests pass (37/37)
- [x] Regression tests verify `charts` and `entities` are present and required in create, optional in update

🤖 Generated with [Claude Code](https://claude.com/claude-code)