### PR TITLE
rename API_SERVICE_API_KEY to ADMIN_DISTRIBUTE_API_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token st
 
 | Variable | Required | Description |
 |---|---|---|
-| `API_SERVICE_API_KEY` | Yes | Bearer token for api-service gateway — all client-facing backend calls (workflows, features, keys, prompts, api-registry) route through api-service |
+| `ADMIN_DISTRIBUTE_API_KEY` | Yes | Bearer token for api-service gateway — all client-facing backend calls (workflows, features, keys, prompts, api-registry) route through api-service |
 | `API_SERVICE_URL` | No | Api-service endpoint (default: `https://api.distribute.you`) |
 | `KEY_SERVICE_API_KEY` | Yes | Service-to-service key for key-service (used only for Anthropic API key decryption — infrastructure, not routed via api-service) |
 | `KEY_SERVICE_URL` | No | Key-service endpoint (default: `https://key.mcpfactory.org`) |

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,6 +1,6 @@
 const API_SERVICE_URL =
   process.env.API_SERVICE_URL || "https://api.distribute.you";
-const API_SERVICE_API_KEY = process.env.API_SERVICE_API_KEY;
+const ADMIN_DISTRIBUTE_API_KEY = process.env.ADMIN_DISTRIBUTE_API_KEY;
 
 export interface ApiCallParams {
   orgId: string;
@@ -19,13 +19,13 @@ export function apiServiceFetch(
   params: ApiCallParams,
   body?: unknown,
 ): Promise<Response> {
-  if (!API_SERVICE_API_KEY) {
-    throw new Error("[api-client] API_SERVICE_API_KEY is required");
+  if (!ADMIN_DISTRIBUTE_API_KEY) {
+    throw new Error("[api-client] ADMIN_DISTRIBUTE_API_KEY is required");
   }
 
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
-    Authorization: `Bearer ${API_SERVICE_API_KEY}`,
+    Authorization: `Bearer ${ADMIN_DISTRIBUTE_API_KEY}`,
     "x-org-id": params.orgId,
     "x-user-id": params.userId,
     "x-run-id": params.runId,

--- a/tests/unit/api-client.test.ts
+++ b/tests/unit/api-client.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 const originalEnv = { ...process.env };
 
 beforeEach(() => {
-  process.env.API_SERVICE_API_KEY = "test-api-svc-key";
+  process.env.ADMIN_DISTRIBUTE_API_KEY = "test-api-svc-key";
   process.env.API_SERVICE_URL = "https://api.test.local";
   vi.stubGlobal("fetch", vi.fn());
 });
@@ -88,13 +88,13 @@ describe("apiServiceFetch", () => {
     expect(callHeaders["x-brand-id"]).toBe("brand-1");
   });
 
-  it("throws when API_SERVICE_API_KEY is not set", async () => {
-    delete process.env.API_SERVICE_API_KEY;
+  it("throws when ADMIN_DISTRIBUTE_API_KEY is not set", async () => {
+    delete process.env.ADMIN_DISTRIBUTE_API_KEY;
 
     const { apiServiceFetch } = await loadModule();
     expect(() =>
       apiServiceFetch("/v1/keys", "GET", { orgId: "o", userId: "u", runId: "r" }),
-    ).toThrow(/API_SERVICE_API_KEY is required/);
+    ).toThrow(/ADMIN_DISTRIBUTE_API_KEY is required/);
 
     expect(fetch).not.toHaveBeenCalled();
   });

--- a/tests/unit/api-registry-client.test.ts
+++ b/tests/unit/api-registry-client.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 const originalEnv = { ...process.env };
 
 beforeEach(() => {
-  process.env.API_SERVICE_API_KEY = "test-api-svc-key";
+  process.env.ADMIN_DISTRIBUTE_API_KEY = "test-api-svc-key";
   process.env.API_SERVICE_URL = "https://api.test.local";
   vi.stubGlobal("fetch", vi.fn());
 });
@@ -71,12 +71,12 @@ describe("listServices", () => {
   });
 
   it("throws when API key is missing", async () => {
-    delete process.env.API_SERVICE_API_KEY;
+    delete process.env.ADMIN_DISTRIBUTE_API_KEY;
 
     const { listServices } = await loadModule();
     await expect(
       listServices({ orgId: "o", userId: "u", runId: "r" }),
-    ).rejects.toThrow(/API_SERVICE_API_KEY is required/);
+    ).rejects.toThrow(/ADMIN_DISTRIBUTE_API_KEY is required/);
   });
 });
 

--- a/tests/unit/content-generation-client.test.ts
+++ b/tests/unit/content-generation-client.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 const originalEnv = { ...process.env };
 
 beforeEach(() => {
-  process.env.API_SERVICE_API_KEY = "test-api-svc-key";
+  process.env.ADMIN_DISTRIBUTE_API_KEY = "test-api-svc-key";
   process.env.API_SERVICE_URL = "https://api.test.local";
   vi.stubGlobal("fetch", vi.fn());
 });
@@ -104,13 +104,13 @@ describe("getPromptTemplate", () => {
     ).rejects.toThrow(/returned 404/);
   });
 
