### PR TITLE
feat: enrich LLM prompts with campaign context

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,14 @@ Unlike POST /chat, this endpoint is **stateless** (no sessions), accepts an **in
 
 Error responses: 400 (validation), 401 (auth), 402 (insufficient credits), 502 (upstream failure).
 
+## Campaign Context Enrichment
+
+When the `x-campaign-id` header is present, both `/chat` and `/complete` automatically fetch the campaign's `featureInputs` from campaign-service and inject them into the system prompt. This ensures every LLM call is informed by the user's campaign-specific inputs (editorial angle, target geography, audience type, etc.).
+
+- Campaign data is fetched via `GET /campaign/campaigns/{id}` through api-service
+- Results are cached in-memory by `campaignId` (featureInputs are immutable for the lifetime of a campaign)
+- If the fetch fails, the LLM call proceeds without campaign context (non-blocking)
+
 ## SSE Protocol
 
 `POST /chat` with headers `Content-Type: application/json`, `x-api-key`, `x-org-id`, `x-user-id`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ import {
   checkProviderRequirements,
 } from "./lib/key-client.js";
 import { authorizeCredits } from "./lib/billing-client.js";
+import { getCampaignFeatureInputs } from "./lib/campaign-client.js";
 import { ChatRequestSchema, CompleteRequestSchema, AppConfigRequestSchema, PlatformConfigRequestSchema } from "./schemas.js";
 import { requireAuth, requireInternalAuth, type AuthLocals } from "./middleware/auth.js";
 import type { ButtonRecord, ToolCallRecord } from "./db/schema.js";
@@ -235,15 +236,32 @@ app.post("/complete", requireAuth, async (req, res) => {
     });
   }
 
