### PR TITLE
feat: sync feature tools with features-service API

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,10 +210,13 @@ When `context.type` is `"feature-creator"`, the standard workflow tools above ar
 | Tool | Description |
 |---|---|
 | `request_user_input` | Asks the user for structured input (same as above) |
-| `create_feature` | Creates a new feature via `POST /features`. Required: name, description, **icon**, category, channel, audienceType, inputs (with key/label/**type**/**placeholder**/description/**extractKey**), outputs (with **key**/**displayOrder**, optional defaultSort/sortDirection — keys from stats registry), charts (min 1), entities (min 1). Optional: slug, implemented, displayOrder, status. Returns 409 on conflict. |
-| `update_feature` | Updates an existing feature by slug via `PUT /features/:slug`. Partial update — only provided fields change. Supports: name, description, icon, category, channel, audienceType, implemented, displayOrder, status, inputs, outputs, charts, entities. |
-| `list_features` | Lists features via `GET /features` with optional filters (category, channel, audienceType, status, implemented). |
+| `create_feature` | Creates a new feature via `POST /features`. Required: name, description, **icon**, category, channel, audienceType, inputs (with key/label/**type**/**placeholder**/description/**extractKey**), outputs (with **key**/**displayOrder**, optional defaultSort/sortDirection — keys from stats registry), charts (min 1), entities (min 1). Optional: slug, implemented, displayOrder, status. Returns 409 on conflict. Response includes `id`, `displayName`, `signature`. |
+| `update_feature` | Updates or forks a feature via `PUT /features/:slug` (fork-on-write). Metadata-only changes update in-place (200). If inputs/outputs change (different signature), a new forked feature is created, the original is deprecated (201). Response includes `forked: boolean`. Supports: name, description, icon, category, channel, audienceType, implemented, displayOrder, status, inputs, outputs, charts, entities. |
+| `list_features` | Lists features via `GET /features` with optional filters (category, channel, audienceType, status, implemented). Responses include `displayName` (stable human label) and `name` (machine identifier, may include version suffix). |
 | `get_feature` | Gets full feature details by slug via `GET /features/:slug`. |
+| `get_feature_inputs` | Gets input definitions only via `GET /features/:slug/inputs`. Lighter than `get_feature`. |
+| `prefill_feature` | Pre-fills feature inputs from brand data via `POST /features/:slug/prefill`. Returns a map of input key → suggested text value. |
+| `get_feature_stats` | Gets computed stats via `GET /features/:slug/stats`. Supports `groupBy` (workflowName, brandId, campaignId) and filter params. Returns system stats (cost, runs, campaigns) and per-output metrics. |
 
 ### 5. Input Request (optional)
 When the AI genuinely needs information it does not have, it emits an input request:
@@ -377,7 +380,7 @@ src/
     runs-client.ts     # RunsService HTTP client for run tracking and cost reporting
     workflow-client.ts              # Workflow-service client for update_workflow and validate_workflow built-in tools
     content-generation-client.ts    # Content-generation service client for get_prompt_template built-in tool