-  it("throws when API_SERVICE_API_KEY is not set", async () => {
-    delete process.env.API_SERVICE_API_KEY;
+  it("throws when ADMIN_DISTRIBUTE_API_KEY is not set", async () => {
+    delete process.env.ADMIN_DISTRIBUTE_API_KEY;
 
     const { getPromptTemplate } = await loadModule();
     await expect(
       getPromptTemplate("cold-email", { orgId: "o", userId: "u", runId: "r" }),
-    ).rejects.toThrow(/API_SERVICE_API_KEY is required/);
+    ).rejects.toThrow(/ADMIN_DISTRIBUTE_API_KEY is required/);
 
     expect(fetch).not.toHaveBeenCalled();
   });
@@ -211,8 +211,8 @@ describe("updatePromptTemplate", () => {
     ).rejects.toThrow(/returned 400/);
   });
 
-  it("throws when API_SERVICE_API_KEY is not set", async () => {
-    delete process.env.API_SERVICE_API_KEY;
+  it("throws when ADMIN_DISTRIBUTE_API_KEY is not set", async () => {
+    delete process.env.ADMIN_DISTRIBUTE_API_KEY;
 
     const { updatePromptTemplate } = await loadModule();
     await expect(
@@ -220,7 +220,7 @@ describe("updatePromptTemplate", () => {
         { sourceType: "cold-email", prompt: "test", variables: [] },
         { orgId: "o", userId: "u", runId: "r" },
       ),
-    ).rejects.toThrow(/API_SERVICE_API_KEY is required/);
+    ).rejects.toThrow(/ADMIN_DISTRIBUTE_API_KEY is required/);
 
     expect(fetch).not.toHaveBeenCalled();
   });

--- a/tests/unit/features-client.test.ts
+++ b/tests/unit/features-client.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 const originalEnv = { ...process.env };
 
 beforeEach(() => {
-  process.env.API_SERVICE_API_KEY = "test-api-svc-key";
+  process.env.ADMIN_DISTRIBUTE_API_KEY = "test-api-svc-key";
   process.env.API_SERVICE_URL = "https://api.test.local";
   vi.stubGlobal("fetch", vi.fn());
 });
@@ -118,13 +118,13 @@ describe("createFeature", () => {
     ).rejects.toThrow(/returned 422/);
   });
 
-  it("throws when API_SERVICE_API_KEY is not set", async () => {
-    delete process.env.API_SERVICE_API_KEY;
+  it("throws when ADMIN_DISTRIBUTE_API_KEY is not set", async () => {
+    delete process.env.ADMIN_DISTRIBUTE_API_KEY;
 
     const { createFeature } = await loadModule();
     await expect(
       createFeature(sampleFeature, { orgId: "o", userId: "u", runId: "r" }),
-    ).rejects.toThrow(/API_SERVICE_API_KEY is required/);
+    ).rejects.toThrow(/ADMIN_DISTRIBUTE_API_KEY is required/);
 
     expect(fetch).not.toHaveBeenCalled();
   });

--- a/tests/unit/key-client.test.ts
+++ b/tests/unit/key-client.test.ts
@@ -7,7 +7,7 @@ beforeEach(() => {
   process.env.KEY_SERVICE_API_KEY = "test-key-svc-key";
   process.env.KEY_SERVICE_URL = "https://key.test.local";
   // Read-only tools now route through api-service
-  process.env.API_SERVICE_API_KEY = "test-api-svc-key";
+  process.env.ADMIN_DISTRIBUTE_API_KEY = "test-api-svc-key";
   process.env.API_SERVICE_URL = "https://api.test.local";
   vi.stubGlobal("fetch", vi.fn());
 });

--- a/tests/unit/workflow-client.test.ts
+++ b/tests/unit/workflow-client.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 const originalEnv = { ...process.env };
 
 beforeEach(() => {
-  process.env.API_SERVICE_API_KEY = "test-api-svc-key";
+  process.env.ADMIN_DISTRIBUTE_API_KEY = "test-api-svc-key";
   process.env.API_SERVICE_URL = "https://api.test.local";
   vi.stubGlobal("fetch", vi.fn());
 });
@@ -175,13 +175,13 @@ describe("updateWorkflow", () => {
     expect(sentBody.dag.nodes[2].inputMapping).toEqual({ "body.to": "$ref:step-1.output.email" });
   });
 
-  it("throws when API_SERVICE_API_KEY is not set", async () => {
-    delete process.env.API_SERVICE_API_KEY;
+  it("throws when ADMIN_DISTRIBUTE_API_KEY is not set", async () => {
+    delete process.env.ADMIN_DISTRIBUTE_API_KEY;
 
     const { updateWorkflow } = await loadModule();
     await expect(
       updateWorkflow("wf-1", { description: "x" }, { orgId: "o", userId: "u", runId: "r" }),
-    ).rejects.toThrow(/API_SERVICE_API_KEY is required/);
+    ).rejects.toThrow(/ADMIN_DISTRIBUTE_API_KEY is required/);
 
     expect(fetch).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- Renames `API_SERVICE_API_KEY` env var to `ADMIN_DISTRIBUTE_API_KEY` across source, tests, and README
- Aligns with the shared admin key naming convention

## Test plan
- [x] All 268 unit tests pass
- [x] Build succeeds
- [x] Zero remaining references to old env var name
- [ ] Deploy: set `ADMIN_DISTRIBUTE_API_KEY` in Railway env vars (same value as old `API_SERVICE_API_KEY`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)