### PR TITLE
refactor: rename workflow-name to workflow-slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ All endpoints (except `/health` and `/openapi.json`) require these headers:
 | `x-run-id` | Caller's run ID — used as `parentRunId` when creating this service's own run in runs-service |
 | `x-campaign-id` | _(optional)_ Campaign ID — injected automatically by workflow-service |
 | `x-brand-id` | _(optional)_ Brand ID — injected automatically by workflow-service |
-| `x-workflow-name` | _(optional)_ Workflow name — injected automatically by workflow-service |
+| `x-workflow-slug` | _(optional)_ Workflow slug — injected automatically by workflow-service |
 | `x-feature-slug` | _(optional)_ Feature slug — propagated through the entire service chain |
 
 ## App Config Registration
@@ -226,7 +226,7 @@ When `context.type` is `"feature-creator"`, the standard workflow tools above ar
 | `get_feature` | Gets full feature details by slug via `GET /features/:slug`. |
 | `get_feature_inputs` | Gets input definitions only via `GET /features/:slug/inputs`. Lighter than `get_feature`. |
 | `prefill_feature` | Pre-fills feature inputs from brand data via `POST /features/:slug/prefill`. Returns a map of input key → suggested text value. |
-| `get_feature_stats` | Gets computed stats via `GET /features/:slug/stats`. Supports `groupBy` (workflowName, brandId, campaignId) and filter params. Returns system stats (cost, runs, campaigns) and per-output metrics. |
+| `get_feature_stats` | Gets computed stats via `GET /features/:slug/stats`. Supports `groupBy` (workflowSlug, brandId, campaignId) and filter params. Returns system stats (cost, runs, campaigns) and per-output metrics. |
 
 ### 5. Input Request (optional)
 When the AI genuinely needs information it does not have, it emits an input request:
@@ -309,7 +309,7 @@ Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token st
 Uses PostgreSQL via Drizzle ORM. Three tables:
 
 - **sessions** — conversation sessions scoped by `orgId` and `userId`
-- **messages** — chat messages with role, content, optional `toolCalls`, `buttons`, `contentBlocks` JSONB (stores full Anthropic content blocks for context management), `runId` linking to RunsService, and optional `campaign_id`, `brand_id`, `workflow_name`, `feature_slug` for workflow tracking
+- **messages** — chat messages with role, content, optional `toolCalls`, `buttons`, `contentBlocks` JSONB (stores full Anthropic content blocks for context management), `runId` linking to RunsService, and optional `campaign_id`, `brand_id`, `workflow_slug`, `feature_slug` for workflow tracking
 - **app_configs** — per-org configuration (system prompt) with unique constraint on `orgId`
 - **platform_configs** — global platform-wide chat configuration (fallback when no per-org config exists)
 