-    features-client.ts              # Features-service client for upsert_feature tool (feature-creator context)
+    features-client.ts              # Features-service client (create, update/fork, list, get, inputs, prefill, stats)
 scripts/
   generate-openapi.ts  # Generates openapi.json from zod schemas via OpenApiGeneratorV3
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ import {
 import { getPromptTemplate, updatePromptTemplate } from "./lib/content-generation-client.js";
 import { listServices, listServiceEndpoints, callApi } from "./lib/api-registry-client.js";
 import { createRun, updateRunStatus, addRunCosts } from "./lib/runs-client.js";
-import { createFeature, updateFeature, listFeatures, getFeature } from "./lib/features-client.js";
+import { createFeature, updateFeature, listFeatures, getFeature, getFeatureInputs, prefillFeature, getFeatureStats } from "./lib/features-client.js";
 import { formatToolError } from "./lib/tool-errors.js";
 import {
   resolveKey,
@@ -854,11 +854,12 @@ app.post("/chat", requireAuth, async (req, res) => {
       if (call.name === "update_feature") {
         const args = (call.args as Record<string, unknown>) || {};
         const { slug, ...updateBody } = args;
-        const result = await updateFeature(
+        const { feature, forked } = await updateFeature(
           slug as string,
           updateBody as Partial<Omit<import("./lib/features-client.js").CreateFeatureBody, "slug">>,
           featureCallParams,
         );
+        const result = { ...feature, forked };
         toolCalls.push({ name: call.name, args, result });
         return { name: call.name, result };
       }
@@ -882,6 +883,36 @@ app.post("/chat", requireAuth, async (req, res) => {
       if (call.name === "get_feature") {
         const args = (call.args as Record<string, unknown>) || {};
         const result = await getFeature(args.slug as string, featureCallParams);
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
+      if (call.name === "get_feature_inputs") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const result = await getFeatureInputs(args.slug as string, featureCallParams);
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
+      if (call.name === "prefill_feature") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const result = await prefillFeature(args.slug as string, featureCallParams);
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
+      if (call.name === "get_feature_stats") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const result = await getFeatureStats(
+          args.slug as string,
+          {
+            groupBy: args.groupBy as "workflowName" | "brandId" | "campaignId" | undefined,
+            brandId: args.brandId as string | undefined,
+            campaignId: args.campaignId as string | undefined,
+            workflowName: args.workflowName as string | undefined,
+          },
+          featureCallParams,
+        );
         toolCalls.push({ name: call.name, args, result });
         return { name: call.name, result };
       }

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -473,7 +473,7 @@ export const CREATE_FEATURE_TOOL: Anthropic.Tool = {
       },
       name: {
         type: "string",
-        description: "Human-readable feature name (e.g. 'Cold Email Outreach')",
+        description: "Machine-readable feature name (e.g. 'Cold Email Outreach'). This becomes the unique identifier — for forked features it may include a version suffix (e.g. 'Cold Email Outreach v2'). The human-readable displayName is derived from this automatically.",
       },
       description: {
         type: "string",
@@ -584,7 +584,7 @@ export const CREATE_FEATURE_TOOL: Anthropic.Tool = {
 export const UPDATE_FEATURE_TOOL: Anthropic.Tool = {
   name: "update_feature",
   description:
-    "Update an existing feature definition by slug. Only provided fields are modified — omit fields you don't want to change. If inputs or outputs change, the feature signature is recomputed automatically. Use this when iterating on an existing feature's design.",
+    "Update an existing feature definition by slug (fork-on-write). Only provided fields are modified — omit fields you don't want to change. If only metadata changes (same signature), the feature is updated in-place. If inputs or outputs change (different signature), a NEW feature is created (forked) with a version suffix, the original is deprecated, and the fork inherits the original's displayName. The response includes a 'forked' boolean indicating which happened.",
   input_schema: {
     type: "object" as const,
     properties: {
@@ -703,6 +703,71 @@ export const GET_FEATURE_TOOL: Anthropic.Tool = {
   },
 };
 
+export const GET_FEATURE_INPUTS_TOOL: Anthropic.Tool = {
+  name: "get_feature_inputs",
+  description:
+    "Get the input field definitions for a feature by slug. Returns the list of inputs the user must provide to run this feature. Lighter than get_feature — use when you only need the input schema.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      slug: {
+        type: "string",
+        description: "The feature slug to look up inputs for.",
+      },
+    },
+    required: ["slug"],
+  },
+};
+
+export const PREFILL_FEATURE_TOOL: Anthropic.Tool = {
+  name: "prefill_feature",
+  description:
+    "Pre-fill input values for a feature using the org's brand data. Returns a map of input key → suggested text value (or null if extraction failed). Use this to auto-populate form fields before the user reviews and submits.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      slug: {
+        type: "string",
+        description: "The feature slug to pre-fill inputs for.",
+      },
+    },
+    required: ["slug"],
+  },
+};
+
+export const GET_FEATURE_STATS_TOOL: Anthropic.Tool = {
+  name: "get_feature_stats",
+  description:
+    "Get computed stats for a feature — cost, run counts, campaign counts, and per-output metrics. Optionally group by workflowName, brandId, or campaignId. System stats (cost, runs, campaigns, dates) are always included.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      slug: {
+        type: "string",
+        description: "The feature slug to get stats for.",
+      },
+      groupBy: {
+        type: "string",
+        enum: ["workflowName", "brandId", "campaignId"],
+        description: "Group stats by this dimension (optional).",
+      },
+      brandId: {
+        type: "string",
+        description: "Filter stats to a specific brand (optional).",
+      },
+      campaignId: {
+        type: "string",
+        description: "Filter stats to a specific campaign (optional).",
+      },
+      workflowName: {
+        type: "string",
+        description: "Filter stats to a specific workflow (optional).",
+      },
+    },
+    required: ["slug"],
+  },
+};
+
 export const BUILTIN_TOOLS: Anthropic.Tool[] = [
   REQUEST_USER_INPUT_TOOL,
   UPDATE_WORKFLOW_TOOL,
@@ -731,6 +796,9 @@ export const FEATURE_CREATOR_TOOLS: Anthropic.Tool[] = [
   UPDATE_FEATURE_TOOL,
   LIST_FEATURES_TOOL,
   GET_FEATURE_TOOL,
+  GET_FEATURE_INPUTS_TOOL,
+  PREFILL_FEATURE_TOOL,
+  GET_FEATURE_STATS_TOOL,
 ];
 
 // ---------------------------------------------------------------------------

--- a/src/lib/features-client.ts
+++ b/src/lib/features-client.ts
@@ -84,15 +84,23 @@ export interface CreateFeatureBody {
 }
 
 export interface FeatureResponse {
+  id: string;
   slug: string;
   name: string;
+  displayName: string;
   description: string;
   icon: string;
   category: string;
   channel: string;
   audienceType: string;
+  implemented: boolean;
+  displayOrder: number;
+  status: "active" | "draft" | "deprecated";
+  signature: string;
   inputs: FeatureInputDef[];
   outputs: FeatureOutputDef[];
+  charts: FeatureChartDef[];
+  entities: string[];
   [key: string]: unknown;
 }
 
@@ -129,16 +137,23 @@ export async function createFeature(
   return (await res.json()) as FeatureResponse;
 }
 
+export interface UpdateFeatureResult {
+  feature: FeatureResponse;
+  /** true when inputs/outputs changed and features-service forked a new version (HTTP 201) */
+  forked: boolean;
+}
+
 /**
- * Partial update an existing feature via PUT /features/:slug.
- * Only provided fields are updated. If inputs/outputs change, the signature
- * is recomputed automatically by features-service.
+ * Update or fork a feature via PUT /features/:slug.
+ * If only metadata changes (same signature) → updates in-place (200).
+ * If inputs or outputs change (different signature) → creates a fork,
+ * deprecates the original, and returns 201. The fork inherits displayName.
  */
 export async function updateFeature(
   slug: string,
   body: Partial<Omit<CreateFeatureBody, "slug">>,
   params: FeaturesCallParams,
-): Promise<FeatureResponse> {
+): Promise<UpdateFeatureResult> {
   const url = `${FEATURES_SERVICE_URL}/features/${encodeURIComponent(slug)}`;
   const res = await fetch(url, {
     method: "PUT",
@@ -153,7 +168,8 @@ export async function updateFeature(
     );
   }
 
-  return (await res.json()) as FeatureResponse;
+  const feature = (await res.json()) as FeatureResponse;
+  return { feature, forked: res.status === 201 };
 }
 
 export interface ListFeaturesFilters {
@@ -216,4 +232,124 @@ export async function getFeature(
   }
 
   return (await res.json()) as FeatureResponse;
+}
+
+export interface FeatureInputsResponse {
+  slug: string;
+  name: string;
+  inputs: FeatureInputDef[];
+}
+
+/**
+ * Get input definitions for a feature via GET /features/:slug/inputs.
+ */
+export async function getFeatureInputs(
+  slug: string,
+  params: FeaturesCallParams,
+): Promise<FeatureInputsResponse> {
+  const url = `${FEATURES_SERVICE_URL}/features/${encodeURIComponent(slug)}/inputs`;
+  const res = await fetch(url, {
+    method: "GET",
+    headers: buildHeaders(params),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `[features-client] GET /features/${slug}/inputs returned ${res.status}: ${text}`,
+    );
+  }
+
+  return (await res.json()) as FeatureInputsResponse;
+}
+
+export interface PrefillTextResponse {
+  slug: string;
+  brandId: string;
+  format: "text";
+  prefilled: Record<string, string | null>;
+}
+
+/**
+ * Pre-fill input values for a feature from brand data via POST /features/:slug/prefill.
+ * Returns a map of input key → pre-filled text value (or null if extraction failed).
+ */
+export async function prefillFeature(
+  slug: string,
+  params: FeaturesCallParams,
+): Promise<PrefillTextResponse> {
+  const url = `${FEATURES_SERVICE_URL}/features/${encodeURIComponent(slug)}/prefill?format=text`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: buildHeaders(params),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `[features-client] POST /features/${slug}/prefill returned ${res.status}: ${text}`,
+    );
+  }
+
+  return (await res.json()) as PrefillTextResponse;
+}
+
+export interface FeatureStatsSystemStats {
+  totalCostInUsdCents: number;
+  completedRuns: number;
+  activeCampaigns: number;
+  firstRunAt: string | null;
+  lastRunAt: string | null;
+}
+
+export interface FeatureStatsResponse {
+  featureSlug: string;
+  groupBy?: string;
+  systemStats: FeatureStatsSystemStats;
+  stats?: Record<string, number | null>;
+  groups?: Array<{
+    workflowName?: string | null;
+    brandId?: string | null;
+    campaignId?: string | null;
+    systemStats: FeatureStatsSystemStats;
+    stats: Record<string, number | null>;
+  }>;
+}
+
+export interface GetFeatureStatsFilters {
+  groupBy?: "workflowName" | "brandId" | "campaignId";
+  brandId?: string;
+  campaignId?: string;
+  workflowName?: string;
+}
+
+/**
+ * Get computed stats for a feature via GET /features/:slug/stats.
+ */
+export async function getFeatureStats(
+  slug: string,
+  filters: GetFeatureStatsFilters,
+  params: FeaturesCallParams,
+): Promise<FeatureStatsResponse> {
+  const query = new URLSearchParams();
+  if (filters.groupBy) query.set("groupBy", filters.groupBy);
+  if (filters.brandId) query.set("brandId", filters.brandId);
+  if (filters.campaignId) query.set("campaignId", filters.campaignId);
+  if (filters.workflowName) query.set("workflowName", filters.workflowName);
+
+  const qs = query.toString();
+  const url = `${FEATURES_SERVICE_URL}/features/${encodeURIComponent(slug)}/stats${qs ? `?${qs}` : ""}`;
+  const res = await fetch(url, {
+    method: "GET",
+    headers: buildHeaders(params),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `[features-client] GET /features/${slug}/stats returned ${res.status}: ${text}`,
+    );
+  }
+
+  return (await res.json()) as FeatureStatsResponse;
 }

--- a/tests/unit/anthropic.test.ts
+++ b/tests/unit/anthropic.test.ts
@@ -629,14 +629,17 @@ describe("Feature-creator tools", () => {
 });
 
 describe("FEATURE_CREATOR_TOOLS", () => {
-  it("includes all 5 feature-creator tools", () => {
+  it("includes all 8 feature-creator tools", () => {
     const names = FEATURE_CREATOR_TOOLS.map((t) => t.name);
     expect(names).toContain("request_user_input");
     expect(names).toContain("create_feature");
     expect(names).toContain("update_feature");
     expect(names).toContain("list_features");
     expect(names).toContain("get_feature");
-    expect(FEATURE_CREATOR_TOOLS).toHaveLength(5);
+    expect(names).toContain("get_feature_inputs");
+    expect(names).toContain("prefill_feature");
+    expect(names).toContain("get_feature_stats");
+    expect(FEATURE_CREATOR_TOOLS).toHaveLength(8);
   });
 
   it("does not include workflow tools", () => {

--- a/tests/unit/features-client.test.ts
+++ b/tests/unit/features-client.test.ts
@@ -148,9 +148,10 @@ describe("createFeature", () => {
 });
 
 describe("updateFeature", () => {
-  it("sends PUT /features/:slug with partial body", async () => {
+  it("returns { feature, forked: false } on 200 (in-place update)", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
+      status: 200,
       json: () => Promise.resolve({ ...sampleFeature, description: "Updated description" }),
     });
 
@@ -176,12 +177,32 @@ describe("updateFeature", () => {
     expect(sentBody.description).toBe("Updated description");
     expect(sentBody.slug).toBeUndefined();
 
-    expect(result.description).toBe("Updated description");
+    expect(result.forked).toBe(false);
+    expect(result.feature.description).toBe("Updated description");
+  });
+
+  it("returns { feature, forked: true } on 201 (fork-on-write)", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: () => Promise.resolve({ ...sampleFeature, slug: "cold-email-outreach-v2", name: "Cold Email Outreach v2" }),
+    });
+
+    const { updateFeature } = await loadModule();
+    const result = await updateFeature(
+      "cold-email-outreach",
+      { inputs: [{ key: "newInput", label: "New", type: "text" as const, placeholder: "...", description: "new input", extractKey: "new" }] },
+      { orgId: "org-1", userId: "user-1", runId: "run-1" },
+    );
+
+    expect(result.forked).toBe(true);
+    expect(result.feature.slug).toBe("cold-email-outreach-v2");
   });
 
   it("forwards tracking headers", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
+      status: 200,
       json: () => Promise.resolve(sampleFeature),
     });
 
@@ -341,5 +362,144 @@ describe("getFeature", () => {
 
     const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(calledUrl).toContain("slug%20with%20spaces");
+  });
+});
+
+describe("getFeatureInputs", () => {
+  it("sends GET /features/:slug/inputs", async () => {
+    const mockResponse = {
+      slug: "cold-email-outreach",
+      name: "Cold Email Outreach",
+      inputs: sampleFeature.inputs,
+    };
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    });
+
+    const { getFeatureInputs } = await loadModule();
+    const result = await getFeatureInputs("cold-email-outreach", {
+      orgId: "org-1",
+      userId: "user-1",
+      runId: "run-1",
+    });
+
+    const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(calledUrl).toBe("https://features.test.local/features/cold-email-outreach/inputs");
+    expect(result.slug).toBe("cold-email-outreach");
+    expect(result.inputs).toHaveLength(1);
+  });
+
+  it("throws on HTTP error", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve("Not found"),
+    });
+
+    const { getFeatureInputs } = await loadModule();
+    await expect(
+      getFeatureInputs("nonexistent", { orgId: "o", userId: "u", runId: "r" }),
+    ).rejects.toThrow(/returned 404/);
+  });
+});
+
+describe("prefillFeature", () => {
+  it("sends POST /features/:slug/prefill?format=text", async () => {
+    const mockResponse = {
+      slug: "cold-email-outreach",
+      brandId: "brand-1",
+      format: "text" as const,
+      prefilled: { targetCompanyUrl: "https://acme.com" },
+    };
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    });
+
+    const { prefillFeature } = await loadModule();
+    const result = await prefillFeature("cold-email-outreach", {
+      orgId: "org-1",
+      userId: "user-1",
+      runId: "run-1",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://features.test.local/features/cold-email-outreach/prefill?format=text",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(result.prefilled.targetCompanyUrl).toBe("https://acme.com");
+    expect(result.format).toBe("text");
+  });
+
+  it("throws on HTTP error", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: () => Promise.resolve("No brand configured"),
+    });
+
+    const { prefillFeature } = await loadModule();
+    await expect(
+      prefillFeature("cold-email-outreach", { orgId: "o", userId: "u", runId: "r" }),
+    ).rejects.toThrow(/returned 400/);
+  });
+});
+
+describe("getFeatureStats", () => {
+  it("sends GET /features/:slug/stats with filters", async () => {
+    const mockResponse = {
+      featureSlug: "cold-email-outreach",
+      systemStats: { totalCostInUsdCents: 150, completedRuns: 10, activeCampaigns: 2, firstRunAt: null, lastRunAt: null },
+      stats: { emailsSent: 42 },
+    };
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    });
+
+    const { getFeatureStats } = await loadModule();
+    const result = await getFeatureStats(
+      "cold-email-outreach",
+      { groupBy: "brandId", brandId: "brand-1" },
+      { orgId: "org-1", userId: "user-1", runId: "run-1" },
+    );
+
+    const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(calledUrl).toContain("/features/cold-email-outreach/stats?");
+    expect(calledUrl).toContain("groupBy=brandId");
+    expect(calledUrl).toContain("brandId=brand-1");
+    expect(result.systemStats.completedRuns).toBe(10);
+    expect(result.stats?.emailsSent).toBe(42);
+  });
+
+  it("sends GET /features/:slug/stats without filters", async () => {
+    const mockResponse = {
+      featureSlug: "cold-email-outreach",
+      systemStats: { totalCostInUsdCents: 0, completedRuns: 0, activeCampaigns: 0, firstRunAt: null, lastRunAt: null },
+    };
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    });
+
+    const { getFeatureStats } = await loadModule();
+    await getFeatureStats("cold-email-outreach", {}, { orgId: "o", userId: "u", runId: "r" });
+
+    const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(calledUrl).toBe("https://features.test.local/features/cold-email-outreach/stats");
+  });
+
+  it("throws on HTTP error", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve("Feature not found"),
+    });
+
+    const { getFeatureStats } = await loadModule();
+    await expect(
+      getFeatureStats("nonexistent", {}, { orgId: "o", userId: "u", runId: "r" }),
+    ).rejects.toThrow(/returned 404/);
   });
 });


### PR DESCRIPTION
## Summary
- **FeatureResponse** now includes `id`, `displayName`, `signature`, `charts`, `entities` from upstream
- **update_feature** returns `{ feature, forked }` — fork-on-write: metadata-only changes update in-place (200), input/output changes create a fork (201)
- **3 new tools**: `get_feature_inputs` (lightweight input schema), `prefill_feature` (auto-fill from brand data), `get_feature_stats` (cost/runs/campaign metrics with groupBy)
- Tool descriptions updated to clarify `name` (machine identifier) vs `displayName` (stable UI label)

## Test plan
- [x] All 261 unit tests pass
- [x] New tests for `getFeatureInputs`, `prefillFeature`, `getFeatureStats`
- [x] Updated tests for `updateFeature` fork-on-write return shape
- [x] TypeScript strict mode compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)