+  // Fetch campaign context if campaignId is present (Convention 2)
+  let campaignFeatureInputs: Record<string, unknown> | null = null;
+  if (workflowTracking.campaignId) {
+    try {
+      campaignFeatureInputs = await getCampaignFeatureInputs(
+        workflowTracking.campaignId,
+        { orgId, userId, runId: callerRunId, trackingHeaders },
+      );
+    } catch (err) {
+      console.warn(`[complete] Failed to fetch campaign context for campaign="${workflowTracking.campaignId}":`, err);
+    }
+  }
+
   let completeFailed = false;
   let totalPromptTokens = 0;
   let totalOutputTokens = 0;
   const claudeModel = MODEL;
   try {
     // Build prompt — for JSON mode, prepend instruction to system prompt
-    const effectiveSystemPrompt = responseFormat === "json"
-      ? `${systemPrompt}\n\nIMPORTANT: You MUST respond with valid JSON only. No markdown, no code fences, no extra text — just a single JSON object or array.`
-      : systemPrompt;
+    let effectiveSystemPrompt = systemPrompt;
+    if (campaignFeatureInputs && Object.keys(campaignFeatureInputs).length > 0) {
+      effectiveSystemPrompt = buildSystemPrompt(systemPrompt, undefined, campaignFeatureInputs);
+    }
+    if (responseFormat === "json") {
+      effectiveSystemPrompt += `\n\nIMPORTANT: You MUST respond with valid JSON only. No markdown, no code fences, no extra text — just a single JSON object or array.`;
+    }
 
     const claude = createAnthropicClient({ apiKey: resolvedKey.key, systemPrompt: effectiveSystemPrompt });
 
@@ -395,6 +413,19 @@ app.post("/chat", requireAuth, async (req, res) => {
     }
   }
 
+  // Fetch campaign context if campaignId is present (Convention 2)
+  let campaignFeatureInputs: Record<string, unknown> | null = null;
+  if (workflowTracking.campaignId) {
+    try {
+      campaignFeatureInputs = await getCampaignFeatureInputs(
+        workflowTracking.campaignId,
+        { orgId, userId, runId: callerRunId, trackingHeaders },
+      );
+    } catch (err) {
+      console.warn(`[chat] Failed to fetch campaign context for campaign="${workflowTracking.campaignId}":`, err);
+    }
+  }
+
   // SSE headers — disable proxy buffering so tokens stream immediately
   res.setHeader("Content-Type", "text/event-stream");
   res.setHeader("Cache-Control", "no-cache");
@@ -402,8 +433,8 @@ app.post("/chat", requireAuth, async (req, res) => {
   res.setHeader("X-Accel-Buffering", "no");
   res.flushHeaders();
 
-  // Build system prompt with optional context
-  const systemPrompt = buildSystemPrompt(appConfig.systemPrompt, context);
+  // Build system prompt with optional context and campaign feature inputs
+  const systemPrompt = buildSystemPrompt(appConfig.systemPrompt, context, campaignFeatureInputs);
   const claude = createAnthropicClient({ apiKey: resolvedKey.key, systemPrompt });
 
   let runId: string | null = null;

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -823,21 +823,32 @@ export interface UsageMetadata {
 export function buildSystemPrompt(
   basePrompt: string,
   context?: Record<string, unknown>,
+  campaignContext?: Record<string, unknown> | null,
 ): string {
-  if (!context || Object.keys(context).length === 0) return basePrompt;
+  let prompt = basePrompt;
 
-  const contextKeys = Object.keys(context);
-  const contextInstructions = [
-    `\n\n---\n## Additional Context (this request only)`,
-    JSON.stringify(context, null, 2),
-    `\n## IMPORTANT: Context Usage Rules`,
-    `The values above (${contextKeys.join(", ")}) are already known — use them directly when calling tools.`,
-    `Do NOT call request_user_input to ask for any value that is already present in this context.`,
-    `For example, if workflowId is in context and you need to update or validate the workflow, pass it directly to the tool.`,
-    `Only use request_user_input when you genuinely need information that is NOT available in context or conversation history.`,
-  ].join("\n");
+  if (campaignContext && Object.keys(campaignContext).length > 0) {
+    prompt += [
+      `\n\n---\n## Campaign Context`,
+      `The user launched this campaign with the following inputs. Use them to inform your responses, suggestions, and any content you generate.`,
+      JSON.stringify(campaignContext, null, 2),
+    ].join("\n");
+  }
 
-  return `${basePrompt}${contextInstructions}`;
+  if (context && Object.keys(context).length > 0) {
+    const contextKeys = Object.keys(context);
+    prompt += [
+      `\n\n---\n## Additional Context (this request only)`,
+      JSON.stringify(context, null, 2),
+      `\n## IMPORTANT: Context Usage Rules`,
+      `The values above (${contextKeys.join(", ")}) are already known — use them directly when calling tools.`,
+      `Do NOT call request_user_input to ask for any value that is already present in this context.`,
+      `For example, if workflowId is in context and you need to update or validate the workflow, pass it directly to the tool.`,
+      `Only use request_user_input when you genuinely need information that is NOT available in context or conversation history.`,
+    ].join("\n");
+  }
+
+  return prompt;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/campaign-client.ts
+++ b/src/lib/campaign-client.ts
@@ -1,0 +1,55 @@
+import { apiServiceFetch, type ApiCallParams } from "./api-client.js";
+
+export interface CampaignFeatureInputs {
+  [key: string]: unknown;
+}
+
+interface CampaignResponse {
+  campaign: {
+    id: string;
+    featureInputs: CampaignFeatureInputs | null;
+  };
+}
+
+// In-memory cache: featureInputs never change during a campaign's lifetime
+const featureInputsCache = new Map<string, CampaignFeatureInputs | null>();
+
+/**
+ * Fetch the featureInputs for a campaign. Results are cached by campaignId
+ * because featureInputs are immutable for the lifetime of a campaign.
+ *
+ * Returns null if the campaign has no featureInputs.
+ * Throws on network/server errors.
+ */
+export async function getCampaignFeatureInputs(
+  campaignId: string,
+  params: ApiCallParams,
+): Promise<CampaignFeatureInputs | null> {
+  const cached = featureInputsCache.get(campaignId);
+  if (cached !== undefined) return cached;
+
+  const res = await apiServiceFetch(
+    `/campaign/campaigns/${campaignId}`,
+    "GET",
+    params,
+  );
+
+  if (!res.ok) {
+    // Non-fatal: log and return null so the LLM call can proceed without context
+    console.warn(
+      `[campaign-client] Failed to fetch campaign "${campaignId}": ${res.status} ${res.statusText}`,
+    );
+    return null;
+  }
+
+  const data = (await res.json()) as CampaignResponse;
+  const featureInputs = data.campaign.featureInputs ?? null;
+
+  featureInputsCache.set(campaignId, featureInputs);
+  return featureInputs;
+}
+
+/** Clear the cache (for testing). */
+export function clearCampaignCache(): void {
+  featureInputsCache.clear();
+}

--- a/tests/unit/anthropic.test.ts
+++ b/tests/unit/anthropic.test.ts
@@ -388,6 +388,42 @@ describe("buildSystemPrompt", () => {
     expect(result).toContain("workflowId");
     expect(result).toContain("use them directly when calling tools");
   });
+
+  it("appends campaign context section when provided", () => {
+    const result = buildSystemPrompt("Base.", undefined, {
+      angle: "sustainability",
+      geography: "US",
+    });
+    expect(result).toContain("## Campaign Context");
+    expect(result).toContain("sustainability");
+    expect(result).toContain("US");
+  });
+
+  it("skips campaign context when null", () => {
+    const result = buildSystemPrompt("Base.", undefined, null);
+    expect(result).toBe("Base.");
+  });
+
+  it("skips campaign context when empty object", () => {
+    const result = buildSystemPrompt("Base.", undefined, {});
+    expect(result).toBe("Base.");
+  });
+
+  it("includes both campaign context and additional context", () => {
+    const result = buildSystemPrompt(
+      "Base.",
+      { workflowId: "wf-1" },
+      { angle: "growth" },
+    );
+    expect(result).toContain("## Campaign Context");
+    expect(result).toContain("growth");
+    expect(result).toContain("## Additional Context");
+    expect(result).toContain("wf-1");
+    // Campaign context should come before additional context
+    const campaignIdx = result.indexOf("## Campaign Context");
+    const additionalIdx = result.indexOf("## Additional Context");
+    expect(campaignIdx).toBeLessThan(additionalIdx);
+  });
 });
 
 describe("REQUEST_USER_INPUT_TOOL", () => {

--- a/tests/unit/campaign-client.test.ts
+++ b/tests/unit/campaign-client.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  process.env.API_SERVICE_URL = "https://api.test.local";
+  process.env.ADMIN_DISTRIBUTE_API_KEY = "test-admin-key";
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.restoreAllMocks();
+});
+
+async function loadModule() {
+  vi.resetModules();
+  return import("../../src/lib/campaign-client.js");
+}
+
+const params = {
+  orgId: "org-uuid-123",
+  userId: "user-uuid-456",
+  runId: "run-uuid-789",
+};
+
+describe("getCampaignFeatureInputs", () => {
+  it("fetches campaign and returns featureInputs", async () => {
+    const featureInputs = { angle: "sustainability", geography: "US" };
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ campaign: { id: "c1", featureInputs } }),
+    });
+
+    const { getCampaignFeatureInputs } = await loadModule();
+    const result = await getCampaignFeatureInputs("c1", params);
+
+    expect(result).toEqual(featureInputs);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.test.local/campaign/campaigns/c1",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("returns null when featureInputs is null in response", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ campaign: { id: "c2", featureInputs: null } }),
+    });
+
+    const { getCampaignFeatureInputs } = await loadModule();
+    const result = await getCampaignFeatureInputs("c2", params);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null on non-ok response", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+    });
+
+    const { getCampaignFeatureInputs } = await loadModule();
+    const result = await getCampaignFeatureInputs("missing", params);
+
+    expect(result).toBeNull();
+  });
+
+  it("caches results by campaignId", async () => {
+    const featureInputs = { angle: "growth" };
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ campaign: { id: "c3", featureInputs } }),
+    });
+
+    const { getCampaignFeatureInputs } = await loadModule();
+
+    const result1 = await getCampaignFeatureInputs("c3", params);
+    const result2 = await getCampaignFeatureInputs("c3", params);
+
+    expect(result1).toEqual(featureInputs);
+    expect(result2).toEqual(featureInputs);
+    // Only one fetch call — second was served from cache
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches null featureInputs too", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ campaign: { id: "c4", featureInputs: null } }),
+    });
+
+    const { getCampaignFeatureInputs } = await loadModule();
+
+    await getCampaignFeatureInputs("c4", params);
+    await getCampaignFeatureInputs("c4", params);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards tracking headers", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ campaign: { id: "c5", featureInputs: {} } }),
+    });
+
+    const { getCampaignFeatureInputs } = await loadModule();
+    await getCampaignFeatureInputs("c5", {
+      ...params,
+      trackingHeaders: { "x-campaign-id": "c5", "x-brand-id": "b1" },
+    });
+
+    const callHeaders = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].headers;
+    expect(callHeaders["x-campaign-id"]).toBe("c5");
+    expect(callHeaders["x-brand-id"]).toBe("b1");
+  });
+});
+
+describe("clearCampaignCache", () => {
+  it("clears cache so next call fetches again", async () => {
+    const featureInputs = { angle: "test" };
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ campaign: { id: "c6", featureInputs } }),
+    });
+
+    const { getCampaignFeatureInputs, clearCampaignCache } = await loadModule();
+
+    await getCampaignFeatureInputs("c6", params);
+    clearCampaignCache();
+    await getCampaignFeatureInputs("c6", params);
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- When `x-campaign-id` header is present, both `/chat` and `/complete` now fetch the campaign's `featureInputs` from campaign-service and inject them into the system prompt
- New `campaign-client.ts` with in-memory caching by campaignId (featureInputs are immutable per campaign)
- Non-blocking: if campaign fetch fails, LLM call proceeds without campaign context

## Test plan
- [x] Unit tests for `campaign-client` (7 tests): fetch, null inputs, error handling, caching, header forwarding
- [x] Unit tests for `buildSystemPrompt` campaign context (4 new tests): injection, null, empty, combined with additional context
- [x] All 281 existing tests pass
- [x] TypeScript build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)