### PR TITLE
refactor: route backend calls through api-service gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,20 +283,14 @@ Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token st
 
 | Variable | Required | Description |
 |---|---|---|
-| `KEY_SERVICE_API_KEY` | Yes | Service-to-service key for key-service (used to resolve the Anthropic API key per-request) |
-| `CHAT_SERVICE_DATABASE_URL` | Yes | PostgreSQL connection string |
+| `API_SERVICE_API_KEY` | Yes | Bearer token for api-service gateway — all client-facing backend calls (workflows, features, keys, prompts, api-registry) route through api-service |
+| `API_SERVICE_URL` | No | Api-service endpoint (default: `https://api.distribute.you`) |
+| `KEY_SERVICE_API_KEY` | Yes | Service-to-service key for key-service (used only for Anthropic API key decryption — infrastructure, not routed via api-service) |
 | `KEY_SERVICE_URL` | No | Key-service endpoint (default: `https://key.mcpfactory.org`) |
+| `CHAT_SERVICE_DATABASE_URL` | Yes | PostgreSQL connection string |
 | `RUNS_SERVICE_URL` | No | RunsService endpoint (default: `https://runs.mcpfactory.org`) |
 | `RUNS_SERVICE_API_KEY` | No | API key for RunsService (runs tracking disabled if unset) |
-| `WORKFLOW_SERVICE_URL` | No | Workflow-service endpoint (default: `https://workflow.mcpfactory.org`) |
-| `WORKFLOW_SERVICE_API_KEY` | No | API key for workflow-service (built-in workflow tools fail if unset) |
-| `CONTENT_GENERATION_SERVICE_URL` | No | Content-generation service endpoint (default: `https://content-generation.distribute.you`) |
-| `CONTENT_GENERATION_SERVICE_API_KEY` | No | API key for content-generation service (get_prompt_template tool fails if unset) |
-| `API_REGISTRY_SERVICE_URL` | No | API registry service endpoint (default: `https://api-registry.distribute.you`) |
-| `API_REGISTRY_SERVICE_API_KEY` | No | API key for api-registry service (list_services, list_service_endpoints, call_api tools fail if unset) |
 | `BILLING_SERVICE_URL` | No | Billing-service endpoint (default: `https://billing.mcpfactory.org`) |
