### PR TITLE
feat: add optional model field to POST /complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ Request body:
   "systemPrompt": "You are a PR research assistant...",
   "responseFormat": "json",
   "temperature": 0.3,
-  "maxTokens": 2000
+  "maxTokens": 2000,
+  "model": "claude-haiku-4-5"
 }
 ```
 
@@ -102,6 +103,7 @@ Request body:
 - `responseFormat` (optional) — set to `"json"` to instruct the model to return valid JSON. The parsed result appears in the `json` field.
 - `temperature` (optional) — sampling temperature, 0–2 (default: model default)
 - `maxTokens` (optional) — max output tokens, 1–64000 (default: 16000)
+- `model` (optional) — Anthropic model to use: `claude-sonnet-4-6` (default) or `claude-haiku-4-5`. Use Haiku for simpler tasks (extraction, classification) to reduce cost.
 
 Response:
 ```json

--- a/openapi.json
+++ b/openapi.json
@@ -466,6 +466,15 @@
             "maximum": 64000,
             "description": "Maximum tokens in the response (default: 16000)",
             "example": 2000
+          },
+          "model": {
+            "type": "string",
+            "enum": [
+              "claude-sonnet-4-6",
+              "claude-haiku-4-5"
+            ],
+            "description": "Anthropic model to use. Defaults to claude-sonnet-4-6. Use claude-haiku-4-5 for simpler tasks (extraction, classification) to reduce cost.",
+            "example": "claude-haiku-4-5"
           }
         },
         "required": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import {
   FEATURE_CREATOR_TOOLS,
   MODEL,
   COST_PREFIX,
+  costPrefixForModel,
 } from "./lib/anthropic.js";
 import {
   updateWorkflow,
@@ -165,7 +166,7 @@ app.post("/complete", requireAuth, async (req, res) => {
       .json({ error: "Invalid request", details: parsed.error.flatten() });
   }
 
-  const { message, systemPrompt, responseFormat, temperature, maxTokens } = parsed.data;
+  const { message, systemPrompt, responseFormat, temperature, maxTokens, model: requestedModel } = parsed.data;
 
   // Resolve Anthropic API key per-request
   let resolvedKey: ResolvedKey;
@@ -185,6 +186,10 @@ app.post("/complete", requireAuth, async (req, res) => {
     });
   }
 
+  // Resolve model and its cost prefix
+  const effectiveModel = requestedModel ?? MODEL;
+  const effectiveCostPrefix = costPrefixForModel(effectiveModel);
+
   // Credit authorization for platform keys
   if (resolvedKey.keySource === "platform") {
     const estimatedInputTokens = Math.max(Math.ceil(message.length / 4), 500);
@@ -192,10 +197,10 @@ app.post("/complete", requireAuth, async (req, res) => {
     try {
       const authResult = await authorizeCredits({
         items: [
-          { costName: `${COST_PREFIX}-tokens-input`, quantity: estimatedInputTokens },
-          { costName: `${COST_PREFIX}-tokens-output`, quantity: estimatedOutputTokens },
+          { costName: `${effectiveCostPrefix}-tokens-input`, quantity: estimatedInputTokens },
+          { costName: `${effectiveCostPrefix}-tokens-output`, quantity: estimatedOutputTokens },
         ],
-        description: `complete — ${MODEL}`,
+        description: `complete — ${effectiveModel}`,
         orgId,
         userId,
         runId: callerRunId,
@@ -252,7 +257,6 @@ app.post("/complete", requireAuth, async (req, res) => {
   let completeFailed = false;
   let totalPromptTokens = 0;
   let totalOutputTokens = 0;
-  const claudeModel = MODEL;
   try {
     // Build prompt — for JSON mode, prepend instruction to system prompt
     let effectiveSystemPrompt = systemPrompt;
@@ -269,6 +273,7 @@ app.post("/complete", requireAuth, async (req, res) => {
       responseFormat,
       temperature,
       maxTokens,
+      model: effectiveModel,
     });
 
     totalPromptTokens = result.tokensInput;
@@ -279,7 +284,7 @@ app.post("/complete", requireAuth, async (req, res) => {
       content: result.content,
       tokensInput: result.tokensInput,
       tokensOutput: result.tokensOutput,
-      model: claude.model,
+      model: result.model,
     };
 
     // Parse JSON if requested
@@ -311,10 +316,10 @@ app.post("/complete", requireAuth, async (req, res) => {
         resolvedKey.keySource === "org" ? "org" : "platform";
       const costItems = [
         ...(totalPromptTokens > 0
-          ? [{ costName: `${COST_PREFIX}-tokens-input`, quantity: totalPromptTokens, costSource }]
+          ? [{ costName: `${effectiveCostPrefix}-tokens-input`, quantity: totalPromptTokens, costSource }]
           : []),
         ...(totalOutputTokens > 0
-          ? [{ costName: `${COST_PREFIX}-tokens-output`, quantity: totalOutputTokens, costSource }]
+          ? [{ costName: `${effectiveCostPrefix}-tokens-output`, quantity: totalOutputTokens, costSource }]
           : []),
       ];
       const runIdentity = { orgId, userId, runId };

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -5,6 +5,20 @@ export const MODEL = "claude-sonnet-4-6";
 export const COST_PREFIX = "anthropic-sonnet-4.6";
 const MAX_TOKENS = 16_000;
 
+/**
+ * Supported models and their costs-service prefixes.
+ * Keys are Anthropic API model IDs; values are cost-name prefixes.
+ */
+export const SUPPORTED_MODELS: Record<string, string> = {
+  "claude-sonnet-4-6": "anthropic-sonnet-4.6",
+  "claude-haiku-4-5": "anthropic-haiku-4.5",
+};
+
+/** Resolve the cost prefix for a given model ID (falls back to default). */
+export function costPrefixForModel(model: string): string {
+  return SUPPORTED_MODELS[model] ?? COST_PREFIX;
+}
+
 // ---------------------------------------------------------------------------
 // Tool definitions (Anthropic JSON Schema format)
 // ---------------------------------------------------------------------------
@@ -933,14 +947,17 @@ export function createAnthropicClient({ apiKey, systemPrompt }: AnthropicOptions
         responseFormat?: "json";
         temperature?: number;
         maxTokens?: number;
+        model?: string;
       },
     ): Promise<{
       content: string;
       tokensInput: number;
       tokensOutput: number;
+      model: string;
     }> {
+      const effectiveModel = options?.model ?? MODEL;
       const params: Anthropic.MessageCreateParamsNonStreaming = {
-        model: MODEL,
+        model: effectiveModel,
         max_tokens: options?.maxTokens ?? MAX_TOKENS,
         system: systemPrompt,
         messages: [{ role: "user", content: message }],
@@ -959,6 +976,7 @@ export function createAnthropicClient({ apiKey, systemPrompt }: AnthropicOptions
         content,
         tokensInput: response.usage.input_tokens,
         tokensOutput: response.usage.output_tokens,
+        model: effectiveModel,
       };
     },
   };

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -240,6 +240,10 @@ export const CompleteRequestSchema = z
       description: "Maximum tokens in the response (default: 16000)",
       example: 2000,
     }),
+    model: z.enum(["claude-sonnet-4-6", "claude-haiku-4-5"]).optional().openapi({
+      description: "Anthropic model to use. Defaults to claude-sonnet-4-6. Use claude-haiku-4-5 for simpler tasks (extraction, classification) to reduce cost.",
+      example: "claude-haiku-4-5",
+    }),
   })
   .openapi("CompleteRequest");
 

--- a/tests/unit/anthropic.test.ts
+++ b/tests/unit/anthropic.test.ts
@@ -31,6 +31,8 @@ import {
   buildSystemPrompt,
   MODEL,
   COST_PREFIX,
+  SUPPORTED_MODELS,
+  costPrefixForModel,
   REQUEST_USER_INPUT_TOOL,
   UPDATE_WORKFLOW_TOOL,
   VALIDATE_WORKFLOW_TOOL,
@@ -59,6 +61,28 @@ describe("COST_PREFIX", () => {
     expect(COST_PREFIX).not.toBe(MODEL);
     expect(COST_PREFIX).not.toContain("claude-");
     expect(COST_PREFIX).toMatch(/^anthropic-/);
+  });
+});
+
+describe("SUPPORTED_MODELS", () => {
+  it("maps all supported model IDs to cost prefixes", () => {
+    expect(SUPPORTED_MODELS["claude-sonnet-4-6"]).toBe("anthropic-sonnet-4.6");
+    expect(SUPPORTED_MODELS["claude-haiku-4-5"]).toBe("anthropic-haiku-4.5");
+  });
+
+  it("includes the default model", () => {
+    expect(SUPPORTED_MODELS[MODEL]).toBe(COST_PREFIX);
+  });
+});
+
+describe("costPrefixForModel", () => {
+  it("returns correct prefix for known models", () => {
+    expect(costPrefixForModel("claude-sonnet-4-6")).toBe("anthropic-sonnet-4.6");
+    expect(costPrefixForModel("claude-haiku-4-5")).toBe("anthropic-haiku-4.5");
+  });
+
+  it("falls back to default COST_PREFIX for unknown models", () => {
+    expect(costPrefixForModel("unknown-model")).toBe(COST_PREFIX);
   });
 });
 

--- a/tests/unit/complete.test.ts
+++ b/tests/unit/complete.test.ts
@@ -106,6 +106,50 @@ describe("CompleteRequestSchema", () => {
     expect(result.success).toBe(false);
   });
 
+  it("accepts valid model override", () => {
+    const result = CompleteRequestSchema.safeParse({
+      message: "Extract metadata",
+      systemPrompt: "You are a metadata extractor.",
+      model: "claude-haiku-4-5",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.model).toBe("claude-haiku-4-5");
+    }
+  });
+
+  it("accepts default model explicitly", () => {
+    const result = CompleteRequestSchema.safeParse({
+      message: "Hello",
+      systemPrompt: "You are helpful.",
+      model: "claude-sonnet-4-6",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.model).toBe("claude-sonnet-4-6");
+    }
+  });
+
+  it("rejects unsupported model", () => {
+    const result = CompleteRequestSchema.safeParse({
+      message: "Hello",
+      systemPrompt: "You are helpful.",
+      model: "gpt-4o",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("defaults model to undefined when omitted", () => {
+    const result = CompleteRequestSchema.safeParse({
+      message: "Hello",
+      systemPrompt: "You are helpful.",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.model).toBeUndefined();
+    }
+  });
+
   it("accepts temperature at boundaries (0 and 2)", () => {
     const atZero = CompleteRequestSchema.safeParse({
       message: "Hello",


### PR DESCRIPTION
## Summary
- Adds an optional `model` field to `POST /complete` request body, allowing callers to choose between `claude-sonnet-4-6` (default) and `claude-haiku-4-5`
- Cost tracking uses the correct cost prefix for the selected model (e.g. `anthropic-haiku-4.5-tokens-input` for Haiku)
- Response `model` field reflects the actually-used model

## Test plan
- [x] Schema validation tests: accepts valid models, rejects unsupported models, defaults to undefined when omitted
- [x] `SUPPORTED_MODELS` mapping tests
- [x] `costPrefixForModel` tests (known models + fallback)
- [x] All 296 existing tests still pass (1 pre-existing flaky failure in graceful-shutdown unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)