--- a/drizzle/0009_rename_workflow_name_to_slug.sql
+++ b/drizzle/0009_rename_workflow_name_to_slug.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "messages" RENAME COLUMN "workflow_name" TO "workflow_slug";

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,286 @@
+{
+  "id": "a1b2c3d4-0009-4000-8000-000000000009",
+  "prevId": "478b9077-097c-4bc3-8bf0-d2e8b3b085c4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_configs": {
+      "name": "app_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_configs_org_id_unique": {
+          "name": "app_configs_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_blocks": {
+          "name": "content_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buttons": {
+          "name": "buttons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_slug": {
+          "name": "workflow_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_slug": {
+          "name": "feature_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platform_configs": {
+      "name": "platform_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "platform_configs_key_unique": {
+          "name": "platform_configs_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1774318699055,
       "tag": "0008_sparkling_the_twelve",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1774886400000,
+      "tag": "0009_rename_workflow_name_to_slug",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -647,11 +647,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name — injected automatically by workflow-service"
+              "description": "Workflow slug — injected automatically by workflow-service"
             },
             "required": false,
-            "description": "Workflow name — injected automatically by workflow-service",
-            "name": "x-workflow-name",
+            "description": "Workflow slug — injected automatically by workflow-service",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {
@@ -842,11 +842,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name — injected automatically by workflow-service"
+              "description": "Workflow slug — injected automatically by workflow-service"
             },
             "required": false,
-            "description": "Workflow name — injected automatically by workflow-service",
-            "name": "x-workflow-name",
+            "description": "Workflow slug — injected automatically by workflow-service",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {
@@ -995,11 +995,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name — injected automatically by workflow-service"
+              "description": "Workflow slug — injected automatically by workflow-service"
             },
             "required": false,
-            "description": "Workflow name — injected automatically by workflow-service",
-            "name": "x-workflow-name",
+            "description": "Workflow slug — injected automatically by workflow-service",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -22,7 +22,7 @@ export const messages = pgTable("messages", {
   runId: uuid("run_id"),
   campaignId: text("campaign_id"),
   brandId: text("brand_id"),
-  workflowName: text("workflow_name"),
+  workflowSlug: text("workflow_slug"),
   featureSlug: text("feature_slug"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,7 +156,7 @@ app.post("/complete", requireAuth, async (req, res) => {
   const trackingHeaders: Record<string, string> = {};
   if (workflowTracking.campaignId) trackingHeaders["x-campaign-id"] = workflowTracking.campaignId;
   if (workflowTracking.brandId) trackingHeaders["x-brand-id"] = workflowTracking.brandId;
-  if (workflowTracking.workflowName) trackingHeaders["x-workflow-name"] = workflowTracking.workflowName;
+  if (workflowTracking.workflowSlug) trackingHeaders["x-workflow-slug"] = workflowTracking.workflowSlug;
   if (workflowTracking.featureSlug) trackingHeaders["x-feature-slug"] = workflowTracking.featureSlug;
 
   const parsed = CompleteRequestSchema.safeParse(req.body);
@@ -340,7 +340,7 @@ app.post("/chat", requireAuth, async (req, res) => {
   const trackingHeaders: Record<string, string> = {};
   if (workflowTracking.campaignId) trackingHeaders["x-campaign-id"] = workflowTracking.campaignId;
   if (workflowTracking.brandId) trackingHeaders["x-brand-id"] = workflowTracking.brandId;
-  if (workflowTracking.workflowName) trackingHeaders["x-workflow-name"] = workflowTracking.workflowName;
+  if (workflowTracking.workflowSlug) trackingHeaders["x-workflow-slug"] = workflowTracking.workflowSlug;
   if (workflowTracking.featureSlug) trackingHeaders["x-feature-slug"] = workflowTracking.featureSlug;
 
   const parsed = ChatRequestSchema.safeParse(req.body);
@@ -539,7 +539,7 @@ app.post("/chat", requireAuth, async (req, res) => {
       content: message.trim(),
       campaignId: workflowTracking.campaignId ?? null,
       brandId: workflowTracking.brandId ?? null,
-      workflowName: workflowTracking.workflowName ?? null,
+      workflowSlug: workflowTracking.workflowSlug ?? null,
       featureSlug: workflowTracking.featureSlug ?? null,
     });
 
@@ -950,10 +950,10 @@ app.post("/chat", requireAuth, async (req, res) => {
         const result = await getFeatureStats(
           args.slug as string,
           {
-            groupBy: args.groupBy as "workflowName" | "brandId" | "campaignId" | undefined,
+            groupBy: args.groupBy as "workflowSlug" | "brandId" | "campaignId" | undefined,
             brandId: args.brandId as string | undefined,
             campaignId: args.campaignId as string | undefined,
-            workflowName: args.workflowName as string | undefined,
+            workflowSlug: args.workflowSlug as string | undefined,
           },
           featureCallParams,
         );
@@ -1159,7 +1159,7 @@ app.post("/chat", requireAuth, async (req, res) => {
       runId,
       campaignId: workflowTracking.campaignId ?? null,
       brandId: workflowTracking.brandId ?? null,
-      workflowName: workflowTracking.workflowName ?? null,
+      workflowSlug: workflowTracking.workflowSlug ?? null,
       featureSlug: workflowTracking.featureSlug ?? null,
     });
 

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -340,7 +340,7 @@ export const GENERATE_WORKFLOW_TOOL: Anthropic.Tool = {
       featureSlug: {
         type: "string",
         description:
-          "Feature slug from features-service (e.g. 'cold-email-outreach'). Required — used to build the workflow name.",
+          "Feature slug from features-service (e.g. 'cold-email-outreach'). Required — used to build the workflow slug.",
       },
       hints: {
         type: "object",
@@ -752,7 +752,7 @@ export const PREFILL_FEATURE_TOOL: Anthropic.Tool = {
 export const GET_FEATURE_STATS_TOOL: Anthropic.Tool = {
   name: "get_feature_stats",
   description:
-    "Get computed stats for a feature — cost, run counts, campaign counts, and per-output metrics. Optionally group by workflowName, brandId, or campaignId. System stats (cost, runs, campaigns, dates) are always included.",
+    "Get computed stats for a feature — cost, run counts, campaign counts, and per-output metrics. Optionally group by workflowSlug, brandId, or campaignId. System stats (cost, runs, campaigns, dates) are always included.",
   input_schema: {
     type: "object" as const,
     properties: {
@@ -762,7 +762,7 @@ export const GET_FEATURE_STATS_TOOL: Anthropic.Tool = {
       },
       groupBy: {
         type: "string",
-        enum: ["workflowName", "brandId", "campaignId"],
+        enum: ["workflowSlug", "brandId", "campaignId"],
         description: "Group stats by this dimension (optional).",
       },
       brandId: {
@@ -773,7 +773,7 @@ export const GET_FEATURE_STATS_TOOL: Anthropic.Tool = {
         type: "string",
         description: "Filter stats to a specific campaign (optional).",
       },
-      workflowName: {
+      workflowSlug: {
         type: "string",
         description: "Filter stats to a specific workflow (optional).",
       },

--- a/src/lib/features-client.ts
+++ b/src/lib/features-client.ts
@@ -249,7 +249,7 @@ export interface FeatureStatsResponse {
   systemStats: FeatureStatsSystemStats;
   stats?: Record<string, number | null>;
   groups?: Array<{
-    workflowName?: string | null;
+    workflowSlug?: string | null;
     brandId?: string | null;
     campaignId?: string | null;
     systemStats: FeatureStatsSystemStats;
@@ -258,10 +258,10 @@ export interface FeatureStatsResponse {
 }
 
 export interface GetFeatureStatsFilters {
-  groupBy?: "workflowName" | "brandId" | "campaignId";
+  groupBy?: "workflowSlug" | "brandId" | "campaignId";
   brandId?: string;
   campaignId?: string;
-  workflowName?: string;
+  workflowSlug?: string;
 }
 
 export async function getFeatureStats(
@@ -273,7 +273,7 @@ export async function getFeatureStats(
   if (filters.groupBy) query.set("groupBy", filters.groupBy);
   if (filters.brandId) query.set("brandId", filters.brandId);
   if (filters.campaignId) query.set("campaignId", filters.campaignId);
-  if (filters.workflowName) query.set("workflowName", filters.workflowName);
+  if (filters.workflowSlug) query.set("workflowSlug", filters.workflowSlug);
 
   const qs = query.toString();
   const res = await apiServiceFetch(

--- a/src/lib/key-client.ts
+++ b/src/lib/key-client.ts
@@ -18,7 +18,7 @@ export interface CallerInfo {
 export interface TrackingHeaders {
   "x-campaign-id"?: string;
   "x-brand-id"?: string;
-  "x-workflow-name"?: string;
+  "x-workflow-slug"?: string;
   "x-feature-slug"?: string;
 }
 

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -32,7 +32,7 @@ export interface CostItem {
 export interface TrackingHeaders {
   "x-campaign-id"?: string;
   "x-brand-id"?: string;
-  "x-workflow-name"?: string;
+  "x-workflow-slug"?: string;
   "x-feature-slug"?: string;
 }
 

--- a/src/lib/workflow-client.ts
+++ b/src/lib/workflow-client.ts
@@ -67,7 +67,7 @@ export interface UpdateWorkflowResult {
 export interface WorkflowConflictError {
   error: string;
   existingWorkflowId: string;
-  existingWorkflowName: string;
+  existingWorkflowSlug: string;
 }
 
 export async function getWorkflow(
@@ -131,7 +131,7 @@ export async function updateWorkflow(
   if (res.status === 409) {
     const conflict = (await res.json()) as WorkflowConflictError;
     throw new Error(
-      `[workflow-client] A workflow with this DAG signature already exists: "${conflict.existingWorkflowName}" (${conflict.existingWorkflowId}). Use the existing workflow instead of creating a duplicate.`,
+      `[workflow-client] A workflow with this DAG signature already exists: "${conflict.existingWorkflowSlug}" (${conflict.existingWorkflowId}). Use the existing workflow instead of creating a duplicate.`,
     );
   }
 

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -3,7 +3,7 @@ import type { Request, Response, NextFunction } from "express";
 export interface WorkflowTrackingHeaders {
   campaignId?: string;
   brandId?: string;
-  workflowName?: string;
+  workflowSlug?: string;
   featureSlug?: string;
 }
 
@@ -56,8 +56,8 @@ function extractWorkflowTracking(req: Request): WorkflowTrackingHeaders {
   if (typeof campaignId === "string") tracking.campaignId = campaignId;
   const brandId = req.headers["x-brand-id"];
   if (typeof brandId === "string") tracking.brandId = brandId;
-  const workflowName = req.headers["x-workflow-name"];
-  if (typeof workflowName === "string") tracking.workflowName = workflowName;
+  const workflowSlug = req.headers["x-workflow-slug"];
+  if (typeof workflowSlug === "string") tracking.workflowSlug = workflowSlug;
   const featureSlug = req.headers["x-feature-slug"];
   if (typeof featureSlug === "string") tracking.featureSlug = featureSlug;
   return tracking;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -17,8 +17,8 @@ const workflowTrackingHeaders = {
   "x-brand-id": z.string().optional().openapi({
     description: "Brand ID — injected automatically by workflow-service",
   }),
-  "x-workflow-name": z.string().optional().openapi({
-    description: "Workflow name — injected automatically by workflow-service",
+  "x-workflow-slug": z.string().optional().openapi({
+    description: "Workflow slug — injected automatically by workflow-service",
   }),
   "x-feature-slug": z.string().optional().openapi({
     description: "Feature slug — propagated through the entire service chain",

--- a/tests/unit/billing-client.test.ts
+++ b/tests/unit/billing-client.test.ts
@@ -99,7 +99,7 @@ describe("authorizeCredits", () => {
       trackingHeaders: {
         "x-campaign-id": "camp-1",
         "x-brand-id": "brand-2",
-        "x-workflow-name": "wf-3",
+        "x-workflow-slug": "wf-3",
       },
     });
 
@@ -107,7 +107,7 @@ describe("authorizeCredits", () => {
     const headers = callArgs[1].headers;
     expect(headers["x-campaign-id"]).toBe("camp-1");
     expect(headers["x-brand-id"]).toBe("brand-2");
-    expect(headers["x-workflow-name"]).toBe("wf-3");
+    expect(headers["x-workflow-slug"]).toBe("wf-3");
   });
 
   it("throws on HTTP error from billing-service", async () => {

--- a/tests/unit/workflow-client.test.ts
+++ b/tests/unit/workflow-client.test.ts
@@ -96,7 +96,7 @@ describe("updateWorkflow", () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: false,
       status: 409,
-      json: () => Promise.resolve({ existingWorkflowId: "wf-existing", existingWorkflowName: "sales-email-v2" }),
+      json: () => Promise.resolve({ existingWorkflowId: "wf-existing", existingWorkflowSlug: "sales-email-v2" }),
     });
 
     const { updateWorkflow } = await loadModule();

--- a/tests/unit/workflow-tracking.test.ts
+++ b/tests/unit/workflow-tracking.test.ts
@@ -26,7 +26,7 @@ describe("workflow tracking headers in auth middleware", () => {
       ...BASE_HEADERS,
       "x-campaign-id": "camp-abc",
       "x-brand-id": "brand-xyz",
-      "x-workflow-name": "outreach-v2",
+      "x-workflow-slug": "outreach-v2",
       "x-feature-slug": "pr-outreach",
     });
     requireAuth(req, res, next);
@@ -35,7 +35,7 @@ describe("workflow tracking headers in auth middleware", () => {
     expect(locals.workflowTracking).toEqual({
       campaignId: "camp-abc",
       brandId: "brand-xyz",
-      workflowName: "outreach-v2",
+      workflowSlug: "outreach-v2",
       featureSlug: "pr-outreach",
     });
   });
@@ -117,7 +117,7 @@ describe("runs-client forwards tracking headers", () => {
     await createRun(
       { serviceName: "chat-service", taskName: "chat" },
       identity,
-      { "x-campaign-id": "camp-1", "x-brand-id": "brand-1", "x-workflow-name": "flow-1", "x-feature-slug": "feat-1" },
+      { "x-campaign-id": "camp-1", "x-brand-id": "brand-1", "x-workflow-slug": "flow-1", "x-feature-slug": "feat-1" },
     );
 
     expect(fetch).toHaveBeenCalledWith(
@@ -129,7 +129,7 @@ describe("runs-client forwards tracking headers", () => {
           "x-run-id": "run-caller",
           "x-campaign-id": "camp-1",
           "x-brand-id": "brand-1",
-          "x-workflow-name": "flow-1",
+          "x-workflow-slug": "flow-1",
           "x-feature-slug": "feat-1",
         }),
       }),
@@ -148,7 +148,7 @@ describe("runs-client forwards tracking headers", () => {
     const callHeaders = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].headers;
     expect(callHeaders["x-campaign-id"]).toBeUndefined();
     expect(callHeaders["x-brand-id"]).toBeUndefined();
-    expect(callHeaders["x-workflow-name"]).toBeUndefined();
+    expect(callHeaders["x-workflow-slug"]).toBeUndefined();
     expect(callHeaders["x-feature-slug"]).toBeUndefined();
   });
 
@@ -228,7 +228,7 @@ describe("key-client forwards tracking headers", () => {
       userId: "user-1",
       runId: "run-1",
       caller: { method: "POST", path: "/chat" },
-      trackingHeaders: { "x-campaign-id": "camp-1", "x-workflow-name": "flow-1" },
+      trackingHeaders: { "x-campaign-id": "camp-1", "x-workflow-slug": "flow-1" },
     });
 
     expect(fetch).toHaveBeenCalledWith(
@@ -236,7 +236,7 @@ describe("key-client forwards tracking headers", () => {
       expect.objectContaining({
         headers: expect.objectContaining({
           "x-campaign-id": "camp-1",
-          "x-workflow-name": "flow-1",
+          "x-workflow-slug": "flow-1",
         }),
       }),
     );


### PR DESCRIPTION
## Summary
- Renames `x-workflow-name` header → `x-workflow-slug` (inbound and outbound)
- Renames DB column `workflow_name` → `workflow_slug` on the `messages` table (migration 0009)
- Updates Zod schemas, OpenAPI spec, Anthropic tool definitions, and all client interfaces (`runs-client`, `key-client`, `features-client`, `workflow-client`)
- Aligns with workflow-service PRs #180/#181 naming refactor

## Test plan
- [x] All 298 unit tests pass
- [x] TypeScript build succeeds
- [x] OpenAPI spec regenerated
- [ ] Verify migration runs on staging DB (`ALTER TABLE messages RENAME COLUMN workflow_name TO workflow_slug`)
- [ ] Confirm downstream services accept `x-workflow-slug` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)