-| `FEATURES_SERVICE_URL` | No | Features-service endpoint (default: `https://features.distribute.you`) |
-| `FEATURES_SERVICE_API_KEY` | No | API key for features-service (upsert_feature tool fails if unset) |
 | `BILLING_SERVICE_API_KEY` | Yes | API key for billing-service — required for credit authorization on platform-key requests |
 | `PORT` | No | Server port (default: `3002`) |
 

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,0 +1,44 @@
+const API_SERVICE_URL =
+  process.env.API_SERVICE_URL || "https://api.distribute.you";
+const API_SERVICE_API_KEY = process.env.API_SERVICE_API_KEY;
+
+export interface ApiCallParams {
+  orgId: string;
+  userId: string;
+  runId: string;
+  trackingHeaders?: Record<string, string>;
+}
+
+/**
+ * Make an authenticated request to api-service.
+ * All client-facing backend calls route through api-service as the single gateway.
+ */
+export function apiServiceFetch(
+  path: string,
+  method: string,
+  params: ApiCallParams,
+  body?: unknown,
+): Promise<Response> {
+  if (!API_SERVICE_API_KEY) {
+    throw new Error("[api-client] API_SERVICE_API_KEY is required");
+  }
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${API_SERVICE_API_KEY}`,
+    "x-org-id": params.orgId,
+    "x-user-id": params.userId,
+    "x-run-id": params.runId,
+  };
+  if (params.trackingHeaders) {
+    for (const [k, v] of Object.entries(params.trackingHeaders)) {
+      if (v) headers[k] = v;
+    }
+  }
+
+  return fetch(`${API_SERVICE_URL}${path}`, {
+    method,
+    headers,
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+}

--- a/src/lib/api-registry-client.ts
+++ b/src/lib/api-registry-client.ts
@@ -1,34 +1,11 @@
-const API_REGISTRY_SERVICE_URL =
-  process.env.API_REGISTRY_SERVICE_URL || "https://api-registry.distribute.you";
-const API_REGISTRY_SERVICE_API_KEY = process.env.API_REGISTRY_SERVICE_API_KEY;
+import { apiServiceFetch, type ApiCallParams } from "./api-client.js";
 
-export interface ApiRegistryCallParams {
-  orgId: string;
-  userId: string;
-  runId: string;
-}
+export type ApiRegistryCallParams = ApiCallParams;
 
 // ---------------------------------------------------------------------------
 // Progressive disclosure: list_services → list_service_endpoints → call_api
+// All routed through api-service gateway.
 // ---------------------------------------------------------------------------
-
-function ensureApiKey(): string {
-  if (!API_REGISTRY_SERVICE_API_KEY) {
-    throw new Error(
-      "[api-registry-client] API_REGISTRY_SERVICE_API_KEY is required",
-    );
-  }
-  return API_REGISTRY_SERVICE_API_KEY;
-}
-
-function baseHeaders(params: ApiRegistryCallParams): Record<string, string> {
-  return {
-    "x-api-key": ensureApiKey(),
-    "x-org-id": params.orgId,
-    "x-user-id": params.userId,
-    "x-run-id": params.runId,
-  };
-}
 
 /** Step 1: Lightweight overview — service names, descriptions, endpoint counts. */
 export interface ServiceOverview {
@@ -48,13 +25,11 @@ export interface ListServicesResponse {
 export async function listServices(
   params: ApiRegistryCallParams,
 ): Promise<ListServicesResponse> {
-  const res = await fetch(`${API_REGISTRY_SERVICE_URL}/llm-context`, {
-    headers: baseHeaders(params),
-  });
+  const res = await apiServiceFetch("/v1/platform/llm-context", "GET", params);
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `[api-registry-client] GET /llm-context returned ${res.status}: ${text}`,
+      `[api-registry-client] GET /v1/platform/llm-context returned ${res.status}: ${text}`,
     );
   }
   return (await res.json()) as ListServicesResponse;
@@ -79,20 +54,21 @@ export async function listServiceEndpoints(
   service: string,
   params: ApiRegistryCallParams,
 ): Promise<ListServiceEndpointsResponse> {
-  const res = await fetch(
-    `${API_REGISTRY_SERVICE_URL}/llm-context/${encodeURIComponent(service)}`,
-    { headers: baseHeaders(params) },
+  const res = await apiServiceFetch(
+    `/v1/platform/services/${encodeURIComponent(service)}`,
+    "GET",
+    params,
   );
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `[api-registry-client] GET /llm-context/${service} returned ${res.status}: ${text}`,
+      `[api-registry-client] GET /v1/platform/services/${service} returned ${res.status}: ${text}`,
     );
   }
   return (await res.json()) as ListServiceEndpointsResponse;
 }
 
-/** Step 3: Proxy an API call to a registered service (api-registry injects API key). */
+/** Step 3: Call an api-service endpoint directly. */
 export interface CallApiParams {
   service: string;
   method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
@@ -110,26 +86,17 @@ export async function callApi(
   callParams: CallApiParams,
   identityParams: ApiRegistryCallParams,
 ): Promise<CallApiResponse> {
-  const res = await fetch(
-    `${API_REGISTRY_SERVICE_URL}/call/${encodeURIComponent(callParams.service)}`,
-    {
-      method: "POST",
-      headers: {
-        ...baseHeaders(identityParams),
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({
-        method: callParams.method,
-        path: callParams.path,
-        ...(callParams.body ? { body: callParams.body } : {}),
-      }),
-    },
+  const res = await apiServiceFetch(
+    callParams.path,
+    callParams.method,
+    identityParams,
+    callParams.body,
   );
-  if (!res.ok) {
-    const text = await res.text().catch(() => "");
-    throw new Error(
-      `[api-registry-client] POST /call/${callParams.service} returned ${res.status}: ${text}`,
-    );
-  }
-  return (await res.json()) as CallApiResponse;
+
+  const data = await res.json().catch(() => null);
+  return {
+    status: res.status,
+    ok: res.ok,
+    data,
+  };
 }

--- a/src/lib/content-generation-client.ts
+++ b/src/lib/content-generation-client.ts
@@ -1,6 +1,4 @@
-const CONTENT_GENERATION_SERVICE_URL =
-  process.env.CONTENT_GENERATION_SERVICE_URL || "https://content-generation.distribute.you";
-const CONTENT_GENERATION_SERVICE_API_KEY = process.env.CONTENT_GENERATION_SERVICE_API_KEY;
+import { apiServiceFetch, type ApiCallParams } from "./api-client.js";
 
 export interface PromptTemplate {
   id: string;
@@ -11,42 +9,22 @@ export interface PromptTemplate {
   updatedAt: string;
 }
 
-export interface ContentGenerationCallParams {
-  orgId: string;
-  userId: string;
-  runId: string;
-  trackingHeaders?: Record<string, string>;
-}
+export type ContentGenerationCallParams = ApiCallParams;
 
 export async function getPromptTemplate(
   type: string,
   params: ContentGenerationCallParams,
 ): Promise<PromptTemplate> {
-  if (!CONTENT_GENERATION_SERVICE_API_KEY) {
-    throw new Error(
-      "[content-generation-client] CONTENT_GENERATION_SERVICE_API_KEY is required",
-    );
-  }
-
-  const url = `${CONTENT_GENERATION_SERVICE_URL}/prompts?type=${encodeURIComponent(type)}`;
-  const headers: Record<string, string> = {
-    "x-api-key": CONTENT_GENERATION_SERVICE_API_KEY,
-    "x-org-id": params.orgId,
-    "x-user-id": params.userId,
-    "x-run-id": params.runId,
-  };
-  if (params.trackingHeaders) {
-    for (const [k, v] of Object.entries(params.trackingHeaders)) {
-      if (v) headers[k] = v;
-    }
-  }
-
-  const res = await fetch(url, { method: "GET", headers });
+  const res = await apiServiceFetch(
+    `/v1/prompts?type=${encodeURIComponent(type)}`,
+    "GET",
+    params,
+  );
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `[content-generation-client] GET /prompts?type=${type} returned ${res.status}: ${text}`,
+      `[content-generation-client] GET /v1/prompts?type=${type} returned ${res.status}: ${text}`,
     );
   }
 
@@ -63,36 +41,12 @@ export async function updatePromptTemplate(
   body: UpdatePromptBody,
   params: ContentGenerationCallParams,
 ): Promise<PromptTemplate> {
-  if (!CONTENT_GENERATION_SERVICE_API_KEY) {
-    throw new Error(
-      "[content-generation-client] CONTENT_GENERATION_SERVICE_API_KEY is required",
-    );
-  }
-
-  const url = `${CONTENT_GENERATION_SERVICE_URL}/prompts`;
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    "x-api-key": CONTENT_GENERATION_SERVICE_API_KEY,
-    "x-org-id": params.orgId,
-    "x-user-id": params.userId,
-    "x-run-id": params.runId,
-  };
-  if (params.trackingHeaders) {
-    for (const [k, v] of Object.entries(params.trackingHeaders)) {
-      if (v) headers[k] = v;
-    }
-  }
-
-  const res = await fetch(url, {
-    method: "PUT",
-    headers,
-    body: JSON.stringify(body),
-  });
+  const res = await apiServiceFetch("/v1/prompts", "PUT", params, body);
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `[content-generation-client] PUT /prompts returned ${res.status}: ${text}`,
+      `[content-generation-client] PUT /v1/prompts returned ${res.status}: ${text}`,
     );
   }
 

--- a/src/lib/features-client.ts
+++ b/src/lib/features-client.ts
@@ -1,35 +1,6 @@
-const FEATURES_SERVICE_URL =
-  process.env.FEATURES_SERVICE_URL || "https://features.distribute.you";
-const FEATURES_SERVICE_API_KEY = process.env.FEATURES_SERVICE_API_KEY;
+import { apiServiceFetch, type ApiCallParams } from "./api-client.js";
 
-export interface FeaturesCallParams {
-  orgId: string;
-  userId: string;
-  runId: string;
-  trackingHeaders?: Record<string, string>;
-}
-
-function buildHeaders(params: FeaturesCallParams): Record<string, string> {
-  if (!FEATURES_SERVICE_API_KEY) {
-    throw new Error(
-      "[features-client] FEATURES_SERVICE_API_KEY is required",
-    );
-  }
-
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    "x-api-key": FEATURES_SERVICE_API_KEY,
-    "x-org-id": params.orgId,
-    "x-user-id": params.userId,
-    "x-run-id": params.runId,
-  };
-  if (params.trackingHeaders) {
-    for (const [k, v] of Object.entries(params.trackingHeaders)) {
-      if (v) headers[k] = v;
-    }
-  }
-  return headers;
-}
+export type FeaturesCallParams = ApiCallParams;
 
 export interface FeatureInputDef {
   key: string;
@@ -104,21 +75,11 @@ export interface FeatureResponse {
   [key: string]: unknown;
 }
 
-/**
- * Create a new feature via POST /features.
- * Slug is optional — auto-generated from name if omitted.
- * Returns 201 on success, throws on 409 (conflict) or other errors.
- */
 export async function createFeature(
   body: CreateFeatureBody,
   params: FeaturesCallParams,
 ): Promise<FeatureResponse> {
-  const url = `${FEATURES_SERVICE_URL}/features`;
-  const res = await fetch(url, {
-    method: "POST",
-    headers: buildHeaders(params),
-    body: JSON.stringify(body),
-  });
+  const res = await apiServiceFetch("/v1/features", "POST", params, body);
 
   if (res.status === 409) {
     const text = await res.text().catch(() => "");
@@ -130,7 +91,7 @@ export async function createFeature(
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `[features-client] POST /features returned ${res.status}: ${text}`,
+      `[features-client] POST /v1/features returned ${res.status}: ${text}`,
     );
   }
 
@@ -139,32 +100,25 @@ export async function createFeature(
 
 export interface UpdateFeatureResult {
   feature: FeatureResponse;
-  /** true when inputs/outputs changed and features-service forked a new version (HTTP 201) */
   forked: boolean;
 }
 
-/**
- * Update or fork a feature via PUT /features/:slug.
- * If only metadata changes (same signature) → updates in-place (200).
- * If inputs or outputs change (different signature) → creates a fork,
- * deprecates the original, and returns 201. The fork inherits displayName.
- */
 export async function updateFeature(
   slug: string,
   body: Partial<Omit<CreateFeatureBody, "slug">>,
   params: FeaturesCallParams,
 ): Promise<UpdateFeatureResult> {
-  const url = `${FEATURES_SERVICE_URL}/features/${encodeURIComponent(slug)}`;
-  const res = await fetch(url, {
-    method: "PUT",
-    headers: buildHeaders(params),
-    body: JSON.stringify(body),
-  });
+  const res = await apiServiceFetch(
+    `/v1/features/${encodeURIComponent(slug)}`,
+    "PUT",
+    params,
+    body,
+  );
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `[features-client] PUT /features/${slug} returned ${res.status}: ${text}`,
+      `[features-client] PUT /v1/features/${slug} returned ${res.status}: ${text}`,
     );
   }
 
@@ -180,9 +134,6 @@ export interface ListFeaturesFilters {
   implemented?: string;
 }
 
-/**
- * List features via GET /features with optional filters.
- */
 export async function listFeatures(
   filters: ListFeaturesFilters,
   params: FeaturesCallParams,
@@ -195,39 +146,36 @@ export async function listFeatures(
   if (filters.implemented) query.set("implemented", filters.implemented);
 
   const qs = query.toString();
-  const url = `${FEATURES_SERVICE_URL}/features${qs ? `?${qs}` : ""}`;
-  const res = await fetch(url, {
-    method: "GET",
-    headers: buildHeaders(params),
-  });
+  const res = await apiServiceFetch(
+    `/v1/features${qs ? `?${qs}` : ""}`,
+    "GET",
+    params,
+  );
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `[features-client] GET /features returned ${res.status}: ${text}`,
+      `[features-client] GET /v1/features returned ${res.status}: ${text}`,
     );
   }
 
   return (await res.json()) as FeatureResponse[];
 }
 
-/**
- * Get a single feature by slug via GET /features/:slug.
- */
 export async function getFeature(
   slug: string,
   params: FeaturesCallParams,
 ): Promise<FeatureResponse> {
-  const url = `${FEATURES_SERVICE_URL}/features/${encodeURIComponent(slug)}`;
-  const res = await fetch(url, {
-    method: "GET",
-    headers: buildHeaders(params),
-  });
+  const res = await apiServiceFetch(
+    `/v1/features/${encodeURIComponent(slug)}`,
+    "GET",
+    params,
+  );
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `[features-client] GET /features/${slug} returned ${res.status}: ${text}`,
+      `[features-client] GET /v1/features/${slug} returned ${res.status}: ${text}`,
     );
   }
 
@@ -240,23 +188,20 @@ export interface FeatureInputsResponse {
   inputs: FeatureInputDef[];
 }
 
-/**
- * Get input definitions for a feature via GET /features/:slug/inputs.
- */
 export async function getFeatureInputs(
   slug: string,
   params: FeaturesCallParams,
 ): Promise<FeatureInputsResponse> {
-  const url = `${FEATURES_SERVICE_URL}/features/${encodeURIComponent(slug)}/inputs`;
-  const res = await fetch(url, {
-    method: "GET",
-    headers: buildHeaders(params),
-  });
+  const res = await apiServiceFetch(
+    `/v1/features/${encodeURIComponent(slug)}/inputs`,
+    "GET",
+    params,
+  );
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `[features-client] GET /features/${slug}/inputs returned ${res.status}: ${text}`,
+      `[features-client] GET /v1/features/${slug}/inputs returned ${res.status}: ${text}`,
     );
   }
 
@@ -270,24 +215,20 @@ export interface PrefillTextResponse {
   prefilled: Record<string, string | null>;
 }
 
-/**
- * Pre-fill input values for a feature from brand data via POST /features/:slug/prefill.
- * Returns a map of input key → pre-filled text value (or null if extraction failed).
- */
 export async function prefillFeature(
   slug: string,
   params: FeaturesCallParams,
 ): Promise<PrefillTextResponse> {
-  const url = `${FEATURES_SERVICE_URL}/features/${encodeURIComponent(slug)}/prefill?format=text`;
-  const res = await fetch(url, {
-    method: "POST",
-    headers: buildHeaders(params),
-  });
+  const res = await apiServiceFetch(
+    `/v1/features/${encodeURIComponent(slug)}/prefill`,
+    "POST",
+    params,
+  );
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `[features-client] POST /features/${slug}/prefill returned ${res.status}: ${text}`,
+      `[features-client] POST /v1/features/${slug}/prefill returned ${res.status}: ${text}`,
     );
   }
 
@@ -323,9 +264,6 @@ export interface GetFeatureStatsFilters {
   workflowName?: string;
 }
 
-/**
- * Get computed stats for a feature via GET /features/:slug/stats.
- */
 export async function getFeatureStats(
   slug: string,
   filters: GetFeatureStatsFilters,
@@ -338,16 +276,16 @@ export async function getFeatureStats(
   if (filters.workflowName) query.set("workflowName", filters.workflowName);
 
   const qs = query.toString();
-  const url = `${FEATURES_SERVICE_URL}/features/${encodeURIComponent(slug)}/stats${qs ? `?${qs}` : ""}`;
-  const res = await fetch(url, {
-    method: "GET",
-    headers: buildHeaders(params),
-  });
+  const res = await apiServiceFetch(
+    `/v1/features/${encodeURIComponent(slug)}/stats${qs ? `?${qs}` : ""}`,
+    "GET",
+    params,
+  );
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `[features-client] GET /features/${slug}/stats returned ${res.status}: ${text}`,
+      `[features-client] GET /v1/features/${slug}/stats returned ${res.status}: ${text}`,
     );
   }
 

--- a/src/lib/key-client.ts
+++ b/src/lib/key-client.ts
@@ -1,3 +1,9 @@
+import { apiServiceFetch, type ApiCallParams } from "./api-client.js";
+
+// ---------------------------------------------------------------------------
+// resolveKey — stays direct to key-service (infrastructure, not client-facing)
+// ---------------------------------------------------------------------------
+
 const KEY_SERVICE_URL =
   process.env.KEY_SERVICE_URL || "https://key.mcpfactory.org";
 const KEY_SERVICE_API_KEY = process.env.KEY_SERVICE_API_KEY;
@@ -74,7 +80,7 @@ export async function resolveKey(
 }
 
 // ---------------------------------------------------------------------------
-// Read-only key-service tools (exposed to LLM)
+// Read-only key tools (exposed to LLM) — routed via api-service
 // ---------------------------------------------------------------------------
 
 export interface KeyCallParams {
@@ -94,26 +100,10 @@ export interface OrgKey {
 export async function listOrgKeys(
   params: KeyCallParams,
 ): Promise<{ keys: OrgKey[] }> {
-  if (!KEY_SERVICE_API_KEY) {
-    throw new Error("[key-client] KEY_SERVICE_API_KEY is required");
-  }
-
-  const headers: Record<string, string> = {
-    "x-api-key": KEY_SERVICE_API_KEY,
-    "x-org-id": params.orgId,
-    "x-user-id": params.userId,
-    "x-run-id": params.runId,
-  };
-  if (params.trackingHeaders) {
-    for (const [k, v] of Object.entries(params.trackingHeaders)) {
-      if (v) headers[k] = v;
-    }
-  }
-
-  const res = await fetch(`${KEY_SERVICE_URL}/keys`, { headers });
+  const res = await apiServiceFetch("/v1/keys", "GET", params);
   if (!res.ok) {
     const text = await res.text().catch(() => "");
-    throw new Error(`[key-client] GET /keys returned ${res.status}: ${text}`);
+    throw new Error(`[key-client] GET /v1/keys returned ${res.status}: ${text}`);
   }
   return (await res.json()) as { keys: OrgKey[] };
 }
@@ -129,30 +119,15 @@ export async function getKeySource(
   provider: string,
   params: KeyCallParams,
 ): Promise<KeySourcePreference> {
-  if (!KEY_SERVICE_API_KEY) {
-    throw new Error("[key-client] KEY_SERVICE_API_KEY is required");
-  }
-
-  const headers: Record<string, string> = {
-    "x-api-key": KEY_SERVICE_API_KEY,
-    "x-org-id": params.orgId,
-    "x-user-id": params.userId,
-    "x-run-id": params.runId,
-  };
-  if (params.trackingHeaders) {
-    for (const [k, v] of Object.entries(params.trackingHeaders)) {
-      if (v) headers[k] = v;
-    }
-  }
-
-  const res = await fetch(
-    `${KEY_SERVICE_URL}/keys/${encodeURIComponent(provider)}/source`,
-    { headers },
+  const res = await apiServiceFetch(
+    `/v1/keys/${encodeURIComponent(provider)}/source`,
+    "GET",
+    params,
   );
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `[key-client] GET /keys/${provider}/source returned ${res.status}: ${text}`,
+      `[key-client] GET /v1/keys/${provider}/source returned ${res.status}: ${text}`,
     );
   }
   return (await res.json()) as KeySourcePreference;
@@ -161,27 +136,11 @@ export async function getKeySource(
 export async function listKeySources(
   params: KeyCallParams,
 ): Promise<{ sources: Array<{ provider: string; keySource: "org" | "platform" }> }> {
-  if (!KEY_SERVICE_API_KEY) {
-    throw new Error("[key-client] KEY_SERVICE_API_KEY is required");
-  }
-
-  const headers: Record<string, string> = {
-    "x-api-key": KEY_SERVICE_API_KEY,
-    "x-org-id": params.orgId,
-    "x-user-id": params.userId,
-    "x-run-id": params.runId,
-  };
-  if (params.trackingHeaders) {
-    for (const [k, v] of Object.entries(params.trackingHeaders)) {
-      if (v) headers[k] = v;
-    }
-  }
-
-  const res = await fetch(`${KEY_SERVICE_URL}/keys/sources`, { headers });
+  const res = await apiServiceFetch("/v1/keys/sources", "GET", params);
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `[key-client] GET /keys/sources returned ${res.status}: ${text}`,
+      `[key-client] GET /v1/keys/sources returned ${res.status}: ${text}`,
     );
   }
   return (await res.json()) as { sources: Array<{ provider: string; keySource: "org" | "platform" }> };
@@ -207,34 +166,17 @@ export async function checkProviderRequirements(
   endpoints: ProviderRequirementsEndpoint[],
   params: KeyCallParams,
 ): Promise<ProviderRequirementsResult> {
-  if (!KEY_SERVICE_API_KEY) {
-    throw new Error("[key-client] KEY_SERVICE_API_KEY is required");
-  }
-
-  const headers: Record<string, string> = {
-    "x-api-key": KEY_SERVICE_API_KEY,
-    "x-org-id": params.orgId,
-    "x-user-id": params.userId,
-    "x-run-id": params.runId,
-    "content-type": "application/json",
-  };
-  if (params.trackingHeaders) {
-    for (const [k, v] of Object.entries(params.trackingHeaders)) {
-      if (v) headers[k] = v;
-    }
-  }
-
-  const res = await fetch(`${KEY_SERVICE_URL}/provider-requirements`, {
-    method: "POST",
-    headers,
-    body: JSON.stringify({ endpoints }),
-  });
+  const res = await apiServiceFetch(
+    "/v1/keys/provider-requirements",
+    "POST",
+    params,
+    { endpoints },
+  );
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `[key-client] POST /provider-requirements returned ${res.status}: ${text}`,
+      `[key-client] POST /v1/keys/provider-requirements returned ${res.status}: ${text}`,
     );
   }
   return (await res.json()) as ProviderRequirementsResult;
 }
-

--- a/src/lib/workflow-client.ts
+++ b/src/lib/workflow-client.ts
@@ -1,35 +1,6 @@
-const WORKFLOW_SERVICE_URL =
-  process.env.WORKFLOW_SERVICE_URL || "https://workflow.mcpfactory.org";
-const WORKFLOW_SERVICE_API_KEY = process.env.WORKFLOW_SERVICE_API_KEY;
+import { apiServiceFetch, type ApiCallParams } from "./api-client.js";
 
-export interface WorkflowCallParams {
-  orgId: string;
-  userId: string;
-  runId: string;
-  trackingHeaders?: Record<string, string>;
-}
-
-function buildHeaders(params: WorkflowCallParams): Record<string, string> {
-  if (!WORKFLOW_SERVICE_API_KEY) {
-    throw new Error(
-      "[workflow-client] WORKFLOW_SERVICE_API_KEY is required",
-    );
-  }
-
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    "x-api-key": WORKFLOW_SERVICE_API_KEY,
-    "x-org-id": params.orgId,
-    "x-user-id": params.userId,
-    "x-run-id": params.runId,
-  };
-  if (params.trackingHeaders) {
-    for (const [k, v] of Object.entries(params.trackingHeaders)) {
-      if (v) headers[k] = v;
-    }
-  }
-  return headers;
-}
+export type WorkflowCallParams = ApiCallParams;
 
 export interface WorkflowResponse {
   id: string;
@@ -65,16 +36,16 @@ export async function getWorkflow(
   workflowId: string,
   params: WorkflowCallParams,
 ): Promise<WorkflowResponse> {
-  const url = `${WORKFLOW_SERVICE_URL}/workflows/${encodeURIComponent(workflowId)}`;
-  const res = await fetch(url, {
-    method: "GET",
-    headers: buildHeaders(params),
-  });
+  const res = await apiServiceFetch(
+    `/v1/workflows/${encodeURIComponent(workflowId)}`,
+    "GET",
+    params,
+  );
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `[workflow-client] GET /workflows/${workflowId} returned ${res.status}: ${text}`,
+      `[workflow-client] GET /v1/workflows/${workflowId} returned ${res.status}: ${text}`,
     );
   }
 
@@ -89,7 +60,7 @@ export interface UpdateWorkflowBody {
 }
 
 /**
- * Strip null values from DAG nodes before sending to workflow-service.
+ * Strip null values from DAG nodes before sending.
  * Gemini sometimes sends `config: null` or `inputMapping: null` instead
  * of omitting the field — workflow-service Zod schema rejects nulls.
  */
@@ -112,12 +83,12 @@ export async function updateWorkflow(
   params: WorkflowCallParams,
 ): Promise<UpdateWorkflowResult> {
   const sanitized = body.dag ? { ...body, dag: sanitizeDag(body.dag) } : body;
-  const url = `${WORKFLOW_SERVICE_URL}/workflows/${encodeURIComponent(workflowId)}`;
-  const res = await fetch(url, {
-    method: "PUT",
-    headers: buildHeaders(params),
-    body: JSON.stringify(sanitized),
-  });
+  const res = await apiServiceFetch(
+    `/v1/workflows/${encodeURIComponent(workflowId)}`,
+    "PUT",
+    params,
+    sanitized,
+  );
 
   if (res.status === 409) {
     const conflict = (await res.json()) as WorkflowConflictError;
@@ -129,7 +100,7 @@ export async function updateWorkflow(
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `[workflow-client] PUT /workflows/${workflowId} returned ${res.status}: ${text}`,
+      `[workflow-client] PUT /v1/workflows/${workflowId} returned ${res.status}: ${text}`,
     );
   }
 
@@ -144,14 +115,12 @@ export async function updateWorkflowNodeConfig(
   configUpdates: Record<string, unknown>,
   params: WorkflowCallParams,
 ): Promise<UpdateWorkflowResult> {
-  // 1. Fetch the current workflow to get the full DAG
   const workflow = await getWorkflow(workflowId, params);
 
   if (!workflow.dag) {
     throw new Error(`[workflow-client] Workflow ${workflowId} has no DAG`);
   }
 
-  // 2. Find the target node
   const nodeIndex = workflow.dag.nodes.findIndex((n) => n.id === nodeId);
   if (nodeIndex === -1) {
     throw new Error(
@@ -159,11 +128,9 @@ export async function updateWorkflowNodeConfig(
     );
   }
 
-  // 3. Merge config updates into the node's existing config
   const node = workflow.dag.nodes[nodeIndex];
   node.config = { ...node.config, ...configUpdates };
 
-  // 4. PUT the updated DAG back
   return updateWorkflow(workflowId, { dag: workflow.dag }, params);
 }
 
@@ -187,17 +154,12 @@ export async function generateWorkflow(
   body: GenerateWorkflowBody,
   params: WorkflowCallParams,
 ): Promise<unknown> {
-  const url = `${WORKFLOW_SERVICE_URL}/workflows/generate`;
-  const res = await fetch(url, {
-    method: "POST",
-    headers: buildHeaders(params),
-    body: JSON.stringify(body),
-  });
+  const res = await apiServiceFetch("/v1/workflows/generate", "POST", params, body);
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `[workflow-client] POST /workflows/generate returned ${res.status}: ${text}`,
+      `[workflow-client] POST /v1/workflows/generate returned ${res.status}: ${text}`,
     );
   }
 
@@ -208,16 +170,16 @@ export async function getWorkflowRequiredProviders(
   workflowId: string,
   params: WorkflowCallParams,
 ): Promise<unknown> {
-  const url = `${WORKFLOW_SERVICE_URL}/workflows/${encodeURIComponent(workflowId)}/required-providers`;
-  const res = await fetch(url, {
-    method: "GET",
-    headers: buildHeaders(params),
-  });
+  const res = await apiServiceFetch(
+    `/v1/workflows/${encodeURIComponent(workflowId)}/key-status`,
+    "GET",
+    params,
+  );
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `[workflow-client] GET /workflows/${workflowId}/required-providers returned ${res.status}: ${text}`,
+      `[workflow-client] GET /v1/workflows/${workflowId}/key-status returned ${res.status}: ${text}`,
     );
   }
 
@@ -252,16 +214,16 @@ export async function listWorkflows(
   if (filters.campaignId) query.set("campaignId", filters.campaignId);
 
   const qs = query.toString();
-  const url = `${WORKFLOW_SERVICE_URL}/workflows${qs ? `?${qs}` : ""}`;
-  const res = await fetch(url, {
-    method: "GET",
-    headers: buildHeaders(params),
-  });
+  const res = await apiServiceFetch(
+    `/v1/workflows${qs ? `?${qs}` : ""}`,
+    "GET",
+    params,
+  );
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `[workflow-client] GET /workflows returned ${res.status}: ${text}`,
+      `[workflow-client] GET /v1/workflows returned ${res.status}: ${text}`,
     );
   }
 
@@ -272,16 +234,16 @@ export async function validateWorkflow(
   workflowId: string,
   params: WorkflowCallParams,
 ): Promise<unknown> {
-  const url = `${WORKFLOW_SERVICE_URL}/workflows/${encodeURIComponent(workflowId)}/validate`;
-  const res = await fetch(url, {
-    method: "POST",
-    headers: buildHeaders(params),
-  });
+  const res = await apiServiceFetch(
+    `/v1/workflows/${encodeURIComponent(workflowId)}/validate`,
+    "POST",
+    params,
+  );
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `[workflow-client] POST /workflows/${workflowId}/validate returned ${res.status}: ${text}`,
+      `[workflow-client] POST /v1/workflows/${workflowId}/validate returned ${res.status}: ${text}`,
     );
   }
 

--- a/tests/unit/api-client.test.ts
+++ b/tests/unit/api-client.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  process.env.API_SERVICE_API_KEY = "test-api-svc-key";
+  process.env.API_SERVICE_URL = "https://api.test.local";
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.restoreAllMocks();
+});
+
+async function loadModule() {
+  vi.resetModules();
+  return import("../../src/lib/api-client.js");
+}
+
+describe("apiServiceFetch", () => {
+  it("sends request with correct URL, Bearer auth, and identity headers", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true });
+
+    const { apiServiceFetch } = await loadModule();
+    await apiServiceFetch("/v1/workflows", "GET", {
+      orgId: "org-1",
+      userId: "user-1",
+      runId: "run-1",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.test.local/v1/workflows",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-api-svc-key",
+          "x-org-id": "org-1",
+          "x-user-id": "user-1",
+          "x-run-id": "run-1",
+          "Content-Type": "application/json",
+        }),
+      }),
+    );
+  });
+
+  it("includes JSON body when provided", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true });
+
+    const { apiServiceFetch } = await loadModule();
+    await apiServiceFetch("/v1/features", "POST", {
+      orgId: "org-1",
+      userId: "user-1",
+      runId: "run-1",
+    }, { name: "My Feature" });
+
+    const callArgs = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1];
+    expect(callArgs.body).toBe(JSON.stringify({ name: "My Feature" }));
+  });
+
+  it("does not include body when not provided", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true });
+
+    const { apiServiceFetch } = await loadModule();
+    await apiServiceFetch("/v1/keys", "GET", {
+      orgId: "org-1",
+      userId: "user-1",
+      runId: "run-1",
+    });
+
+    const callArgs = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1];
+    expect(callArgs.body).toBeUndefined();
+  });
+
+  it("forwards tracking headers", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true });
+
+    const { apiServiceFetch } = await loadModule();
+    await apiServiceFetch("/v1/keys", "GET", {
+      orgId: "org-1",
+      userId: "user-1",
+      runId: "run-1",
+      trackingHeaders: { "x-campaign-id": "camp-1", "x-brand-id": "brand-1" },
+    });
+
+    const callHeaders = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].headers;
+    expect(callHeaders["x-campaign-id"]).toBe("camp-1");
+    expect(callHeaders["x-brand-id"]).toBe("brand-1");
+  });
+
+  it("throws when API_SERVICE_API_KEY is not set", async () => {
+    delete process.env.API_SERVICE_API_KEY;
+
+    const { apiServiceFetch } = await loadModule();
+    expect(() =>
+      apiServiceFetch("/v1/keys", "GET", { orgId: "o", userId: "u", runId: "r" }),
+    ).toThrow(/API_SERVICE_API_KEY is required/);
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("uses default API_SERVICE_URL when not set", async () => {
+    delete process.env.API_SERVICE_URL;
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true });
+
+    const { apiServiceFetch } = await loadModule();
+    await apiServiceFetch("/v1/test", "GET", { orgId: "o", userId: "u", runId: "r" });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.distribute.you/v1/test",
+      expect.anything(),
+    );
+  });
+});

--- a/tests/unit/api-registry-client.test.ts
+++ b/tests/unit/api-registry-client.test.ts
@@ -1,20 +1,25 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-vi.stubGlobal("fetch", vi.fn());
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  process.env.API_SERVICE_API_KEY = "test-api-svc-key";
+  process.env.API_SERVICE_URL = "https://api.test.local";
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.restoreAllMocks();
+});
 
 async function loadModule() {
   vi.resetModules();
-  process.env.API_REGISTRY_SERVICE_URL = "https://api-registry.test.local";
-  process.env.API_REGISTRY_SERVICE_API_KEY = "test-registry-key";
   return import("../../src/lib/api-registry-client.js");
 }
 
 describe("listServices", () => {
-  beforeEach(() => {
-    vi.mocked(fetch).mockReset();
-  });
-
-  it("calls GET /llm-context with correct headers", async () => {
+  it("calls GET /v1/platform/llm-context via api-service", async () => {
     const mockResponse = {
       _description: "API registry",
       _workflow: "list_services → list_service_endpoints → call_api",
@@ -25,10 +30,10 @@ describe("listServices", () => {
       ],
     };
 
-    vi.mocked(fetch).mockResolvedValue({
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: () => Promise.resolve(mockResponse),
-    } as Response);
+    });
 
     const { listServices } = await loadModule();
     const result = await listServices({
@@ -38,10 +43,10 @@ describe("listServices", () => {
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://api-registry.test.local/llm-context",
+      "https://api.test.local/v1/platform/llm-context",
       expect.objectContaining({
         headers: expect.objectContaining({
-          "x-api-key": "test-registry-key",
+          Authorization: "Bearer test-api-svc-key",
           "x-org-id": "org-1",
           "x-user-id": "user-1",
           "x-run-id": "run-1",
@@ -53,11 +58,11 @@ describe("listServices", () => {
   });
 
   it("throws on HTTP error", async () => {
-    vi.mocked(fetch).mockResolvedValue({
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: false,
       status: 401,
       text: () => Promise.resolve("Unauthorized"),
-    } as Response);
+    });
 
     const { listServices } = await loadModule();
     await expect(
@@ -66,25 +71,17 @@ describe("listServices", () => {
   });
 
   it("throws when API key is missing", async () => {
-    vi.resetModules();
-    process.env.API_REGISTRY_SERVICE_URL = "https://api-registry.test.local";
-    delete process.env.API_REGISTRY_SERVICE_API_KEY;
+    delete process.env.API_SERVICE_API_KEY;
 
-    const { listServices } = await import(
-      "../../src/lib/api-registry-client.js"
-    );
+    const { listServices } = await loadModule();
     await expect(
       listServices({ orgId: "o", userId: "u", runId: "r" }),
-    ).rejects.toThrow(/API_REGISTRY_SERVICE_API_KEY is required/);
+    ).rejects.toThrow(/API_SERVICE_API_KEY is required/);
   });
 });
 
 describe("listServiceEndpoints", () => {
-  beforeEach(() => {
-    vi.mocked(fetch).mockReset();
-  });
-
-  it("calls GET /llm-context/{service} with correct path", async () => {
+  it("calls GET /v1/platform/services/{service} via api-service", async () => {
     const mockResponse = {
       service: "brand",
       title: "Brand Service",
@@ -95,10 +92,10 @@ describe("listServiceEndpoints", () => {
       ],
     };
 
-    vi.mocked(fetch).mockResolvedValue({
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: () => Promise.resolve(mockResponse),
-    } as Response);
+    });
 
     const { listServiceEndpoints } = await loadModule();
     const result = await listServiceEndpoints("brand", {
@@ -108,7 +105,7 @@ describe("listServiceEndpoints", () => {
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://api-registry.test.local/llm-context/brand",
+      "https://api.test.local/v1/platform/services/brand",
       expect.anything(),
     );
     expect(result.service).toBe("brand");
@@ -116,11 +113,11 @@ describe("listServiceEndpoints", () => {
   });
 
   it("throws on 404 (service not found)", async () => {
-    vi.mocked(fetch).mockResolvedValue({
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: false,
       status: 404,
       text: () => Promise.resolve("Service not found"),
-    } as Response);
+    });
 
     const { listServiceEndpoints } = await loadModule();
     await expect(
@@ -130,89 +127,82 @@ describe("listServiceEndpoints", () => {
 });
 
 describe("callApi", () => {
-  beforeEach(() => {
-    vi.mocked(fetch).mockReset();
-  });
-
-  it("proxies a GET request", async () => {
-    vi.mocked(fetch).mockResolvedValue({
+  it("makes a direct GET request via api-service", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
+      status: 200,
       json: () =>
-        Promise.resolve({
-          status: 200,
-          ok: true,
-          data: { keys: [{ provider: "anthropic", maskedKey: "sk-...abc" }] },
-        }),
-    } as Response);
+        Promise.resolve({ keys: [{ provider: "anthropic", maskedKey: "sk-...abc" }] }),
+    });
 
     const { callApi } = await loadModule();
     const result = await callApi(
-      { service: "key", method: "GET", path: "/keys" },
+      { service: "key", method: "GET", path: "/v1/keys" },
       { orgId: "org-1", userId: "user-1", runId: "run-1" },
     );
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://api-registry.test.local/call/key",
+      "https://api.test.local/v1/keys",
       expect.objectContaining({
-        method: "POST",
+        method: "GET",
         headers: expect.objectContaining({
-          "content-type": "application/json",
-          "x-api-key": "test-registry-key",
+          Authorization: "Bearer test-api-svc-key",
         }),
       }),
     );
-
-    // Verify body contains the proxied request details
-    const callBody = JSON.parse(
-      (vi.mocked(fetch).mock.calls[0][1] as RequestInit).body as string,
-    );
-    expect(callBody).toEqual({ method: "GET", path: "/keys" });
 
     expect(result.ok).toBe(true);
     expect(result.status).toBe(200);
   });
 
-  it("proxies a POST request with body", async () => {
-    vi.mocked(fetch).mockResolvedValue({
+  it("makes a direct POST request with body via api-service", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
+      status: 200,
       json: () =>
-        Promise.resolve({ status: 200, ok: true, data: { providers: ["anthropic"] } }),
-    } as Response);
+        Promise.resolve({ providers: ["anthropic"] }),
+    });
 
     const { callApi } = await loadModule();
     await callApi(
       {
         service: "key",
         method: "POST",
-        path: "/provider-requirements",
+        path: "/v1/keys/provider-requirements",
         body: { endpoints: [{ service: "chat", method: "POST", path: "/complete" }] },
       },
       { orgId: "org-1", userId: "user-1", runId: "run-1" },
     );
 
-    const callBody = JSON.parse(
-      (vi.mocked(fetch).mock.calls[0][1] as RequestInit).body as string,
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.test.local/v1/keys/provider-requirements",
+      expect.objectContaining({
+        method: "POST",
+      }),
     );
-    expect(callBody.method).toBe("POST");
-    expect(callBody.path).toBe("/provider-requirements");
-    expect(callBody.body).toEqual({
+
+    const callBody = JSON.parse(
+      (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body,
+    );
+    expect(callBody).toEqual({
       endpoints: [{ service: "chat", method: "POST", path: "/complete" }],
     });
   });
 
-  it("throws on 502 (downstream failure)", async () => {
-    vi.mocked(fetch).mockResolvedValue({
+  it("returns error status for failed requests", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: false,
       status: 502,
-      text: () => Promise.resolve("Downstream unavailable"),
-    } as Response);
+      json: () => Promise.resolve({ error: "Downstream unavailable" }),
+    });
 
     const { callApi } = await loadModule();
-    await expect(
-      callApi(
-        { service: "brand", method: "GET", path: "/brands" },
-        { orgId: "o", userId: "u", runId: "r" },
-      ),
-    ).rejects.toThrow(/returned 502/);
+    const result = await callApi(
+      { service: "brand", method: "GET", path: "/v1/brands" },
+      { orgId: "o", userId: "u", runId: "r" },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(502);
   });
 });

--- a/tests/unit/content-generation-client.test.ts
+++ b/tests/unit/content-generation-client.test.ts
@@ -3,8 +3,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 const originalEnv = { ...process.env };
 
 beforeEach(() => {
-  process.env.CONTENT_GENERATION_SERVICE_API_KEY = "test-cg-key";
-  process.env.CONTENT_GENERATION_SERVICE_URL = "https://content-generation.test.local";
+  process.env.API_SERVICE_API_KEY = "test-api-svc-key";
+  process.env.API_SERVICE_URL = "https://api.test.local";
   vi.stubGlobal("fetch", vi.fn());
 });
 
@@ -19,7 +19,7 @@ async function loadModule() {
 }
 
 describe("getPromptTemplate", () => {
-  it("sends GET with correct URL, headers, and query param", async () => {
+  it("sends GET via api-service with correct URL and headers", async () => {
     const mockPrompt = {
       id: "p-1",
       type: "cold-email",
@@ -42,11 +42,11 @@ describe("getPromptTemplate", () => {
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://content-generation.test.local/prompts?type=cold-email",
+      "https://api.test.local/v1/prompts?type=cold-email",
       expect.objectContaining({
         method: "GET",
         headers: expect.objectContaining({
-          "x-api-key": "test-cg-key",
+          Authorization: "Bearer test-api-svc-key",
           "x-org-id": "org-1",
           "x-user-id": "user-1",
           "x-run-id": "run-1",
@@ -70,7 +70,7 @@ describe("getPromptTemplate", () => {
     });
 
     const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0];
-    expect(calledUrl).toBe("https://content-generation.test.local/prompts?type=cold%20email");
+    expect(calledUrl).toBe("https://api.test.local/v1/prompts?type=cold%20email");
   });
 
   it("forwards tracking headers", async () => {
@@ -104,19 +104,19 @@ describe("getPromptTemplate", () => {
     ).rejects.toThrow(/returned 404/);
   });
 
-  it("throws when CONTENT_GENERATION_SERVICE_API_KEY is not set", async () => {
-    delete process.env.CONTENT_GENERATION_SERVICE_API_KEY;
+  it("throws when API_SERVICE_API_KEY is not set", async () => {
+    delete process.env.API_SERVICE_API_KEY;
 
     const { getPromptTemplate } = await loadModule();
     await expect(
       getPromptTemplate("cold-email", { orgId: "o", userId: "u", runId: "r" }),
-    ).rejects.toThrow(/CONTENT_GENERATION_SERVICE_API_KEY is required/);
+    ).rejects.toThrow(/API_SERVICE_API_KEY is required/);
 
     expect(fetch).not.toHaveBeenCalled();
   });
 
-  it("uses default URL when CONTENT_GENERATION_SERVICE_URL is not set", async () => {
-    delete process.env.CONTENT_GENERATION_SERVICE_URL;
+  it("uses default URL when API_SERVICE_URL is not set", async () => {
+    delete process.env.API_SERVICE_URL;
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ id: "p-1", type: "t", prompt: "", variables: [], createdAt: "", updatedAt: "" }),
@@ -126,14 +126,14 @@ describe("getPromptTemplate", () => {
     await getPromptTemplate("cold-email", { orgId: "o", userId: "u", runId: "r" });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://content-generation.distribute.you/prompts?type=cold-email",
+      "https://api.distribute.you/v1/prompts?type=cold-email",
       expect.anything(),
     );
   });
 });
 
 describe("updatePromptTemplate", () => {
-  it("sends PUT with correct URL, headers, and body", async () => {
+  it("sends PUT via api-service with correct URL, headers, and body", async () => {
     const mockResult = {
       id: "p-2",
       type: "cold-email-v2",
@@ -159,12 +159,12 @@ describe("updatePromptTemplate", () => {
     );
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://content-generation.test.local/prompts",
+      "https://api.test.local/v1/prompts",
       expect.objectContaining({
         method: "PUT",
         headers: expect.objectContaining({
           "Content-Type": "application/json",
-          "x-api-key": "test-cg-key",
+          Authorization: "Bearer test-api-svc-key",
           "x-org-id": "org-1",
           "x-user-id": "user-1",
           "x-run-id": "run-1",
@@ -211,8 +211,8 @@ describe("updatePromptTemplate", () => {
     ).rejects.toThrow(/returned 400/);
   });
 
-  it("throws when CONTENT_GENERATION_SERVICE_API_KEY is not set", async () => {
-    delete process.env.CONTENT_GENERATION_SERVICE_API_KEY;
+  it("throws when API_SERVICE_API_KEY is not set", async () => {
+    delete process.env.API_SERVICE_API_KEY;
 
     const { updatePromptTemplate } = await loadModule();
     await expect(
@@ -220,7 +220,7 @@ describe("updatePromptTemplate", () => {
         { sourceType: "cold-email", prompt: "test", variables: [] },
         { orgId: "o", userId: "u", runId: "r" },
       ),
-    ).rejects.toThrow(/CONTENT_GENERATION_SERVICE_API_KEY is required/);
+    ).rejects.toThrow(/API_SERVICE_API_KEY is required/);
 
     expect(fetch).not.toHaveBeenCalled();
   });

--- a/tests/unit/features-client.test.ts
+++ b/tests/unit/features-client.test.ts
@@ -3,8 +3,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 const originalEnv = { ...process.env };
 
 beforeEach(() => {
-  process.env.FEATURES_SERVICE_API_KEY = "test-feat-key";
-  process.env.FEATURES_SERVICE_URL = "https://features.test.local";
+  process.env.API_SERVICE_API_KEY = "test-api-svc-key";
+  process.env.API_SERVICE_URL = "https://api.test.local";
   vi.stubGlobal("fetch", vi.fn());
 });
 
@@ -35,7 +35,7 @@ const sampleFeature = {
 };
 
 describe("createFeature", () => {
-  it("sends POST /features with correct URL, headers, and body", async () => {
+  it("sends POST /v1/features via api-service", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       status: 201,
@@ -50,12 +50,12 @@ describe("createFeature", () => {
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://features.test.local/features",
+      "https://api.test.local/v1/features",
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({
           "Content-Type": "application/json",
-          "x-api-key": "test-feat-key",
+          Authorization: "Bearer test-api-svc-key",
           "x-org-id": "org-1",
           "x-user-id": "user-1",
           "x-run-id": "run-1",
@@ -118,19 +118,19 @@ describe("createFeature", () => {
     ).rejects.toThrow(/returned 422/);
   });
 
-  it("throws when FEATURES_SERVICE_API_KEY is not set", async () => {
-    delete process.env.FEATURES_SERVICE_API_KEY;
+  it("throws when API_SERVICE_API_KEY is not set", async () => {
+    delete process.env.API_SERVICE_API_KEY;
 
     const { createFeature } = await loadModule();
     await expect(
       createFeature(sampleFeature, { orgId: "o", userId: "u", runId: "r" }),
-    ).rejects.toThrow(/FEATURES_SERVICE_API_KEY is required/);
+    ).rejects.toThrow(/API_SERVICE_API_KEY is required/);
 
     expect(fetch).not.toHaveBeenCalled();
   });
 
-  it("uses default FEATURES_SERVICE_URL when not set", async () => {
-    delete process.env.FEATURES_SERVICE_URL;
+  it("uses default API_SERVICE_URL when not set", async () => {
+    delete process.env.API_SERVICE_URL;
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       status: 201,
@@ -141,7 +141,7 @@ describe("createFeature", () => {
     await createFeature(sampleFeature, { orgId: "o", userId: "u", runId: "r" });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://features.distribute.you/features",
+      "https://api.distribute.you/v1/features",
       expect.anything(),
     );
   });
@@ -163,11 +163,11 @@ describe("updateFeature", () => {
     );
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://features.test.local/features/cold-email-outreach",
+      "https://api.test.local/v1/features/cold-email-outreach",
       expect.objectContaining({
         method: "PUT",
         headers: expect.objectContaining({
-          "x-api-key": "test-feat-key",
+          Authorization: "Bearer test-api-svc-key",
           "x-org-id": "org-1",
         }),
       }),
@@ -263,7 +263,7 @@ describe("updateFeature", () => {
 });
 
 describe("listFeatures", () => {
-  it("sends GET /features with query params", async () => {
+  it("sends GET /v1/features with query params via api-service", async () => {
     const mockFeatures = [sampleFeature];
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
@@ -277,14 +277,14 @@ describe("listFeatures", () => {
     );
 
     const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
-    expect(calledUrl).toContain("/features?");
+    expect(calledUrl).toContain("/v1/features?");
     expect(calledUrl).toContain("category=sales");
     expect(calledUrl).toContain("channel=email");
     expect(calledUrl).toContain("audienceType=cold-outreach");
     expect(result).toEqual(mockFeatures);
   });
 
-  it("sends GET /features without query params when no filters", async () => {
+  it("sends GET /v1/features without query params when no filters", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: () => Promise.resolve([]),
@@ -294,7 +294,7 @@ describe("listFeatures", () => {
     await listFeatures({}, { orgId: "o", userId: "u", runId: "r" });
 
     const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
-    expect(calledUrl).toBe("https://features.test.local/features");
+    expect(calledUrl).toBe("https://api.test.local/v1/features");
   });
 
   it("throws on HTTP error", async () => {
@@ -312,7 +312,7 @@ describe("listFeatures", () => {
 });
 
 describe("getFeature", () => {
-  it("sends GET /features/:slug with correct URL and headers", async () => {
+  it("sends GET /v1/features/:slug via api-service", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: () => Promise.resolve(sampleFeature),
@@ -326,11 +326,11 @@ describe("getFeature", () => {
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://features.test.local/features/cold-email-outreach",
+      "https://api.test.local/v1/features/cold-email-outreach",
       expect.objectContaining({
         method: "GET",
         headers: expect.objectContaining({
-          "x-api-key": "test-feat-key",
+          Authorization: "Bearer test-api-svc-key",
           "x-org-id": "org-1",
         }),
       }),
@@ -366,7 +366,7 @@ describe("getFeature", () => {
 });
 
 describe("getFeatureInputs", () => {
-  it("sends GET /features/:slug/inputs", async () => {
+  it("sends GET /v1/features/:slug/inputs via api-service", async () => {
     const mockResponse = {
       slug: "cold-email-outreach",
       name: "Cold Email Outreach",
@@ -385,7 +385,7 @@ describe("getFeatureInputs", () => {
     });
 
     const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
-    expect(calledUrl).toBe("https://features.test.local/features/cold-email-outreach/inputs");
+    expect(calledUrl).toBe("https://api.test.local/v1/features/cold-email-outreach/inputs");
     expect(result.slug).toBe("cold-email-outreach");
     expect(result.inputs).toHaveLength(1);
   });
@@ -405,7 +405,7 @@ describe("getFeatureInputs", () => {
 });
 
 describe("prefillFeature", () => {
-  it("sends POST /features/:slug/prefill?format=text", async () => {
+  it("sends POST /v1/features/:slug/prefill via api-service", async () => {
     const mockResponse = {
       slug: "cold-email-outreach",
       brandId: "brand-1",
@@ -425,7 +425,7 @@ describe("prefillFeature", () => {
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://features.test.local/features/cold-email-outreach/prefill?format=text",
+      "https://api.test.local/v1/features/cold-email-outreach/prefill",
       expect.objectContaining({ method: "POST" }),
     );
     expect(result.prefilled.targetCompanyUrl).toBe("https://acme.com");
@@ -447,7 +447,7 @@ describe("prefillFeature", () => {
 });
 
 describe("getFeatureStats", () => {
-  it("sends GET /features/:slug/stats with filters", async () => {
+  it("sends GET /v1/features/:slug/stats with filters via api-service", async () => {
     const mockResponse = {
       featureSlug: "cold-email-outreach",
       systemStats: { totalCostInUsdCents: 150, completedRuns: 10, activeCampaigns: 2, firstRunAt: null, lastRunAt: null },
@@ -466,14 +466,14 @@ describe("getFeatureStats", () => {
     );
 
     const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
-    expect(calledUrl).toContain("/features/cold-email-outreach/stats?");
+    expect(calledUrl).toContain("/v1/features/cold-email-outreach/stats?");
     expect(calledUrl).toContain("groupBy=brandId");
     expect(calledUrl).toContain("brandId=brand-1");
     expect(result.systemStats.completedRuns).toBe(10);
     expect(result.stats?.emailsSent).toBe(42);
   });
 
-  it("sends GET /features/:slug/stats without filters", async () => {
+  it("sends GET /v1/features/:slug/stats without filters", async () => {
     const mockResponse = {
       featureSlug: "cold-email-outreach",
       systemStats: { totalCostInUsdCents: 0, completedRuns: 0, activeCampaigns: 0, firstRunAt: null, lastRunAt: null },
@@ -487,7 +487,7 @@ describe("getFeatureStats", () => {
     await getFeatureStats("cold-email-outreach", {}, { orgId: "o", userId: "u", runId: "r" });
 
     const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
-    expect(calledUrl).toBe("https://features.test.local/features/cold-email-outreach/stats");
+    expect(calledUrl).toBe("https://api.test.local/v1/features/cold-email-outreach/stats");
   });
 
   it("throws on HTTP error", async () => {

--- a/tests/unit/key-client.test.ts
+++ b/tests/unit/key-client.test.ts
@@ -3,8 +3,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 const originalEnv = { ...process.env };
 
 beforeEach(() => {
+  // resolveKey still uses key-service directly
   process.env.KEY_SERVICE_API_KEY = "test-key-svc-key";
   process.env.KEY_SERVICE_URL = "https://key.test.local";
+  // Read-only tools now route through api-service
+  process.env.API_SERVICE_API_KEY = "test-api-svc-key";
+  process.env.API_SERVICE_URL = "https://api.test.local";
   vi.stubGlobal("fetch", vi.fn());
 });
 
@@ -17,6 +21,10 @@ async function loadModule() {
   vi.resetModules();
   return import("../../src/lib/key-client.js");
 }
+
+// ---------------------------------------------------------------------------
+// resolveKey — still direct to key-service
+// ---------------------------------------------------------------------------
 
 describe("resolveKey", () => {
   it("sends GET with orgId and userId as headers (not query params)", async () => {
@@ -204,11 +212,11 @@ describe("resolveKey", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Read-only key-service tools
+// Read-only key tools — now routed via api-service
 // ---------------------------------------------------------------------------
 
 describe("listOrgKeys", () => {
-  it("calls GET /keys with identity headers", async () => {
+  it("calls GET /v1/keys via api-service", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: () =>
@@ -227,10 +235,10 @@ describe("listOrgKeys", () => {
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://key.test.local/keys",
+      "https://api.test.local/v1/keys",
       expect.objectContaining({
         headers: expect.objectContaining({
-          "x-api-key": "test-key-svc-key",
+          Authorization: "Bearer test-api-svc-key",
           "x-org-id": "org-1",
         }),
       }),
@@ -267,7 +275,7 @@ describe("listOrgKeys", () => {
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://key.test.local/keys",
+      "https://api.test.local/v1/keys",
       expect.objectContaining({
         headers: expect.objectContaining({
           "x-campaign-id": "camp-123",
@@ -278,7 +286,7 @@ describe("listOrgKeys", () => {
 });
 
 describe("getKeySource", () => {
-  it("calls GET /keys/{provider}/source", async () => {
+  it("calls GET /v1/keys/{provider}/source via api-service", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: () =>
@@ -298,7 +306,7 @@ describe("getKeySource", () => {
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://key.test.local/keys/anthropic/source",
+      "https://api.test.local/v1/keys/anthropic/source",
       expect.anything(),
     );
     expect(result.keySource).toBe("org");
@@ -325,14 +333,14 @@ describe("getKeySource", () => {
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://key.test.local/keys/my%2Fprovider/source",
+      "https://api.test.local/v1/keys/my%2Fprovider/source",
       expect.anything(),
     );
   });
 });
 
 describe("listKeySources", () => {
-  it("calls GET /keys/sources and returns source preferences", async () => {
+  it("calls GET /v1/keys/sources via api-service", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: () =>
@@ -352,7 +360,7 @@ describe("listKeySources", () => {
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://key.test.local/keys/sources",
+      "https://api.test.local/v1/keys/sources",
       expect.anything(),
     );
     expect(result.sources).toHaveLength(2);
@@ -360,7 +368,7 @@ describe("listKeySources", () => {
 });
 
 describe("checkProviderRequirements", () => {
-  it("calls POST /provider-requirements with endpoints", async () => {
+  it("calls POST /v1/keys/provider-requirements via api-service", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: () =>
@@ -379,11 +387,11 @@ describe("checkProviderRequirements", () => {
     );
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://key.test.local/provider-requirements",
+      "https://api.test.local/v1/keys/provider-requirements",
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({
-          "content-type": "application/json",
+          Authorization: "Bearer test-api-svc-key",
         }),
       }),
     );
@@ -411,4 +419,3 @@ describe("checkProviderRequirements", () => {
     ).rejects.toThrow(/returned 400/);
   });
 });
-

--- a/tests/unit/workflow-client.test.ts
+++ b/tests/unit/workflow-client.test.ts
@@ -3,8 +3,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 const originalEnv = { ...process.env };
 
 beforeEach(() => {
-  process.env.WORKFLOW_SERVICE_API_KEY = "test-wf-key";
-  process.env.WORKFLOW_SERVICE_URL = "https://workflow.test.local";
+  process.env.API_SERVICE_API_KEY = "test-api-svc-key";
+  process.env.API_SERVICE_URL = "https://api.test.local";
   vi.stubGlobal("fetch", vi.fn());
 });
 
@@ -19,7 +19,7 @@ async function loadModule() {
 }
 
 describe("updateWorkflow", () => {
-  it("sends PUT with correct URL, headers, and body", async () => {
+  it("sends PUT with correct URL, headers, and body via api-service", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ id: "wf-123", description: "Updated" }),
@@ -33,12 +33,12 @@ describe("updateWorkflow", () => {
     );
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://workflow.test.local/workflows/wf-123",
+      "https://api.test.local/v1/workflows/wf-123",
       expect.objectContaining({
         method: "PUT",
         headers: expect.objectContaining({
           "Content-Type": "application/json",
-          "x-api-key": "test-wf-key",
+          Authorization: "Bearer test-api-svc-key",
           "x-org-id": "org-1",
           "x-user-id": "user-1",
           "x-run-id": "run-1",
@@ -89,7 +89,7 @@ describe("updateWorkflow", () => {
     ).rejects.toThrow(/sales-email-v2.*wf-existing/);
   });
 
-  it("always sends x-run-id header (regression: workflow-service 400)", async () => {
+  it("always sends identity headers", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ id: "wf-123" }),
@@ -106,7 +106,7 @@ describe("updateWorkflow", () => {
     expect(callHeaders["x-run-id"]).toBe("run-1");
     expect(callHeaders["x-org-id"]).toBe("org-1");
     expect(callHeaders["x-user-id"]).toBe("user-1");
-    expect(callHeaders["x-api-key"]).toBe("test-wf-key");
+    expect(callHeaders["Authorization"]).toBe("Bearer test-api-svc-key");
   });
 
   it("forwards tracking headers", async () => {
@@ -167,31 +167,28 @@ describe("updateWorkflow", () => {
     );
 
     const sentBody = JSON.parse((fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
-    // Null fields stripped
     expect(sentBody.dag.nodes[0]).toEqual({ id: "step-1", type: "http.call", retries: 0 });
     expect(sentBody.dag.nodes[0].config).toBeUndefined();
     expect(sentBody.dag.nodes[0].inputMapping).toBeUndefined();
-    // Nodes without config/inputMapping stay clean
     expect(sentBody.dag.nodes[1]).toEqual({ id: "step-2", type: "condition" });
-    // Non-null fields preserved
     expect(sentBody.dag.nodes[2].config).toEqual({ path: "/send" });
     expect(sentBody.dag.nodes[2].inputMapping).toEqual({ "body.to": "$ref:step-1.output.email" });
   });
 
-  it("throws when WORKFLOW_SERVICE_API_KEY is not set", async () => {
-    delete process.env.WORKFLOW_SERVICE_API_KEY;
+  it("throws when API_SERVICE_API_KEY is not set", async () => {
+    delete process.env.API_SERVICE_API_KEY;
 
     const { updateWorkflow } = await loadModule();
     await expect(
       updateWorkflow("wf-1", { description: "x" }, { orgId: "o", userId: "u", runId: "r" }),
-    ).rejects.toThrow(/WORKFLOW_SERVICE_API_KEY is required/);
+    ).rejects.toThrow(/API_SERVICE_API_KEY is required/);
 
     expect(fetch).not.toHaveBeenCalled();
   });
 });
 
 describe("validateWorkflow", () => {
-  it("sends POST with correct URL and headers", async () => {
+  it("sends POST with correct URL and headers via api-service", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ valid: true, errors: [] }),
@@ -205,11 +202,11 @@ describe("validateWorkflow", () => {
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://workflow.test.local/workflows/wf-456/validate",
+      "https://api.test.local/v1/workflows/wf-456/validate",
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({
-          "x-api-key": "test-wf-key",
+          Authorization: "Bearer test-api-svc-key",
           "x-org-id": "org-1",
           "x-user-id": "user-1",
           "x-run-id": "run-1",
@@ -232,8 +229,8 @@ describe("validateWorkflow", () => {
     ).rejects.toThrow(/returned 500/);
   });
 
-  it("uses default WORKFLOW_SERVICE_URL when not set", async () => {
-    delete process.env.WORKFLOW_SERVICE_URL;
+  it("uses default API_SERVICE_URL when not set", async () => {
+    delete process.env.API_SERVICE_URL;
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ valid: true }),
@@ -243,14 +240,14 @@ describe("validateWorkflow", () => {
     await validateWorkflow("wf-1", { orgId: "o", userId: "u", runId: "r" });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://workflow.mcpfactory.org/workflows/wf-1/validate",
+      "https://api.distribute.you/v1/workflows/wf-1/validate",
       expect.anything(),
     );
   });
 });
 
 describe("getWorkflow", () => {
-  it("sends GET with correct URL and headers", async () => {
+  it("sends GET with correct URL and headers via api-service", async () => {
     const mockWorkflow = { id: "wf-1", dag: { nodes: [], edges: [] } };
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
@@ -261,11 +258,11 @@ describe("getWorkflow", () => {
     const result = await getWorkflow("wf-1", { orgId: "org-1", userId: "user-1", runId: "run-1" });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://workflow.test.local/workflows/wf-1",
+      "https://api.test.local/v1/workflows/wf-1",
       expect.objectContaining({
         method: "GET",
         headers: expect.objectContaining({
-          "x-api-key": "test-wf-key",
+          Authorization: "Bearer test-api-svc-key",
           "x-org-id": "org-1",
         }),
       }),
@@ -303,8 +300,8 @@ describe("updateWorkflowNodeConfig", () => {
     const updatedWorkflow = { ...existingWorkflow, updatedAt: "2026-03-18T00:00:00Z" };
 
     (fetch as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(existingWorkflow) }) // GET
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(updatedWorkflow) }); // PUT
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(existingWorkflow) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(updatedWorkflow) });
 
     const { updateWorkflowNodeConfig } = await loadModule();
     const result = await updateWorkflowNodeConfig(
@@ -314,17 +311,13 @@ describe("updateWorkflowNodeConfig", () => {
       { orgId: "org-1", userId: "user-1", runId: "run-1" },
     );
 
-    // Verify GET was called first
-    expect((fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe("https://workflow.test.local/workflows/wf-1");
+    expect((fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe("https://api.test.local/v1/workflows/wf-1");
     expect((fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].method).toBe("GET");
 
-    // Verify PUT was called with merged config
     const putBody = JSON.parse((fetch as ReturnType<typeof vi.fn>).mock.calls[1][1].body);
     expect(putBody.dag.nodes[0].config.body.type).toBe("cold-email-v3");
-    // Preserved other config keys
     expect(putBody.dag.nodes[0].config.path).toBe("/generate");
     expect(putBody.dag.nodes[0].config.service).toBe("content-generation");
-    // Other nodes unchanged
     expect(putBody.dag.nodes[1].id).toBe("email-send");
 
     expect(result).toEqual({ workflow: updatedWorkflow, outcome: "updated" });
@@ -342,8 +335,8 @@ describe("updateWorkflowNodeConfig", () => {
     const forkedWorkflow = { id: "wf-forked", name: "wf-1-custom", forkedFrom: "wf-1", dag: existingWorkflow.dag };
 
     (fetch as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(existingWorkflow) }) // GET
-      .mockResolvedValueOnce({ ok: true, status: 201, json: () => Promise.resolve(forkedWorkflow) }); // PUT (fork)
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(existingWorkflow) })
+      .mockResolvedValueOnce({ ok: true, status: 201, json: () => Promise.resolve(forkedWorkflow) });
 
     const { updateWorkflowNodeConfig } = await loadModule();
     const result = await updateWorkflowNodeConfig(
@@ -397,7 +390,7 @@ describe("updateWorkflowNodeConfig", () => {
 });
 
 describe("generateWorkflow", () => {
-  it("sends POST /workflows/generate with description and hints", async () => {
+  it("sends POST /v1/workflows/generate via api-service", async () => {
     const mockResponse = {
       workflow: { id: "wf-new", name: "sales-email-cold-outreach-nova" },
       dag: { nodes: [{ id: "step-1", type: "http.call" }], edges: [] },
@@ -416,17 +409,18 @@ describe("generateWorkflow", () => {
     const result = await generateWorkflow(
       {
         description: "Create a cold email workflow that fetches a lead, generates an email, and sends it",
+        featureSlug: "cold-email",
         hints: { services: ["lead", "content-generation", "email-gateway"] },
       },
       { orgId: "org-1", userId: "user-1", runId: "run-1" },
     );
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://workflow.test.local/workflows/generate",
+      "https://api.test.local/v1/workflows/generate",
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({
-          "x-api-key": "test-wf-key",
+          Authorization: "Bearer test-api-svc-key",
           "x-org-id": "org-1",
         }),
       }),
@@ -449,7 +443,7 @@ describe("generateWorkflow", () => {
     const { generateWorkflow } = await loadModule();
     await expect(
       generateWorkflow(
-        { description: "bad workflow" },
+        { description: "bad workflow", featureSlug: "test" },
         { orgId: "o", userId: "u", runId: "r" },
       ),
     ).rejects.toThrow(/returned 422/);
@@ -463,7 +457,7 @@ describe("generateWorkflow", () => {
 
     const { generateWorkflow } = await loadModule();
     await generateWorkflow(
-      { description: "Simple workflow that sends an email" },
+      { description: "Simple workflow that sends an email", featureSlug: "email" },
       { orgId: "o", userId: "u", runId: "r" },
     );
 
@@ -474,7 +468,7 @@ describe("generateWorkflow", () => {
 });
 
 describe("getWorkflowRequiredProviders", () => {
-  it("sends GET to /workflows/{id}/required-providers", async () => {
+  it("sends GET to /v1/workflows/{id}/key-status via api-service", async () => {
     const mockProviders = { providers: ["stripe", "anthropic"] };
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
@@ -489,11 +483,11 @@ describe("getWorkflowRequiredProviders", () => {
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://workflow.test.local/workflows/wf-1/required-providers",
+      "https://api.test.local/v1/workflows/wf-1/key-status",
       expect.objectContaining({
         method: "GET",
         headers: expect.objectContaining({
-          "x-api-key": "test-wf-key",
+          Authorization: "Bearer test-api-svc-key",
           "x-org-id": "org-1",
         }),
       }),
@@ -516,7 +510,7 @@ describe("getWorkflowRequiredProviders", () => {
 });
 
 describe("listWorkflows", () => {
-  it("sends GET /workflows with query params", async () => {
+  it("sends GET /v1/workflows with query params via api-service", async () => {
     const mockWorkflows = [{ id: "wf-1", name: "sales-email" }];
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
@@ -530,7 +524,7 @@ describe("listWorkflows", () => {
     );
 
     const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
-    expect(calledUrl).toContain("/workflows?");
+    expect(calledUrl).toContain("/v1/workflows?");
     expect(calledUrl).toContain("category=sales");
     expect(calledUrl).toContain("channel=email");
     expect(calledUrl).toContain("tag=cold");
@@ -539,7 +533,7 @@ describe("listWorkflows", () => {
     expect(result).toEqual(mockWorkflows);
   });
 
-  it("sends GET /workflows without query params when no filters", async () => {
+  it("sends GET /v1/workflows without query params when no filters", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: () => Promise.resolve([]),
@@ -549,7 +543,7 @@ describe("listWorkflows", () => {
     await listWorkflows({}, { orgId: "o", userId: "u", runId: "r" });
 
     const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
-    expect(calledUrl).toBe("https://workflow.test.local/workflows");
+    expect(calledUrl).toBe("https://api.test.local/v1/workflows");
   });
 
   it("throws on HTTP error", async () => {


### PR DESCRIPTION
## Summary
- **Route all client-facing backend calls through api-service** instead of calling 7 backend services directly
- New shared `src/lib/api-client.ts` with `apiServiceFetch()` helper using Bearer auth to api-service
- Rewrote 5 client files (workflow, features, key read-tools, content-generation, api-registry) to use api-service `/v1/*` endpoints
- **Kept direct**: runs-service, billing-service, and key-service decrypt (infrastructure calls not exposed in api-service)
- Reduced env vars from 14 (7 URLs + 7 API keys) to 6 (`API_SERVICE_URL` + `API_SERVICE_API_KEY` + runs/billing/key-decrypt)

## Test plan
- [x] All 267 unit tests pass (including new `api-client.test.ts`)
- [x] TypeScript build succeeds
- [ ] Deploy to staging and verify chat tool calls work end-to-end
- [ ] Set `API_SERVICE_URL` and `API_SERVICE_API_KEY` env vars in Railway
- [ ] Remove deprecated env vars: `WORKFLOW_SERVICE_URL`, `WORKFLOW_SERVICE_API_KEY`, `FEATURES_SERVICE_URL`, `FEATURES_SERVICE_API_KEY`, `CONTENT_GENERATION_SERVICE_URL`, `CONTENT_GENERATION_SERVICE_API_KEY`, `API_REGISTRY_SERVICE_URL`, `API_REGISTRY_SERVICE_API_KEY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)