### PR TITLE
fix: strip markdown fences from JSON responses

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -269,7 +269,13 @@ app.post("/complete", requireAuth, async (req, res) => {
       try {
         response.json = JSON.parse(result.content);
       } catch {
-        // Model returned non-parsable content despite JSON mode — return raw content only
+        // LLM sometimes wraps JSON in markdown fences — strip and retry
+        const stripped = result.content.replace(/^```(?:json)?\s*\n?/i, "").replace(/\n?```\s*$/i, "");
+        try {
+          response.json = JSON.parse(stripped);
+        } catch {
+          // Model returned non-parsable content despite JSON mode — return raw content only
+        }
       }
     }
 

--- a/tests/unit/json-markdown-strip.test.ts
+++ b/tests/unit/json-markdown-strip.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * Mirrors the markdown-fence stripping logic in src/index.ts /complete handler.
+ * If JSON.parse fails on raw content, strip ```json fences and retry.
+ */
+function parseJsonWithFenceStrip(content: string): unknown | null {
+  try {
+    return JSON.parse(content);
+  } catch {
+    const stripped = content.replace(/^```(?:json)?\s*\n?/i, "").replace(/\n?```\s*$/i, "");
+    try {
+      return JSON.parse(stripped);
+    } catch {
+      return null;
+    }
+  }
+}
+
+describe("JSON markdown fence stripping", () => {
+  it("parses plain JSON without fences", () => {
+    const result = parseJsonWithFenceStrip('{"key": "value"}');
+    expect(result).toEqual({ key: "value" });
+  });
+
+  it("strips ```json fences and parses", () => {
+    const content = '```json\n{"key": "value"}\n```';
+    const result = parseJsonWithFenceStrip(content);
+    expect(result).toEqual({ key: "value" });
+  });
+
+  it("strips ``` fences without json tag", () => {
+    const content = '```\n{"key": "value"}\n```';
+    const result = parseJsonWithFenceStrip(content);
+    expect(result).toEqual({ key: "value" });
+  });
+
+  it("strips ```JSON fences (case-insensitive)", () => {
+    const content = '```JSON\n{"items": [1, 2, 3]}\n```';
+    const result = parseJsonWithFenceStrip(content);
+    expect(result).toEqual({ items: [1, 2, 3] });
+  });
+
+  it("handles array responses wrapped in fences", () => {
+    const content = '```json\n[{"id": 1}, {"id": 2}]\n```';
+    const result = parseJsonWithFenceStrip(content);
+    expect(result).toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  it("returns null for truly unparsable content", () => {
+    const result = parseJsonWithFenceStrip("This is not JSON at all");
+    expect(result).toBeNull();
+  });
+
+  it("returns null for fenced non-JSON content", () => {
+    const content = '```json\nnot actually json\n```';
+    const result = parseJsonWithFenceStrip(content);
+    expect(result).toBeNull();
+  });
+
+  it("handles fences with no trailing newline", () => {
+    const content = '```json\n{"ok": true}```';
+    const result = parseJsonWithFenceStrip(content);
+    expect(result).toEqual({ ok: true });
+  });
+});


### PR DESCRIPTION
## Summary
- When `responseFormat: "json"` is set, the LLM sometimes wraps valid JSON in markdown code fences (` ```json ... ``` `), causing `JSON.parse` to fail and returning `json: null` in the response
- This caused intermittent 502s in outlets-service and other downstream consumers
- Now strips markdown fences and retries parsing before falling back to `json: null`

## Test plan
- [x] Unit tests covering: plain JSON, `json` fenced, bare fenced, case-insensitive, arrays, unparsable content, no trailing newline
- [x] All 277 existing tests still pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)