### PR TITLE
feat: align workflow-client types with workflow-service spec

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -619,9 +619,10 @@ app.post("/chat", requireAuth, async (req, res) => {
             wfParams,
           );
           if (updateResult.outcome === "forked") {
+            const forkedFrom = updateResult.workflow._forkedFromName || workflowId;
             result = {
               ...updateResult.workflow,
-              _note: `This is a NEW workflow forked from ${workflowId}. Tell the user: "Your customized workflow is ready: ${updateResult.workflow.name || updateResult.workflow.signatureName || updateResult.workflow.id}. Use this name for future campaigns."`,
+              _note: `This is a NEW workflow forked from "${forkedFrom}". Tell the user: "Your customized workflow is ready: ${updateResult.workflow.name || updateResult.workflow.signatureName || updateResult.workflow.id}. Use this name for future campaigns."`,
             };
           } else {
             result = updateResult.workflow;
@@ -698,9 +699,10 @@ app.post("/chat", requireAuth, async (req, res) => {
 
         let result: unknown;
         if (updateResult.outcome === "forked") {
+          const forkedFrom = updateResult.workflow._forkedFromName || "the original";
           result = {
             ...updateResult.workflow,
-            _note: `This is a NEW workflow forked from the original. Tell the user: "Your customized workflow is ready: ${updateResult.workflow.name || updateResult.workflow.signatureName || updateResult.workflow.id}. Use this name for future campaigns."`,
+            _note: `This is a NEW workflow forked from "${forkedFrom}". Tell the user: "Your customized workflow is ready: ${updateResult.workflow.name || updateResult.workflow.signatureName || updateResult.workflow.id}. Use this name for future campaigns."`,
           };
         } else {
           result = updateResult.workflow;

--- a/src/lib/workflow-client.ts
+++ b/src/lib/workflow-client.ts
@@ -2,32 +2,70 @@ import { apiServiceFetch, type ApiCallParams } from "./api-client.js";
 
 export type WorkflowCallParams = ApiCallParams;
 
+export interface DAGNode {
+  id: string;
+  type: string;
+  config?: Record<string, unknown>;
+  inputMapping?: Record<string, string>;
+  retries?: number;
+}
+
+export interface DAGEdge {
+  from: string;
+  to: string;
+  condition?: string;
+}
+
+export interface DAG {
+  nodes: DAGNode[];
+  edges: DAGEdge[];
+  onError?: string;
+}
+
 export interface WorkflowResponse {
   id: string;
-  name?: string;
-  signatureName?: string;
-  forkedFrom?: string;
-  dag: {
-    nodes: Array<{
-      id: string;
-      type: string;
-      config?: Record<string, unknown>;
-      inputMapping?: Record<string, string>;
-      retries?: number;
-    }>;
-    edges: Array<{ from: string; to: string; condition?: string }>;
-    onError?: string;
-  };
+  orgId: string;
+  featureSlug: string;
+  name: string;
+  displayName?: string | null;
+  description?: string | null;
+  signatureName: string;
+  signature: string;
+  category?: string;
+  channel?: string;
+  audienceType?: string;
+  tags?: string[];
+  status?: "active" | "deprecated";
+  upgradedTo?: string | null;
+  forkedFrom?: string | null;
+  createdForBrandId?: string | null;
+  humanId?: string | null;
+  campaignId?: string | null;
+  subrequestId?: string | null;
+  styleName?: string | null;
+  createdByUserId?: string | null;
+  createdByRunId?: string | null;
+  dag: DAG;
+  createdAt?: string;
+  updatedAt?: string;
   [key: string]: unknown;
 }
 
+export interface WorkflowMutationResponse extends WorkflowResponse {
+  /** What happened: 'updated' = in-place, 'forked' = new workflow created */
+  _action: "updated" | "forked";
+  /** Only present when _action is 'forked'. Name of the original workflow. */
+  _forkedFromName?: string;
+}
+
 export interface UpdateWorkflowResult {
-  workflow: WorkflowResponse;
+  workflow: WorkflowMutationResponse;
   /** "updated" = in-place 200, "forked" = new workflow 201 */
   outcome: "updated" | "forked";
 }
 
 export interface WorkflowConflictError {
+  error: string;
   existingWorkflowId: string;
   existingWorkflowName: string;
 }
@@ -56,7 +94,7 @@ export interface UpdateWorkflowBody {
   name?: string;
   description?: string;
   tags?: string[];
-  dag?: WorkflowResponse["dag"];
+  dag?: DAG;
 }
 
 /**
@@ -64,15 +102,15 @@ export interface UpdateWorkflowBody {
  * Gemini sometimes sends `config: null` or `inputMapping: null` instead
  * of omitting the field — workflow-service Zod schema rejects nulls.
  */
-function sanitizeDag(dag: WorkflowResponse["dag"]): WorkflowResponse["dag"] {
+function sanitizeDag(dag: DAG): DAG {
   return {
     ...dag,
     nodes: dag.nodes.map((node) => {
-      const clean: Record<string, unknown> = { id: node.id, type: node.type };
+      const clean: DAGNode = { id: node.id, type: node.type };
       if (node.config != null) clean.config = node.config;
       if (node.inputMapping != null) clean.inputMapping = node.inputMapping;
       if (node.retries != null) clean.retries = node.retries;
-      return clean as typeof node;
+      return clean;
     }),
   };
 }
@@ -104,8 +142,8 @@ export async function updateWorkflow(
     );
   }
 
-  const workflow = (await res.json()) as WorkflowResponse;
-  const outcome = res.status === 201 ? "forked" : "updated";
+  const workflow = (await res.json()) as WorkflowMutationResponse;
+  const outcome = workflow._action ?? (res.status === 201 ? "forked" : "updated");
   return { workflow, outcome };
 }
 

--- a/tests/unit/workflow-client.test.ts
+++ b/tests/unit/workflow-client.test.ts
@@ -56,7 +56,7 @@ describe("updateWorkflow", () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       status: 201,
-      json: () => Promise.resolve({ id: "wf-new", name: "sales-email-v2", forkedFrom: "wf-123", signatureName: "sales-email-v2" }),
+      json: () => Promise.resolve({ id: "wf-new", name: "sales-email-v2", forkedFrom: "wf-123", signatureName: "sales-email-v2", _action: "forked", _forkedFromName: "sales-email-v1" }),
     });
 
     const { updateWorkflow } = await loadModule();
@@ -70,6 +70,26 @@ describe("updateWorkflow", () => {
     expect(result.workflow.id).toBe("wf-new");
     expect(result.workflow.forkedFrom).toBe("wf-123");
     expect(result.workflow.signatureName).toBe("sales-email-v2");
+    expect(result.workflow._action).toBe("forked");
+    expect(result.workflow._forkedFromName).toBe("sales-email-v1");
+  });
+
+  it("uses _action from response body over status code", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ id: "wf-1", _action: "updated" }),
+    });
+
+    const { updateWorkflow } = await loadModule();
+    const result = await updateWorkflow(
+      "wf-1",
+      { description: "test" },
+      { orgId: "o", userId: "u", runId: "r" },
+    );
+
+    expect(result.outcome).toBe("updated");
+    expect(result.workflow._action).toBe("updated");
   });
 
   it("throws with existing workflow info on HTTP 409", async () => {
@@ -173,6 +193,43 @@ describe("updateWorkflow", () => {
     expect(sentBody.dag.nodes[1]).toEqual({ id: "step-2", type: "condition" });
     expect(sentBody.dag.nodes[2].config).toEqual({ path: "/send" });
     expect(sentBody.dag.nodes[2].inputMapping).toEqual({ "body.to": "$ref:step-1.output.email" });
+  });
+
+  it("preserves condition field on DAG edges when sending", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: "wf-1", _action: "updated" }),
+    });
+
+    const { updateWorkflow } = await loadModule();
+    await updateWorkflow(
+      "wf-1",
+      {
+        dag: {
+          nodes: [
+            { id: "check", type: "condition" },
+            { id: "yes-branch", type: "http.call", config: { path: "/yes" } },
+            { id: "no-branch", type: "http.call", config: { path: "/no" } },
+            { id: "always", type: "http.call", config: { path: "/done" } },
+          ],
+          edges: [
+            { from: "check", to: "yes-branch", condition: "results.check.found == true" },
+            { from: "check", to: "no-branch", condition: "results.check.found == false" },
+            { from: "check", to: "always" },
+            { from: "yes-branch", to: "always" },
+          ],
+        },
+      },
+      { orgId: "o", userId: "u", runId: "r" },
+    );
+
+    const sentBody = JSON.parse((fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
+    expect(sentBody.dag.edges).toEqual([
+      { from: "check", to: "yes-branch", condition: "results.check.found == true" },
+      { from: "check", to: "no-branch", condition: "results.check.found == false" },
+      { from: "check", to: "always" },
+      { from: "yes-branch", to: "always" },
+    ]);
   });
 
   it("throws when ADMIN_DISTRIBUTE_API_KEY is not set", async () => {


### PR DESCRIPTION
## Summary
- Aligned `WorkflowResponse`, `DAGNode`, `DAGEdge`, `DAG` types with the latest workflow-service OpenAPI spec
- Added `WorkflowMutationResponse` with `_action` and `_forkedFromName` fields (PRs #170/#171 upstream)
- `updateWorkflow()` now reads `_action` from response body instead of relying solely on HTTP status code
- Fork notification messages now include the original workflow name via `_forkedFromName`
- Verified that `condition` on DAG edges is NOT stripped by `sanitizeDag()` (only nodes are sanitized)

## Test plan
- [x] New test: `_action` and `_forkedFromName` are captured from response
- [x] New test: `_action` from body takes precedence over status code
- [x] New test: `condition` field on edges is preserved through sanitization
- [x] All existing tests pass (270 passed)
- [x] Build passes with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)