### PR TITLE
fix: sync tool schemas with upstream workflow/features APIs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -659,10 +659,15 @@ app.post("/chat", requireAuth, async (req, res) => {
         const args = (call.args as Record<string, unknown>) || {};
         const result = await listWorkflows(
           {
+            featureSlug: args.featureSlug as string | undefined,
             category: args.category as string | undefined,
             channel: args.channel as string | undefined,
-            tags: args.tags as string[] | undefined,
-            search: args.search as string | undefined,
+            audienceType: args.audienceType as string | undefined,
+            tag: args.tag as string | undefined,
+            status: args.status as string | undefined,
+            brandId: args.brandId as string | undefined,
+            humanId: args.humanId as string | undefined,
+            campaignId: args.campaignId as string | undefined,
           },
           {
             orgId,

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -323,13 +323,43 @@ export const GENERATE_WORKFLOW_TOOL: Anthropic.Tool = {
         description:
           "Natural language description of the desired workflow. Be specific about the steps, services, and data flow. Minimum 10 characters.",
       },
+      featureSlug: {
+        type: "string",
+        description:
+          "Feature slug from features-service (e.g. 'cold-email-outreach'). Required — used to build the workflow name.",
+      },
       hints: {
         type: "object",
         description:
           "Optional hints to guide generation. Can include: services (array of service names to scope to), nodeTypes (suggested node types), expectedInputs (expected flow_input field names like 'campaignId').",
       },
+      style: {
+        type: "object",
+        description:
+          "Optional style configuration. When provided, the workflow is generated in the style of the specified human or brand, and the signatureName uses the style name with auto-versioning (e.g. 'hormozi-v1').",
+        properties: {
+          type: {
+            type: "string",
+            enum: ["human", "brand"],
+            description: "Style source type. 'human' for an industry expert, 'brand' for a company/organization.",
+          },
+          humanId: {
+            type: "string",
+            description: "Human ID from human-service. Required when type is 'human'.",
+          },
+          brandId: {
+            type: "string",
+            description: "Brand ID from brand-service. Required when type is 'brand'.",
+          },
+          name: {
+            type: "string",
+            description: "Display name of the human or brand (e.g. 'Hormozi'). Used to build the signatureName.",
+          },
+        },
+        required: ["type", "name"],
+      },
     },
-    required: ["description"],
+    required: ["description", "featureSlug"],
   },
 };
 
@@ -353,26 +383,48 @@ export const GET_WORKFLOW_REQUIRED_PROVIDERS_TOOL: Anthropic.Tool = {
 export const LIST_WORKFLOWS_TOOL: Anthropic.Tool = {
   name: "list_workflows",
   description:
-    "List or search existing workflows. Use this when the user asks to see their workflows, find a specific workflow, or check if a workflow already exists for a given purpose.",
+    "List existing workflows with optional filters. Use this when the user asks to see their workflows, find a specific workflow, or check if a workflow already exists for a given purpose.",
   input_schema: {
     type: "object" as const,
     properties: {
+      featureSlug: {
+        type: "string",
+        description: "Filter by feature slug (e.g. 'cold-email-outreach')",
+      },
       category: {
         type: "string",
-        description: "Filter by category: 'sales' or 'pr' (optional)",
+        enum: ["sales", "pr", "outlets", "journalists"],
+        description: "Filter by category (optional)",
       },
       channel: {
         type: "string",
-        description: "Filter by channel: 'email' (optional)",
+        enum: ["email", "database"],
+        description: "Filter by channel (optional)",
       },
-      tags: {
-        type: "array",
-        items: { type: "string" },
-        description: "Filter by tags (optional)",
-      },
-      search: {
+      audienceType: {
         type: "string",
-        description: "Free-text search across workflow names and descriptions (optional)",
+        enum: ["cold-outreach", "discovery"],
+        description: "Filter by audience type (optional)",
+      },
+      tag: {
+        type: "string",
+        description: "Filter workflows that contain this tag (optional)",
+      },
+      status: {
+        type: "string",
+        description: "Filter by status. Defaults to 'active'. Use 'all' to include deprecated workflows (optional)",
+      },
+      brandId: {
+        type: "string",
+        description: "Filter by brand ID (optional)",
+      },
+      humanId: {
+        type: "string",
+        description: "Filter by human ID (optional)",
+      },
+      campaignId: {
+        type: "string",
+        description: "Filter by campaign ID (optional)",
       },
     },
   },
@@ -399,17 +451,12 @@ const featureInputItems = {
 const featureOutputItems = {
   type: "object" as const,
   properties: {
-    key: { type: "string", description: "Machine-readable output key (e.g. 'emailsSent')" },
-    label: { type: "string", description: "Human-readable label (e.g. 'Emails Sent')" },
-    type: { type: "string", enum: ["count", "rate", "currency", "percentage"], description: "Output metric type" },
+    key: { type: "string", description: "Stats registry key (e.g. 'emailsSent'). Must reference a valid key from GET /stats/registry." },
     displayOrder: { type: "integer", description: "Order in which this output appears in the UI (0-based)" },
-    showInCampaignRow: { type: "boolean", description: "Whether to show this metric in the campaign list row" },
-    showInFunnel: { type: "boolean", description: "Whether to include this metric in the funnel visualization" },
-    funnelOrder: { type: "integer", description: "Order in the funnel (optional, only when showInFunnel is true)" },
-    numeratorKey: { type: "string", description: "For rate metrics: key of the numerator output (optional)" },
-    denominatorKey: { type: "string", description: "For rate metrics: key of the denominator output (optional)" },
+    defaultSort: { type: "boolean", description: "Whether this output is the default sort column (optional)" },
+    sortDirection: { type: "string", enum: ["asc", "desc"], description: "Sort direction when this is the default sort column (optional)" },
   },
-  required: ["key", "label", "type", "displayOrder", "showInCampaignRow", "showInFunnel"],
+  required: ["key", "displayOrder"],
 };
 
 export const CREATE_FEATURE_TOOL: Anthropic.Tool = {
@@ -447,6 +494,19 @@ export const CREATE_FEATURE_TOOL: Anthropic.Tool = {
       audienceType: {
         type: "string",
         description: "Target audience type (e.g. 'cold-outreach', 'warm-leads', 'existing-customers')",
+      },
+      implemented: {
+        type: "boolean",
+        description: "Whether this feature is implemented and ready for use (default: true)",
+      },
+      displayOrder: {
+        type: "integer",
+        description: "Display order in the feature catalogue (default: 0)",
+      },
+      status: {
+        type: "string",
+        enum: ["active", "draft", "deprecated"],
+        description: "Feature lifecycle status (default: 'active')",
       },
       inputs: {
         type: "array",
@@ -538,6 +598,9 @@ export const UPDATE_FEATURE_TOOL: Anthropic.Tool = {
       category: { type: "string", description: "New category (optional)" },
       channel: { type: "string", description: "New channel (optional)" },
       audienceType: { type: "string", description: "New audience type (optional)" },
+      implemented: { type: "boolean", description: "Whether this feature is implemented (optional)" },
+      displayOrder: { type: "integer", description: "New display order (optional)" },
+      status: { type: "string", enum: ["active", "draft", "deprecated"], description: "New status (optional)" },
       inputs: {
         type: "array",
         items: featureInputItems,

--- a/src/lib/features-client.ts
+++ b/src/lib/features-client.ts
@@ -43,14 +43,9 @@ export interface FeatureInputDef {
 
 export interface FeatureOutputDef {
   key: string;
-  label: string;
-  type: "count" | "rate" | "currency" | "percentage";
   displayOrder: number;
-  showInCampaignRow: boolean;
-  showInFunnel: boolean;
-  funnelOrder?: number;
-  numeratorKey?: string;
-  denominatorKey?: string;
+  defaultSort?: boolean;
+  sortDirection?: "asc" | "desc";
 }
 
 export interface FunnelBarChart {
@@ -79,6 +74,9 @@ export interface CreateFeatureBody {
   category: string;
   channel: string;
   audienceType: string;
+  implemented?: boolean;
+  displayOrder?: number;
+  status?: "active" | "draft" | "deprecated";
   inputs: FeatureInputDef[];
   outputs: FeatureOutputDef[];
   charts: FeatureChartDef[];

--- a/src/lib/tool-errors.ts
+++ b/src/lib/tool-errors.ts
@@ -51,7 +51,7 @@ const TOOL_HINTS: Record<string, string> = {
   get_workflow_required_providers:
     "Pass workflowId as a UUID string.",
   list_workflows:
-    "All parameters are optional: category ('sales'|'pr'), channel ('email'), tags (string[]), search (free text).",
+    "All parameters are optional: featureSlug, category ('sales'|'pr'|'outlets'|'journalists'), channel ('email'|'database'), audienceType ('cold-outreach'|'discovery'), tag (string), status (defaults to 'active', use 'all' to include deprecated), brandId, humanId, campaignId.",
   get_prompt_template:
     "Pass type as a string (e.g. 'cold-email', 'follow-up').",
   update_prompt_template:
@@ -59,9 +59,9 @@ const TOOL_HINTS: Record<string, string> = {
   list_available_services:
     "No parameters needed. Returns all services and their endpoints.",
   create_feature:
-    "Pass name, description, icon, category, channel, audienceType, inputs (array of {key, label, type, placeholder, description, extractKey}), and outputs (array of {key, label, type, displayOrder, showInCampaignRow, showInFunnel}). Slug is optional. Returns 409 if slug/name already exists.",
+    "Pass name, description, icon, category, channel, audienceType, inputs (array of {key, label, type, placeholder, description, extractKey}), outputs (array of {key, displayOrder}, keys from stats registry), charts (min 1), and entities (min 1). Optional: slug, implemented, displayOrder, status. Returns 409 if slug/name already exists.",
   update_feature:
-    "Pass slug (required) and any fields to update: name, description, icon, category, channel, audienceType, inputs, outputs. Only provided fields are changed. Input/output items must include all required fields when provided.",
+    "Pass slug (required) and any fields to update: name, description, icon, category, channel, audienceType, implemented, displayOrder, status, inputs, outputs, charts, entities. Only provided fields are changed.",
   list_features:
     "All parameters are optional: category, channel, audienceType, status, implemented ('true'/'false').",
   get_feature:

--- a/src/lib/workflow-client.ts
+++ b/src/lib/workflow-client.ts
@@ -169,6 +169,7 @@ export async function updateWorkflowNodeConfig(
 
 export interface GenerateWorkflowBody {
   description: string;
+  featureSlug: string;
   hints?: {
     services?: string[];
     nodeTypes?: string[];
@@ -224,10 +225,15 @@ export async function getWorkflowRequiredProviders(
 }
 
 export interface ListWorkflowsParams {
+  featureSlug?: string;
   category?: string;
   channel?: string;
-  tags?: string[];
-  search?: string;
+  audienceType?: string;
+  tag?: string;
+  status?: string;
+  brandId?: string;
+  humanId?: string;
+  campaignId?: string;
 }
 
 export async function listWorkflows(
@@ -235,12 +241,15 @@ export async function listWorkflows(
   params: WorkflowCallParams,
 ): Promise<unknown> {
   const query = new URLSearchParams();
+  if (filters.featureSlug) query.set("featureSlug", filters.featureSlug);
   if (filters.category) query.set("category", filters.category);
   if (filters.channel) query.set("channel", filters.channel);
-  if (filters.tags?.length) {
-    for (const tag of filters.tags) query.append("tags", tag);
-  }
-  if (filters.search) query.set("search", filters.search);
+  if (filters.audienceType) query.set("audienceType", filters.audienceType);
+  if (filters.tag) query.set("tag", filters.tag);
+  if (filters.status) query.set("status", filters.status);
+  if (filters.brandId) query.set("brandId", filters.brandId);
+  if (filters.humanId) query.set("humanId", filters.humanId);
+  if (filters.campaignId) query.set("campaignId", filters.campaignId);
 
   const qs = query.toString();
   const url = `${WORKFLOW_SERVICE_URL}/workflows${qs ? `?${qs}` : ""}`;

--- a/tests/unit/anthropic.test.ts
+++ b/tests/unit/anthropic.test.ts
@@ -583,12 +583,11 @@ describe("Feature-creator tools", () => {
     expect(inputItems.required).toEqual(["key", "label", "type", "placeholder", "description", "extractKey"]);
     expect(inputItems.properties).toHaveProperty("options");
 
-    // Output items: 6 required fields
+    // Output items: 2 required fields (key + displayOrder), optional defaultSort + sortDirection
     const outputItems = schema.properties.outputs.items!;
-    expect(outputItems.required).toEqual(["key", "label", "type", "displayOrder", "showInCampaignRow", "showInFunnel"]);
-    expect(outputItems.properties).toHaveProperty("funnelOrder");
-    expect(outputItems.properties).toHaveProperty("numeratorKey");
-    expect(outputItems.properties).toHaveProperty("denominatorKey");
+    expect(outputItems.required).toEqual(["key", "displayOrder"]);
+    expect(outputItems.properties).toHaveProperty("defaultSort");
+    expect(outputItems.properties).toHaveProperty("sortDirection");
   });
 
   it("UPDATE_FEATURE_TOOL requires only slug, has icon field", () => {

--- a/tests/unit/workflow-client.test.ts
+++ b/tests/unit/workflow-client.test.ts
@@ -525,7 +525,7 @@ describe("listWorkflows", () => {
 
     const { listWorkflows } = await loadModule();
     const result = await listWorkflows(
-      { category: "sales", channel: "email", tags: ["cold", "outreach"], search: "lead" },
+      { category: "sales", channel: "email", tag: "cold", featureSlug: "cold-email-outreach", status: "active" },
       { orgId: "org-1", userId: "user-1", runId: "run-1" },
     );
 
@@ -533,9 +533,9 @@ describe("listWorkflows", () => {
     expect(calledUrl).toContain("/workflows?");
     expect(calledUrl).toContain("category=sales");
     expect(calledUrl).toContain("channel=email");
-    expect(calledUrl).toContain("tags=cold");
-    expect(calledUrl).toContain("tags=outreach");
-    expect(calledUrl).toContain("search=lead");
+    expect(calledUrl).toContain("tag=cold");
+    expect(calledUrl).toContain("featureSlug=cold-email-outreach");
+    expect(calledUrl).toContain("status=active");
     expect(result).toEqual(mockWorkflows);
   });
 


### PR DESCRIPTION
## Summary
- **generate_workflow**: added required `featureSlug` and optional `style` params to match upstream
- **list_workflows**: replaced stale `search`/`tags` params with actual upstream filters (`featureSlug`, `tag`, `audienceType`, `status`, `brandId`, `humanId`, `campaignId`)
- **create_feature/update_feature**: replaced old output schema (`label`, `type`, `showInCampaignRow`, `showInFunnel`, `funnelOrder`, `numeratorKey`, `denominatorKey`) with new upstream schema (`key`, `displayOrder`, `defaultSort`, `sortDirection`). Added `implemented`, `displayOrder`, `status` fields.
- Updated TypeScript interfaces in `features-client.ts` and `workflow-client.ts`
- Updated `tool-errors.ts` hints
- Updated existing tests to match new schemas

## Test plan
- [x] Build passes (`npm run build`)
- [x] All unit tests pass (`npm run test:unit`)
- [x] Verified tool schemas match upstream OpenAPI specs via API Registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)