### PR TITLE
fix: accept sessionId: null so reset-chat preserves context

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Request body:
 ```
 
 - `message` (required) — the user's chat message
-- `sessionId` (optional) — UUID of an existing session to continue. **Omit to start a new conversation** — the service creates the session and returns its ID in the first SSE event (`{"sessionId":"<uuid>"}`). Store that ID and pass it in subsequent requests. If a provided `sessionId` does not exist or belongs to a different org, the stream returns `"Session not found."` and closes. **Do not generate your own UUID** — always use the one returned by the service.
+- `sessionId` (optional, nullable) — UUID of an existing session to continue. **Omit or pass `null` to start a new conversation** — the service creates the session and returns its ID in the first SSE event (`{"sessionId":"<uuid>"}`). Store that ID and pass it in subsequent requests. If a provided `sessionId` does not exist or belongs to a different org, the stream returns `"Session not found."` and closes. **Do not generate your own UUID** — always use the one returned by the service.
 - `context` (optional) — free-form JSON injected into the system prompt for this request only (not stored)
 
 The response is a stream of SSE events in this order:

--- a/openapi.json
+++ b/openapi.json
@@ -493,6 +493,7 @@
           },
           "sessionId": {
             "type": "string",
+            "nullable": true,
             "format": "uuid",
             "description": "UUID of an existing session to continue. Omit to create a new session. When omitted, the service creates a new session and returns its ID in the first SSE event ({\"sessionId\":\"<uuid>\"}). Use that ID in subsequent requests to continue the conversation. If a sessionId is provided but does not exist or belongs to a different org, the stream returns a \"Session not found.\" error and closes.",
             "example": "550e8400-e29b-41d4-a716-446655440000"

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -345,7 +345,7 @@ export const ChatRequestSchema = z
       description: "The user's chat message",
       example: "What campaigns are performing best this week?",
     }),
-    sessionId: z.string().uuid().optional().openapi({
+    sessionId: z.string().uuid().nullish().openapi({
       description:
         "UUID of an existing session to continue. Omit to create a new session. " +
         "When omitted, the service creates a new session and returns its ID in the first SSE event " +

--- a/tests/unit/schemas.test.ts
+++ b/tests/unit/schemas.test.ts
@@ -46,6 +46,22 @@ describe("ChatRequestSchema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts sessionId: null (reset chat sends null)", () => {
+    const result = ChatRequestSchema.safeParse({
+      message: "Hello",
+      sessionId: null,
+      context: { type: "workflow-viewer", workflowId: "wf-123" },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.sessionId).toBeNull();
+      expect(result.data.context).toEqual({
+        type: "workflow-viewer",
+        workflowId: "wf-123",
+      });
+    }
+  });
+
   it("rejects non-uuid sessionId", () => {
     const result = ChatRequestSchema.safeParse({
       message: "Hello",


### PR DESCRIPTION
## Summary
- The dashboard sends `sessionId: null` after "Reset Chat", but the Zod schema only accepted `string | undefined` (`.optional()`). This caused the entire request to fail validation (400) before context was ever read, so the LLM appeared to respond as a generic assistant without workflow awareness.
- Changed `sessionId` from `.optional()` to `.nullish()` so `null` is treated the same as omitting the field — a new session is created and the `context` payload is properly injected into the system prompt.

## Test plan
- [x] Added regression test: `ChatRequestSchema` accepts `sessionId: null` with context payload
- [x] All 298 unit tests pass
- [x] Build + OpenAPI regeneration succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)