### PR TITLE
switch auth to X-API-Key header for api-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token st
 
 | Variable | Required | Description |
 |---|---|---|
-| `ADMIN_DISTRIBUTE_API_KEY` | Yes | Bearer token for api-service gateway — all client-facing backend calls (workflows, features, keys, prompts, api-registry) route through api-service |
+| `ADMIN_DISTRIBUTE_API_KEY` | Yes | Admin API key for api-service gateway (sent as `X-API-Key` header) — all client-facing backend calls (workflows, features, keys, prompts, api-registry) route through api-service |
 | `API_SERVICE_URL` | No | Api-service endpoint (default: `https://api.distribute.you`) |
 | `KEY_SERVICE_API_KEY` | Yes | Service-to-service key for key-service (used only for Anthropic API key decryption — infrastructure, not routed via api-service) |
 | `KEY_SERVICE_URL` | No | Key-service endpoint (default: `https://key.mcpfactory.org`) |

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -25,7 +25,7 @@ export function apiServiceFetch(
 
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
-    Authorization: `Bearer ${ADMIN_DISTRIBUTE_API_KEY}`,
+    "X-API-Key": ADMIN_DISTRIBUTE_API_KEY,
     "x-org-id": params.orgId,
     "x-user-id": params.userId,
     "x-run-id": params.runId,

--- a/tests/unit/api-client.test.ts
+++ b/tests/unit/api-client.test.ts
@@ -19,7 +19,7 @@ async function loadModule() {
 }
 
 describe("apiServiceFetch", () => {
-  it("sends request with correct URL, Bearer auth, and identity headers", async () => {
+  it("sends request with correct URL, X-API-Key auth, and identity headers", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true });
 
     const { apiServiceFetch } = await loadModule();
@@ -34,7 +34,7 @@ describe("apiServiceFetch", () => {
       expect.objectContaining({
         method: "GET",
         headers: expect.objectContaining({
-          Authorization: "Bearer test-api-svc-key",
+          "X-API-Key": "test-api-svc-key",
           "x-org-id": "org-1",
           "x-user-id": "user-1",
           "x-run-id": "run-1",

--- a/tests/unit/api-registry-client.test.ts
+++ b/tests/unit/api-registry-client.test.ts
@@ -46,7 +46,7 @@ describe("listServices", () => {
       "https://api.test.local/v1/platform/llm-context",
       expect.objectContaining({
         headers: expect.objectContaining({
-          Authorization: "Bearer test-api-svc-key",
+          "X-API-Key": "test-api-svc-key",
           "x-org-id": "org-1",
           "x-user-id": "user-1",
           "x-run-id": "run-1",
@@ -146,7 +146,7 @@ describe("callApi", () => {
       expect.objectContaining({
         method: "GET",
         headers: expect.objectContaining({
-          Authorization: "Bearer test-api-svc-key",
+          "X-API-Key": "test-api-svc-key",
         }),
       }),
     );

--- a/tests/unit/content-generation-client.test.ts
+++ b/tests/unit/content-generation-client.test.ts
@@ -46,7 +46,7 @@ describe("getPromptTemplate", () => {
       expect.objectContaining({
         method: "GET",
         headers: expect.objectContaining({
-          Authorization: "Bearer test-api-svc-key",
+          "X-API-Key": "test-api-svc-key",
           "x-org-id": "org-1",
           "x-user-id": "user-1",
           "x-run-id": "run-1",
@@ -164,7 +164,7 @@ describe("updatePromptTemplate", () => {
         method: "PUT",
         headers: expect.objectContaining({
           "Content-Type": "application/json",
-          Authorization: "Bearer test-api-svc-key",
+          "X-API-Key": "test-api-svc-key",
           "x-org-id": "org-1",
           "x-user-id": "user-1",
           "x-run-id": "run-1",

--- a/tests/unit/features-client.test.ts
+++ b/tests/unit/features-client.test.ts
@@ -55,7 +55,7 @@ describe("createFeature", () => {
         method: "POST",
         headers: expect.objectContaining({
           "Content-Type": "application/json",
-          Authorization: "Bearer test-api-svc-key",
+          "X-API-Key": "test-api-svc-key",
           "x-org-id": "org-1",
           "x-user-id": "user-1",
           "x-run-id": "run-1",
@@ -167,7 +167,7 @@ describe("updateFeature", () => {
       expect.objectContaining({
         method: "PUT",
         headers: expect.objectContaining({
-          Authorization: "Bearer test-api-svc-key",
+          "X-API-Key": "test-api-svc-key",
           "x-org-id": "org-1",
         }),
       }),
@@ -330,7 +330,7 @@ describe("getFeature", () => {
       expect.objectContaining({
         method: "GET",
         headers: expect.objectContaining({
-          Authorization: "Bearer test-api-svc-key",
+          "X-API-Key": "test-api-svc-key",
           "x-org-id": "org-1",
         }),
       }),

--- a/tests/unit/key-client.test.ts
+++ b/tests/unit/key-client.test.ts
@@ -238,7 +238,7 @@ describe("listOrgKeys", () => {
       "https://api.test.local/v1/keys",
       expect.objectContaining({
         headers: expect.objectContaining({
-          Authorization: "Bearer test-api-svc-key",
+          "X-API-Key": "test-api-svc-key",
           "x-org-id": "org-1",
         }),
       }),
@@ -391,7 +391,7 @@ describe("checkProviderRequirements", () => {
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({
-          Authorization: "Bearer test-api-svc-key",
+          "X-API-Key": "test-api-svc-key",
         }),
       }),
     );

--- a/tests/unit/workflow-client.test.ts
+++ b/tests/unit/workflow-client.test.ts
@@ -38,7 +38,7 @@ describe("updateWorkflow", () => {
         method: "PUT",
         headers: expect.objectContaining({
           "Content-Type": "application/json",
-          Authorization: "Bearer test-api-svc-key",
+          "X-API-Key": "test-api-svc-key",
           "x-org-id": "org-1",
           "x-user-id": "user-1",
           "x-run-id": "run-1",
@@ -106,7 +106,7 @@ describe("updateWorkflow", () => {
     expect(callHeaders["x-run-id"]).toBe("run-1");
     expect(callHeaders["x-org-id"]).toBe("org-1");
     expect(callHeaders["x-user-id"]).toBe("user-1");
-    expect(callHeaders["Authorization"]).toBe("Bearer test-api-svc-key");
+    expect(callHeaders["X-API-Key"]).toBe("test-api-svc-key");
   });
 
   it("forwards tracking headers", async () => {
@@ -206,7 +206,7 @@ describe("validateWorkflow", () => {
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({
-          Authorization: "Bearer test-api-svc-key",
+          "X-API-Key": "test-api-svc-key",
           "x-org-id": "org-1",
           "x-user-id": "user-1",
           "x-run-id": "run-1",
@@ -262,7 +262,7 @@ describe("getWorkflow", () => {
       expect.objectContaining({
         method: "GET",
         headers: expect.objectContaining({
-          Authorization: "Bearer test-api-svc-key",
+          "X-API-Key": "test-api-svc-key",
           "x-org-id": "org-1",
         }),
       }),
@@ -420,7 +420,7 @@ describe("generateWorkflow", () => {
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({
-          Authorization: "Bearer test-api-svc-key",
+          "X-API-Key": "test-api-svc-key",
           "x-org-id": "org-1",
         }),
       }),
@@ -487,7 +487,7 @@ describe("getWorkflowRequiredProviders", () => {
       expect.objectContaining({
         method: "GET",
         headers: expect.objectContaining({
-          Authorization: "Bearer test-api-svc-key",
+          "X-API-Key": "test-api-svc-key",
           "x-org-id": "org-1",
         }),
       }),


### PR DESCRIPTION
## Summary
- Replace `Authorization: Bearer <key>` with `X-API-Key: <key>` header in api-client to match api-service admin auth path
- Update all test assertions accordingly
- Update README env var description

## Test plan
- [x] All unit tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [ ] Verify api-service accepts X-API-Key header after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)