### PR TITLE
fix: correct campaign-client API route (404 fix)

### DIFF
--- a/src/lib/campaign-client.ts
+++ b/src/lib/campaign-client.ts
@@ -29,7 +29,7 @@ export async function getCampaignFeatureInputs(
   if (cached !== undefined) return cached;
 
   const res = await apiServiceFetch(
-    `/campaign/campaigns/${campaignId}`,
+    `/v1/campaigns/${campaignId}`,
     "GET",
     params,
   );

--- a/tests/unit/campaign-client.test.ts
+++ b/tests/unit/campaign-client.test.ts
@@ -37,9 +37,23 @@ describe("getCampaignFeatureInputs", () => {
 
     expect(result).toEqual(featureInputs);
     expect(fetch).toHaveBeenCalledWith(
-      "https://api.test.local/campaign/campaigns/c1",
+      "https://api.test.local/v1/campaigns/c1",
       expect.objectContaining({ method: "GET" }),
     );
+  });
+
+  it("calls the correct api-service v1 route (regression: was /campaign/campaigns/)", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ campaign: { id: "reg1", featureInputs: { x: 1 } } }),
+    });
+
+    const { getCampaignFeatureInputs } = await loadModule();
+    await getCampaignFeatureInputs("reg1", params);
+
+    const url = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(url).toBe("https://api.test.local/v1/campaigns/reg1");
+    expect(url).not.toContain("/campaign/campaigns/");
   });
 
   it("returns null when featureInputs is null in response", async () => {


### PR DESCRIPTION
## Summary
- **Bug**: `campaign-client.ts` was calling `/campaign/campaigns/{id}` on api-service, which doesn't exist → 404
- **Fix**: Changed to the correct route `/v1/campaigns/{id}`
- Added regression test verifying the URL path

## Test plan
- [x] Existing campaign-client tests updated and passing
- [x] New regression test ensures the correct `/v1/campaigns/` path is used
- [x] Full test suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)