### PR TITLE
feat: keyed configs with allowedTools, remove call_api

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,26 +27,68 @@ All endpoints (except `/health` and `/openapi.json`) require these headers:
 
 ## App Config Registration
 
-Before using `/chat`, orgs must register their configuration via:
+Before using `/chat`, register a config for each chat mode your app needs. Each config is identified by a `key` (e.g. `"workflow"`, `"feature"`, `"press-kit"`) and defines the system prompt + which tools the LLM can use.
 
 `PUT /config`
 
-Request body:
+**Example — workflow chat:**
 ```json
 {
-  "systemPrompt": "You are a helpful assistant for cold email campaigns..."
+  "key": "workflow",
+  "systemPrompt": "You are an AI assistant that helps users understand and modify their outreach workflows...",
+  "allowedTools": [
+    "request_user_input",
+    "update_workflow",
+    "validate_workflow",
+    "get_workflow_details",
+    "generate_workflow",
+    "get_workflow_required_providers",
+    "list_workflows",
+    "update_workflow_node_config",
+    "get_prompt_template",
+    "update_prompt_template",
+    "list_services",
+    "list_service_endpoints",
+    "list_org_keys",
+    "get_key_source",
+    "list_key_sources",
+    "check_provider_requirements"
+  ]
 }
 ```
 
-- `systemPrompt` (required) — the system prompt sent to Claude for this org
+**Example — feature chat:**
+```json
+{
+  "key": "feature",
+  "systemPrompt": "You are an AI assistant that helps users design and manage features...",
+  "allowedTools": [
+    "request_user_input",
+    "create_feature",
+    "update_feature",
+    "list_features",
+    "get_feature",
+    "get_feature_inputs",
+    "prefill_feature",
+    "get_feature_stats"
+  ]
+}
+```
 
-This endpoint is **idempotent** (upsert on `orgId` from the `x-org-id` header). Call it on every cold start.
+Fields:
+- `key` (required) — config identifier, unique per org. Clients pass this as `configKey` in `POST /chat`.
+- `systemPrompt` (required) — the system prompt sent to Claude for this chat mode
+- `allowedTools` (required, min 1) — which tools the LLM can use. The service rejects any tool call not in this list. See [Available Tools](#available-tools) for the full list.
+
+This endpoint is **idempotent** (upsert on `(orgId, key)`). Call it on every cold start.
 
 Response:
 ```json
 {
   "orgId": "org-uuid",
+  "key": "workflow",
   "systemPrompt": "...",
+  "allowedTools": ["..."],
   "createdAt": "2026-02-26T00:00:00.000Z",
   "updatedAt": "2026-02-26T00:00:00.000Z"
 }
@@ -54,29 +96,37 @@ Response:
 
 ## Platform Config Registration
 
-Register a global (non-org-scoped) chat configuration used as fallback when no per-org config exists:
+Register a platform-wide config for a given key. Used as fallback when no per-org config exists for that key.
 
 `PUT /platform-config`
 
 **Auth:** `X-API-Key` only — no `x-org-id`, `x-user-id`, or `x-run-id` headers required.
 
-Request body:
 ```json
 {
-  "systemPrompt": "You are a helpful assistant..."
+  "key": "workflow",
+  "systemPrompt": "You are a helpful assistant...",
+  "allowedTools": ["request_user_input", "get_workflow_details", "list_workflows"]
 }
 ```
 
-- `systemPrompt` (required) — the default system prompt for all orgs without a per-org config
+Fields: same as `PUT /config` — `key`, `systemPrompt`, `allowedTools` (all required).
 
-This endpoint is **idempotent** (upsert). Called on every cold start by api-service.
+This endpoint is **idempotent** (upsert on `key`). Called on every cold start by api-service.
 
-**Config resolution in POST /chat:** Per-org config (from `PUT /config`) takes priority. If none exists, the platform config (from `PUT /platform-config`) is used. If neither exists, the request fails with 404. There is no merging — it's one or the other.
+**Config resolution in POST /chat:**
+1. Per-org config `(orgId, configKey)` → if found, use it
+2. Platform config `(configKey)` → if found, use it
+3. Neither found → **404**
+
+There is no merging — it's one or the other.
 
 Response:
 ```json
 {
+  "key": "workflow",
   "systemPrompt": "...",
+  "allowedTools": ["..."],
   "createdAt": "2026-02-26T00:00:00.000Z",
   "updatedAt": "2026-02-26T00:00:00.000Z"
 }
@@ -140,19 +190,23 @@ When the `x-campaign-id` header is present, both `/chat` and `/complete` automat
 Request body:
 ```json
 {
+  "configKey": "workflow",
   "message": "Hello",
-  "sessionId": "optional-uuid",
+  "sessionId": "optional-uuid-or-null",
   "context": {
-    "brandUrl": "https://example.com",
-    "objective": "clicks",
-    "budgetAmount": 500
+    "workflowId": "wf-550e8400-e29b-41d4-a716-446655440000",
+    "workflowSlug": "cold-email-outreach",
+    "workflowName": "Cold Email Outreach",
+    "brandId": "brand-123",
+    "brandUrl": "https://example.com"
   }
 }
 ```
 
+- `configKey` (required) — which config to use (must match a key from `PUT /config` or `PUT /platform-config`)
 - `message` (required) — the user's chat message
 - `sessionId` (optional, nullable) — UUID of an existing session to continue. **Omit or pass `null` to start a new conversation** — the service creates the session and returns its ID in the first SSE event (`{"sessionId":"<uuid>"}`). Store that ID and pass it in subsequent requests. If a provided `sessionId` does not exist or belongs to a different org, the stream returns `"Session not found."` and closes. **Do not generate your own UUID** — always use the one returned by the service.
-- `context` (optional) — free-form JSON injected into the system prompt for this request only (not stored)
+- `context` (optional) — free-form JSON provided by the **frontend** (not user-editable). Injected into the system prompt for this request only (not stored). **Re-send on every message** — the service does not cache it. After a fork (e.g. workflow updated → new workflow created), update the context with the new IDs.
 
 The response is a stream of SSE events in this order:
 
@@ -192,41 +246,57 @@ data: {"type":"tool_result","id":"tc_550e8400-e29b-41d4-a716-446655440000","name
 
 After a tool result, more `token` events follow with the AI's continuation.
 
-**Built-in tools:**
+### Available Tools
+
+The tools available in each chat session are determined by the `allowedTools` array in the config. The LLM only sees and can call tools that are listed. Unknown or unlisted tools are rejected.
+
+**Workflow tools:**
 
 | Tool | Description |
 |---|---|
 | `get_workflow_details` | Fetches full workflow details (DAG, metadata, status) via workflow-service `GET /workflows/{id}` |
-| `get_workflow_required_providers` | Returns BYOK providers needed to execute a workflow via `GET /workflows/{id}/required-providers`. Proactively warns about missing keys. |
-| `list_workflows` | Lists workflows via `GET /workflows` with optional filters: featureSlug, category, channel, audienceType, tag, status, brandId, humanId, campaignId |
-| `update_workflow` | Updates a workflow's metadata or DAG via `PUT /workflows/{id}`. DAG changes trigger a fork (201 with new workflow) rather than in-place update. Returns 409 if DAG signature already exists. Metadata-only changes update in-place (200). |
-| `update_workflow_node_config` | Updates a specific node's config in a workflow's DAG (e.g. change prompt type on `email-generate` node). Fetches, merges, and saves. May fork the workflow if the DAG changes. |
-| `validate_workflow` | Validates a workflow's DAG structure via workflow-service `POST /workflows/{id}/validate` |
-| `get_prompt_template` | Retrieves a stored prompt template by type from content-generation `GET /prompts?type=...` |
-| `update_prompt_template` | Creates a new version of an existing prompt template via content-generation `PUT /prompts` (auto-versions: e.g. `cold-email` → `cold-email-v2`) |
-| `list_services` | Lists all microservices with name, description, and endpoint count via api-registry `GET /llm-context`. Start here for service discovery. |
-| `list_service_endpoints` | Lists endpoints (method, path, summary) for a specific service via api-registry `GET /llm-context/{service}`. Use after `list_services` to drill down. |
-| `call_api` | Proxies an API call to any registered service via api-registry `POST /call/{service}`. API key injected automatically. Use to verify data or read resources. |
-| `list_org_keys` | Lists API keys configured for the current org (provider + masked key) via key-service `GET /keys`. Never exposes actual secrets. |
-| `get_key_source` | Gets key source preference (org vs platform) for a provider via key-service `GET /keys/{provider}/source`. |
-| `list_key_sources` | Lists all key source preferences for the org via key-service `GET /keys/sources`. |
-| `check_provider_requirements` | Queries which providers are needed for a set of endpoints via key-service `POST /provider-requirements`. |
-| `request_user_input` | Asks the user for structured input (see Input Request below) |
+| `generate_workflow` | Generates a new workflow from natural language via workflow-service `POST /workflows/generate` |
+| `get_workflow_required_providers` | Returns BYOK providers needed to execute a workflow via `GET /workflows/{id}/required-providers` |
+| `list_workflows` | Lists workflows via `GET /workflows` with optional filters |
+| `update_workflow` | Updates a workflow's metadata or DAG. DAG changes trigger a fork (new workflow). Metadata-only changes update in-place. |
+| `update_workflow_node_config` | Updates a specific node's config in a workflow's DAG. May fork if DAG changes. |
+| `validate_workflow` | Validates a workflow's DAG structure |
+| `get_prompt_template` | Retrieves a stored prompt template by type |
+| `update_prompt_template` | Creates a new version of an existing prompt template (auto-versions) |
 
-**Context-specific tools:**
-
-When `context.type` is `"feature-creator"`, the standard workflow tools above are **replaced** by a focused toolset for designing features:
+**Service discovery tools (read-only):**
 
 | Tool | Description |
 |---|---|
-| `request_user_input` | Asks the user for structured input (same as above) |
-| `create_feature` | Creates a new feature via `POST /features`. Required: name, description, **icon**, category, channel, audienceType, inputs (with key/label/**type**/**placeholder**/description/**extractKey**), outputs (with **key**/**displayOrder**, optional defaultSort/sortDirection — keys from stats registry), charts (min 1), entities (min 1). Optional: slug, implemented, displayOrder, status. Returns 409 on conflict. Response includes `id`, `displayName`, `signature`. |
-| `update_feature` | Updates or forks a feature via `PUT /features/:slug` (fork-on-write). Metadata-only changes update in-place (200). If inputs/outputs change (different signature), a new forked feature is created, the original is deprecated (201). Response includes `forked: boolean`. Supports: name, description, icon, category, channel, audienceType, implemented, displayOrder, status, inputs, outputs, charts, entities. |
-| `list_features` | Lists features via `GET /features` with optional filters (category, channel, audienceType, status, implemented). Responses include `displayName` (stable human label) and `name` (machine identifier, may include version suffix). |
-| `get_feature` | Gets full feature details by slug via `GET /features/:slug`. |
-| `get_feature_inputs` | Gets input definitions only via `GET /features/:slug/inputs`. Lighter than `get_feature`. |
-| `prefill_feature` | Pre-fills feature inputs from brand data via `POST /features/:slug/prefill`. Returns a map of input key → suggested text value. |
-| `get_feature_stats` | Gets computed stats via `GET /features/:slug/stats`. Supports `groupBy` (workflowSlug, brandId, campaignId) and filter params. Returns system stats (cost, runs, campaigns) and per-output metrics. |
+| `list_services` | Lists all microservices with name, description, and endpoint count |
+| `list_service_endpoints` | Lists endpoints for a specific service (method, path, summary) |
+
+**Key management tools (read-only):**
+
+| Tool | Description |
+|---|---|
+| `list_org_keys` | Lists API keys configured for the org (masked, never exposes secrets) |
+| `get_key_source` | Gets key source preference (org vs platform) for a provider |
+| `list_key_sources` | Lists all key source preferences for the org |
+| `check_provider_requirements` | Queries which providers are needed for a set of endpoints |
+
+**Feature tools:**
+
+| Tool | Description |
+|---|---|
+| `create_feature` | Creates a new feature definition |
+| `update_feature` | Updates or forks a feature (fork-on-write if signature changes) |
+| `list_features` | Lists features with optional filters |
+| `get_feature` | Gets full feature details by slug |
+| `get_feature_inputs` | Gets input definitions only (lighter than get_feature) |
+| `prefill_feature` | Pre-fills feature inputs from brand data |
+| `get_feature_stats` | Gets computed stats for a feature |
+
+**UI tools:**
+
+| Tool | Description |
+|---|---|
+| `request_user_input` | Asks the user for structured input (see Input Request below) |
 
 ### 5. Input Request (optional)
 When the AI genuinely needs information it does not have, it emits an input request:
@@ -310,8 +380,8 @@ Uses PostgreSQL via Drizzle ORM. Three tables:
 
 - **sessions** — conversation sessions scoped by `orgId` and `userId`
 - **messages** — chat messages with role, content, optional `toolCalls`, `buttons`, `contentBlocks` JSONB (stores full Anthropic content blocks for context management), `runId` linking to RunsService, and optional `campaign_id`, `brand_id`, `workflow_slug`, `feature_slug` for workflow tracking
-- **app_configs** — per-org configuration (system prompt) with unique constraint on `orgId`
-- **platform_configs** — global platform-wide chat configuration (fallback when no per-org config exists)
+- **app_configs** — per-org configuration keyed by `(orgId, key)`. Each entry defines a system prompt and `allowedTools` for a specific chat mode.
+- **platform_configs** — platform-wide configuration keyed by `key`. Fallback when no per-org config exists for the same key.
 
 Migrations run automatically on server start. To generate new migrations after schema changes:
 

--- a/drizzle/0010_add_config_key_and_allowed_tools.sql
+++ b/drizzle/0010_add_config_key_and_allowed_tools.sql
@@ -1,0 +1,15 @@
+-- Add key and allowed_tools columns to app_configs
+ALTER TABLE "app_configs" ADD COLUMN "key" text NOT NULL DEFAULT 'default';
+ALTER TABLE "app_configs" ADD COLUMN "allowed_tools" jsonb NOT NULL DEFAULT '["request_user_input", "update_workflow", "validate_workflow", "get_prompt_template", "update_prompt_template", "update_workflow_node_config", "get_workflow_details", "generate_workflow", "get_workflow_required_providers", "list_workflows", "list_services", "list_service_endpoints", "list_org_keys", "get_key_source", "list_key_sources", "check_provider_requirements"]'::jsonb;
+
+-- Drop old unique constraint on orgId only, add new one on (orgId, key)
+ALTER TABLE "app_configs" DROP CONSTRAINT IF EXISTS "app_configs_org_id_unique";
+ALTER TABLE "app_configs" ADD CONSTRAINT "app_configs_org_id_key_unique" UNIQUE ("org_id", "key");
+
+-- Remove the default now that existing rows are migrated
+ALTER TABLE "app_configs" ALTER COLUMN "key" DROP DEFAULT;
+ALTER TABLE "app_configs" ALTER COLUMN "allowed_tools" DROP DEFAULT;
+
+-- Add allowed_tools to platform_configs
+ALTER TABLE "platform_configs" ADD COLUMN "allowed_tools" jsonb NOT NULL DEFAULT '["request_user_input", "update_workflow", "validate_workflow", "get_prompt_template", "update_prompt_template", "update_workflow_node_config", "get_workflow_details", "generate_workflow", "get_workflow_required_providers", "list_workflows", "list_services", "list_service_endpoints", "list_org_keys", "get_key_source", "list_key_sources", "check_provider_requirements"]'::jsonb;
+ALTER TABLE "platform_configs" ALTER COLUMN "allowed_tools" DROP DEFAULT;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1774886400000,
       "tag": "0009_rename_workflow_name_to_slug",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1774972800000,
+      "tag": "0010_add_config_key_and_allowed_tools",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -291,8 +291,17 @@
           "orgId": {
             "type": "string"
           },
+          "key": {
+            "type": "string"
+          },
           "systemPrompt": {
             "type": "string"
+          },
+          "allowedTools": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "createdAt": {
             "type": "string"
@@ -303,7 +312,9 @@
         },
         "required": [
           "orgId",
+          "key",
           "systemPrompt",
+          "allowedTools",
           "createdAt",
           "updatedAt"
         ]
@@ -328,21 +339,56 @@
       "AppConfigRequest": {
         "type": "object",
         "properties": {
+          "key": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Config key — identifies which chat mode this config is for (e.g. 'workflow', 'feature', 'press-kit'). Each org can have multiple configs, one per key.",
+            "example": "workflow"
+          },
           "systemPrompt": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "description": "System prompt sent to the LLM for this chat mode",
+            "example": "You are an AI assistant that helps users understand and modify their workflows."
+          },
+          "allowedTools": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "minItems": 1,
+            "description": "List of tool names the LLM is allowed to use in this chat mode. Only these tools will be provided to the model and executable server-side. Available tools: request_user_input, update_workflow, validate_workflow, get_workflow_details, generate_workflow, get_workflow_required_providers, list_workflows, update_workflow_node_config, get_prompt_template, update_prompt_template, list_services, list_service_endpoints, list_org_keys, get_key_source, list_key_sources, check_provider_requirements, create_feature, update_feature, list_features, get_feature, get_feature_inputs, prefill_feature, get_feature_stats",
+            "example": [
+              "request_user_input",
+              "update_workflow",
+              "validate_workflow",
+              "get_workflow_details",
+              "list_workflows"
+            ]
           }
         },
         "required": [
-          "systemPrompt"
+          "key",
+          "systemPrompt",
+          "allowedTools"
         ],
         "additionalProperties": false
       },
       "PlatformConfigResponse": {
         "type": "object",
         "properties": {
+          "key": {
+            "type": "string"
+          },
           "systemPrompt": {
             "type": "string"
+          },
+          "allowedTools": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "createdAt": {
             "type": "string"
@@ -352,7 +398,9 @@
           }
         },
         "required": [
+          "key",
           "systemPrompt",
+          "allowedTools",
           "createdAt",
           "updatedAt"
         ]
@@ -360,13 +408,39 @@
       "PlatformConfigRequest": {
         "type": "object",
         "properties": {
+          "key": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Config key — identifies which chat mode this platform config is for. Used as fallback when no per-org config exists for this key.",
+            "example": "workflow"
+          },
           "systemPrompt": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "description": "Default system prompt for all orgs without a per-org config for this key",
+            "example": "You are an AI assistant that helps users understand and modify their workflows."
+          },
+          "allowedTools": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "minItems": 1,
+            "description": "List of tool names the LLM is allowed to use. Same semantics as in PUT /config.",
+            "example": [
+              "request_user_input",
+              "update_workflow",
+              "validate_workflow",
+              "get_workflow_details",
+              "list_workflows"
+            ]
           }
         },
         "required": [
-          "systemPrompt"
+          "key",
+          "systemPrompt",
+          "allowedTools"
         ],
         "additionalProperties": false
       },
@@ -485,6 +559,12 @@
       "ChatRequest": {
         "type": "object",
         "properties": {
+          "configKey": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Which chat config to use for this request. Must match a key registered via PUT /config (per-org) or PUT /platform-config (platform-wide fallback). Examples: 'workflow', 'feature', 'press-kit'.",
+            "example": "workflow"
+          },
           "message": {
             "type": "string",
             "minLength": 1,
@@ -495,7 +575,7 @@
             "type": "string",
             "nullable": true,
             "format": "uuid",
-            "description": "UUID of an existing session to continue. Omit to create a new session. When omitted, the service creates a new session and returns its ID in the first SSE event ({\"sessionId\":\"<uuid>\"}). Use that ID in subsequent requests to continue the conversation. If a sessionId is provided but does not exist or belongs to a different org, the stream returns a \"Session not found.\" error and closes.",
+            "description": "UUID of an existing session to continue. Omit or pass null to start a new conversation. When omitted, the service creates a new session and returns its ID in the first SSE event ({\"sessionId\":\"<uuid>\"}). Use that ID in subsequent requests to continue the conversation. If a sessionId is provided but does not exist or belongs to a different org, the stream returns a \"Session not found.\" error and closes.",
             "example": "550e8400-e29b-41d4-a716-446655440000"
           },
           "context": {
@@ -503,15 +583,18 @@
             "additionalProperties": {
               "nullable": true
             },
-            "description": "Free-form JSON injected into the system prompt for this request only (not stored). Use this to pass dynamic data like brand URLs, campaign objectives, budgets, etc.",
+            "description": "Free-form JSON context provided by the frontend (not user-editable). Injected into the system prompt for this request only (not stored). Re-send on every message — the service does not cache it. Use this to pass the current page state: workflow details, brand info, etc.",
             "example": {
-              "brandUrl": "https://example.com",
-              "objective": "clicks",
-              "budgetAmount": 500
+              "workflowId": "wf-550e8400-e29b-41d4-a716-446655440000",
+              "workflowSlug": "cold-email-outreach",
+              "workflowName": "Cold Email Outreach",
+              "brandId": "brand-123",
+              "brandUrl": "https://example.com"
             }
           }
         },
         "required": [
+          "configKey",
           "message"
         ]
       }
@@ -581,7 +664,7 @@
           "App Config"
         ],
         "summary": "Register or update app configuration",
-        "description": "Idempotent upsert of app configuration scoped by org (via x-org-id header). Includes system prompt. Call on every cold start.",
+        "description": "Idempotent upsert of app configuration scoped by (orgId, key). Each key represents a chat mode (e.g. 'workflow', 'feature', 'press-kit'). The config defines the system prompt and which tools the LLM can use in that mode. Call on every cold start.\n\n**Example — workflow chat config:**\n```json\n{ \"key\": \"workflow\", \"systemPrompt\": \"You help users understand and modify workflows...\", \"allowedTools\": [\"request_user_input\", \"update_workflow\", \"validate_workflow\", \"get_workflow_details\", \"list_workflows\", \"update_workflow_node_config\", \"get_prompt_template\", \"update_prompt_template\", \"list_org_keys\", \"get_key_source\", \"list_key_sources\", \"check_provider_requirements\", \"list_services\", \"list_service_endpoints\", \"generate_workflow\", \"get_workflow_required_providers\"] }\n```\n\n**Example — feature chat config:**\n```json\n{ \"key\": \"feature\", \"systemPrompt\": \"You help users design and manage features...\", \"allowedTools\": [\"request_user_input\", \"create_feature\", \"update_feature\", \"list_features\", \"get_feature\", \"get_feature_inputs\", \"prefill_feature\", \"get_feature_stats\"] }\n```",
         "parameters": [
           {
             "schema": {
@@ -714,7 +797,7 @@
           "Platform Config"
         ],
         "summary": "Register or update platform-wide chat configuration",
-        "description": "Idempotent upsert of a global chat configuration (not scoped to any org). Used as fallback when no per-org config exists. Auth: X-API-Key only — no x-org-id, x-user-id, or x-run-id required. Called on every cold start by api-service.",
+        "description": "Idempotent upsert of a platform-wide chat configuration keyed by `key`. Used as fallback when no per-org config exists for the same key. Auth: X-API-Key only — no x-org-id, x-user-id, or x-run-id required. Called on every cold start by api-service.\n\n**Config resolution in POST /chat:** Per-org config `(orgId, configKey)` takes priority. If none exists, platform config `(configKey)` is used. If neither exists → 404.",
         "parameters": [
           {
             "schema": {
@@ -929,7 +1012,7 @@
           "Chat"
         ],
         "summary": "Stream AI chat response",
-        "description": "Send a message and receive a streamed AI response via Server-Sent Events (SSE).\n\n**Session lifecycle:**\n- To start a new conversation, omit `sessionId`. The first SSE event will be `{\"sessionId\":\"<uuid>\"}` — store this ID.\n- To continue a conversation, pass that `sessionId` in subsequent requests.\n- If a provided `sessionId` does not exist or belongs to a different org, the stream returns an error and closes.\n\n**SSE event order:**\nEach `data:` line contains a JSON object. Events arrive in this order:\n\n1. **Session** — `{\"sessionId\":\"<uuid>\"}` (always first)\n2. **Thinking** _(optional)_ — `thinking_start` → one or more `thinking_delta` → `thinking_stop`. May appear before tokens and after tool results.\n3. **Tokens** — `{\"type\":\"token\",\"content\":\"...\"}` streamed incrementally as the AI generates text.\n4. **Tool calls** _(optional, repeatable)_ — `tool_call` followed by `tool_result`, then more thinking/tokens as the AI continues.\n5. **Input request** _(optional)_ — `input_request` when the AI needs structured user input (terminates the response).\n6. **Buttons** _(optional)_ — `{\"type\":\"buttons\",\"buttons\":[...]}` with quick-reply options, sent after all tokens.\n7. **Error** _(optional)_ — `{\"type\":\"error\",\"message\":\"...\"}` if the AI model returns an empty response (context overflow, safety filter) or an unexpected error occurs. Sent before `[DONE]`.\n8. **Done** — `\"[DONE]\"` (always last).\n\nSee the SSE event schemas (SSESessionEvent, SSETokenEvent, SSEThinkingStartEvent, SSEThinkingDeltaEvent, SSEThinkingStopEvent, SSEToolCallEvent, SSEToolResultEvent, SSEInputRequestEvent, SSEButtonsEvent, SSEErrorEvent) in components/schemas for exact payload shapes.\n\nRequires app config to be registered first via PUT /config (or platform config via PUT /platform-config as fallback).",
+        "description": "Send a message and receive a streamed AI response via Server-Sent Events (SSE).\n\n**Config resolution:**\nThe `configKey` field selects which chat config to use. Resolution order:\n1. Per-org config: `(orgId, configKey)` from PUT /config\n2. Platform config: `(configKey)` from PUT /platform-config\n3. If neither exists → 404\n\nThe selected config determines both the system prompt and which tools the LLM can use.\n\n**Session lifecycle:**\n- To start a new conversation, omit `sessionId` (or pass `null`). The first SSE event will be `{\"sessionId\":\"<uuid>\"}` — store this ID.\n- To continue a conversation, pass that `sessionId` in subsequent requests.\n- To reset a conversation (e.g. after a fork), omit `sessionId` and send a new `context`.\n\n**Context:**\nThe `context` field is a free-form JSON object provided by the frontend on **every** message. It is injected into the system prompt but not stored. Re-send it on every request — the service does not cache it. After a fork (e.g. workflow updated → new workflow created), the frontend should update its context with the new IDs and either continue the session or start a new one.\n\n**SSE event order:**\nEach `data:` line contains a JSON object. Events arrive in this order:\n\n1. **Session** — `{\"sessionId\":\"<uuid>\"}` (always first)\n2. **Thinking** _(optional)_ — `thinking_start` → one or more `thinking_delta` → `thinking_stop`.\n3. **Tokens** — `{\"type\":\"token\",\"content\":\"...\"}` streamed incrementally.\n4. **Tool calls** _(optional, repeatable)_ — `tool_call` followed by `tool_result`, then more thinking/tokens.\n5. **Input request** _(optional)_ — `input_request` when the AI needs structured user input (terminates the response).\n6. **Buttons** _(optional)_ — `{\"type\":\"buttons\",\"buttons\":[...]}` with quick-reply options, sent after all tokens.\n7. **Error** _(optional)_ — `{\"type\":\"error\",\"message\":\"...\"}` if something goes wrong. Sent before `[DONE]`.\n8. **Done** — `\"[DONE]\"` (always last).\n\n**Available tools** depend on the config's `allowedTools`. The LLM only sees and can call the tools listed there. See PUT /config documentation for the full list of available tool names.",
         "parameters": [
           {
             "schema": {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -32,17 +32,20 @@ export const appConfigs = pgTable(
   {
     id: uuid("id").primaryKey().defaultRandom(),
     orgId: text("org_id").notNull(),
+    key: text("key").notNull(),
     systemPrompt: text("system_prompt").notNull(),
+    allowedTools: jsonb("allowed_tools").notNull().$type<string[]>(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
-  (table) => [unique("app_configs_org_id_unique").on(table.orgId)],
+  (table) => [unique("app_configs_org_id_key_unique").on(table.orgId, table.key)],
 );
 
 export const platformConfigs = pgTable("platform_configs", {
   id: uuid("id").primaryKey().defaultRandom(),
   key: text("key").notNull().unique(),
   systemPrompt: text("system_prompt").notNull(),
+  allowedTools: jsonb("allowed_tools").notNull().$type<string[]>(),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,8 @@ import Anthropic from "@anthropic-ai/sdk";
 import {
   createAnthropicClient,
   buildSystemPrompt,
-  BUILTIN_TOOLS,
-  FEATURE_CREATOR_TOOLS,
+  resolveToolSet,
+  AVAILABLE_TOOL_NAMES,
   MODEL,
   COST_PREFIX,
   costPrefixForModel,
@@ -26,7 +26,7 @@ import {
   listWorkflows,
 } from "./lib/workflow-client.js";
 import { getPromptTemplate, updatePromptTemplate } from "./lib/content-generation-client.js";
-import { listServices, listServiceEndpoints, callApi } from "./lib/api-registry-client.js";
+import { listServices, listServiceEndpoints } from "./lib/api-registry-client.js";
 import { createRun, updateRunStatus, addRunCosts } from "./lib/runs-client.js";
 import { createFeature, updateFeature, listFeatures, getFeature, getFeatureInputs, prefillFeature, getFeatureStats } from "./lib/features-client.js";
 import { formatToolError } from "./lib/tool-errors.js";
@@ -87,18 +87,29 @@ app.put("/config", requireAuth, async (req, res) => {
       .json({ error: "Invalid request", details: parsed.error.flatten() });
   }
 
-  const { systemPrompt } = parsed.data;
+  const { key, systemPrompt, allowedTools } = parsed.data;
+
+  // Validate all tool names
+  const unknownTools = allowedTools.filter((t) => !AVAILABLE_TOOL_NAMES.includes(t));
+  if (unknownTools.length > 0) {
+    return res.status(400).json({
+      error: `Unknown tools: ${unknownTools.join(", ")}. Available: ${AVAILABLE_TOOL_NAMES.join(", ")}`,
+    });
+  }
 
   const [config] = await db
     .insert(appConfigs)
     .values({
       orgId,
+      key,
       systemPrompt,
+      allowedTools,
     })
     .onConflictDoUpdate({
-      target: [appConfigs.orgId],
+      target: [appConfigs.orgId, appConfigs.key],
       set: {
         systemPrompt,
+        allowedTools,
         updatedAt: new Date(),
       },
     })
@@ -106,15 +117,15 @@ app.put("/config", requireAuth, async (req, res) => {
 
   res.json({
     orgId: config.orgId,
+    key: config.key,
     systemPrompt: config.systemPrompt,
+    allowedTools: config.allowedTools,
     createdAt: config.createdAt.toISOString(),
     updatedAt: config.updatedAt.toISOString(),
   });
 });
 
 // --- Platform Config Registration ---
-
-const PLATFORM_CONFIG_KEY = "default";
 
 app.put("/platform-config", requireInternalAuth, async (req, res) => {
   const parsed = PlatformConfigRequestSchema.safeParse(req.body);
@@ -124,25 +135,37 @@ app.put("/platform-config", requireInternalAuth, async (req, res) => {
       .json({ error: "Invalid request", details: parsed.error.flatten() });
   }
 
-  const { systemPrompt } = parsed.data;
+  const { key, systemPrompt, allowedTools } = parsed.data;
+
+  // Validate all tool names
+  const unknownTools = allowedTools.filter((t) => !AVAILABLE_TOOL_NAMES.includes(t));
+  if (unknownTools.length > 0) {
+    return res.status(400).json({
+      error: `Unknown tools: ${unknownTools.join(", ")}. Available: ${AVAILABLE_TOOL_NAMES.join(", ")}`,
+    });
+  }
 
   const [config] = await db
     .insert(platformConfigs)
     .values({
-      key: PLATFORM_CONFIG_KEY,
+      key,
       systemPrompt,
+      allowedTools,
     })
     .onConflictDoUpdate({
       target: [platformConfigs.key],
       set: {
         systemPrompt,
+        allowedTools,
         updatedAt: new Date(),
       },
     })
     .returning();
 
   res.json({
+    key: config.key,
     systemPrompt: config.systemPrompt,
+    allowedTools: config.allowedTools,
     createdAt: config.createdAt.toISOString(),
     updatedAt: config.updatedAt.toISOString(),
   });
@@ -350,25 +373,27 @@ app.post("/chat", requireAuth, async (req, res) => {
       .json({ error: "Invalid request", details: parsed.error.flatten() });
   }
 
-  const { message, sessionId, context } = parsed.data;
+  const { configKey, message, sessionId, context } = parsed.data;
 
-  // Look up app config by orgId, fall back to platform config
+  // Look up app config by (orgId, configKey), fall back to platform config by configKey
   const [orgConfig] = await db
     .select()
     .from(appConfigs)
-    .where(eq(appConfigs.orgId, orgId));
+    .where(and(eq(appConfigs.orgId, orgId), eq(appConfigs.key, configKey)));
 
   const appConfig = orgConfig ?? (await db
     .select()
     .from(platformConfigs)
-    .where(eq(platformConfigs.key, PLATFORM_CONFIG_KEY))
+    .where(eq(platformConfigs.key, configKey))
     .then(([row]) => row ?? null));
 
   if (!appConfig) {
     return res.status(404).json({
-      error: `No chat config found for org="${orgId}". Register via PUT /config or PUT /platform-config.`,
+      error: `No chat config found for key="${configKey}" (org="${orgId}"). Register via PUT /config or PUT /platform-config.`,
     });
   }
+
+  const allowedToolNames: string[] = appConfig.allowedTools as string[];
 
   // Resolve Anthropic API key per-request (supports BYOK per org)
   let resolvedKey: ResolvedKey;
@@ -590,9 +615,8 @@ app.post("/chat", requireAuth, async (req, res) => {
       }
     }
 
-    const allTools = context?.type === "feature-creator"
-      ? FEATURE_CREATOR_TOOLS
-      : BUILTIN_TOOLS;
+    const allTools = resolveToolSet(allowedToolNames);
+    const allowedToolSet = new Set(allowedToolNames);
 
     // Detect client disconnect to abort in-flight streams
     const abortController = new AbortController();
@@ -610,6 +634,15 @@ app.post("/chat", requireAuth, async (req, res) => {
     async function executeTool(
       call: { name: string; args: Record<string, unknown> },
     ): Promise<{ name: string; result: unknown } | "input_request" | null> {
+      // Tool guard: reject tools not in the config's allowedTools
+      if (!allowedToolSet.has(call.name)) {
+        console.warn(`[chat] Tool "${call.name}" not in allowedTools for configKey="${configKey}" — rejecting`);
+        return {
+          name: call.name,
+          result: { error: `Tool "${call.name}" is not available in this chat mode.` },
+        };
+      }
+
       // Client-side tool: emit input_request and signal to stop
       if (call.name === "request_user_input") {
         const args = (call.args as Record<string, unknown>) || {};
@@ -809,20 +842,7 @@ app.post("/chat", requireAuth, async (req, res) => {
         return { name: call.name, result };
       }
 
-      if (call.name === "call_api") {
-        const args = (call.args as Record<string, unknown>) || {};
-        const result = await callApi(
-          {
-            service: args.service as string,
-            method: args.method as "GET" | "POST" | "PUT" | "PATCH" | "DELETE",
-            path: args.path as string,
-            body: args.body as Record<string, unknown> | undefined,
-          },
-          { orgId, userId, runId: runId! },
-        );
-        toolCalls.push({ name: call.name, args, result });
-        return { name: call.name, result };
-      }
+      // call_api removed — security risk (unrestricted admin-key access to all services)
 
       // Key-service read tools
       if (call.name === "list_org_keys") {

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -212,35 +212,7 @@ export const LIST_SERVICE_ENDPOINTS_TOOL: Anthropic.Tool = {
   },
 };
 
-export const CALL_API_TOOL: Anthropic.Tool = {
-  name: "call_api",
-  description:
-    "Call an API endpoint on a registered service. The API key is injected automatically — you only need the service name, method, path, and optional body. Use list_services → list_service_endpoints first to discover available endpoints. Use this to verify data, read resources, or check service state.",
-  input_schema: {
-    type: "object" as const,
-    properties: {
-      service: {
-        type: "string",
-        description: "Target service name (e.g. 'brand', 'features')",
-      },
-      method: {
-        type: "string",
-        enum: ["GET", "POST", "PUT", "PATCH", "DELETE"],
-        description: "HTTP method",
-      },
-      path: {
-        type: "string",
-        description:
-          "Endpoint path on the target service (e.g. '/features/cold-email-outreach/inputs')",
-      },
-      body: {
-        type: "object",
-        description: "Request body for POST/PUT/PATCH (optional)",
-      },
-    },
-    required: ["service", "method", "path"],
-  },
-};
+// call_api tool removed — security risk (unrestricted admin-key access to all services)
 
 // ---------------------------------------------------------------------------
 // Key-service read tools
@@ -782,38 +754,56 @@ export const GET_FEATURE_STATS_TOOL: Anthropic.Tool = {
   },
 };
 
-export const BUILTIN_TOOLS: Anthropic.Tool[] = [
-  REQUEST_USER_INPUT_TOOL,
-  UPDATE_WORKFLOW_TOOL,
-  VALIDATE_WORKFLOW_TOOL,
-  GET_PROMPT_TEMPLATE_TOOL,
-  UPDATE_PROMPT_TEMPLATE_TOOL,
-  UPDATE_WORKFLOW_NODE_CONFIG_TOOL,
-  GET_WORKFLOW_DETAILS_TOOL,
-  GET_WORKFLOW_REQUIRED_PROVIDERS_TOOL,
-  LIST_WORKFLOWS_TOOL,
-  // API Registry progressive disclosure
-  LIST_SERVICES_TOOL,
-  LIST_SERVICE_ENDPOINTS_TOOL,
-  CALL_API_TOOL,
-  // Key-service read tools
-  LIST_ORG_KEYS_TOOL,
-  GET_KEY_SOURCE_TOOL,
-  LIST_KEY_SOURCES_TOOL,
-  CHECK_PROVIDER_REQUIREMENTS_TOOL,
-];
+// ---------------------------------------------------------------------------
+// Tool registry — every tool the service knows how to execute.
+// Clients choose which subset to enable via allowedTools in their config.
+// ---------------------------------------------------------------------------
 
-/** Tools available when context.type === "feature-creator" */
-export const FEATURE_CREATOR_TOOLS: Anthropic.Tool[] = [
-  REQUEST_USER_INPUT_TOOL,
-  CREATE_FEATURE_TOOL,
-  UPDATE_FEATURE_TOOL,
-  LIST_FEATURES_TOOL,
-  GET_FEATURE_TOOL,
-  GET_FEATURE_INPUTS_TOOL,
-  PREFILL_FEATURE_TOOL,
-  GET_FEATURE_STATS_TOOL,
-];
+export const TOOL_REGISTRY: Record<string, Anthropic.Tool> = {
+  request_user_input: REQUEST_USER_INPUT_TOOL,
+  update_workflow: UPDATE_WORKFLOW_TOOL,
+  validate_workflow: VALIDATE_WORKFLOW_TOOL,
+  get_prompt_template: GET_PROMPT_TEMPLATE_TOOL,
+  update_prompt_template: UPDATE_PROMPT_TEMPLATE_TOOL,
+  update_workflow_node_config: UPDATE_WORKFLOW_NODE_CONFIG_TOOL,
+  get_workflow_details: GET_WORKFLOW_DETAILS_TOOL,
+  generate_workflow: GENERATE_WORKFLOW_TOOL,
+  get_workflow_required_providers: GET_WORKFLOW_REQUIRED_PROVIDERS_TOOL,
+  list_workflows: LIST_WORKFLOWS_TOOL,
+  list_services: LIST_SERVICES_TOOL,
+  list_service_endpoints: LIST_SERVICE_ENDPOINTS_TOOL,
+  list_org_keys: LIST_ORG_KEYS_TOOL,
+  get_key_source: GET_KEY_SOURCE_TOOL,
+  list_key_sources: LIST_KEY_SOURCES_TOOL,
+  check_provider_requirements: CHECK_PROVIDER_REQUIREMENTS_TOOL,
+  create_feature: CREATE_FEATURE_TOOL,
+  update_feature: UPDATE_FEATURE_TOOL,
+  list_features: LIST_FEATURES_TOOL,
+  get_feature: GET_FEATURE_TOOL,
+  get_feature_inputs: GET_FEATURE_INPUTS_TOOL,
+  prefill_feature: PREFILL_FEATURE_TOOL,
+  get_feature_stats: GET_FEATURE_STATS_TOOL,
+};
+
+/** All tool names available for use in allowedTools config. */
+export const AVAILABLE_TOOL_NAMES = Object.keys(TOOL_REGISTRY);
+
+/**
+ * Resolve a list of tool names to their Anthropic tool definitions.
+ * Ignores unknown names (logs a warning).
+ */
+export function resolveToolSet(allowedTools: string[]): Anthropic.Tool[] {
+  const tools: Anthropic.Tool[] = [];
+  for (const name of allowedTools) {
+    const tool = TOOL_REGISTRY[name];
+    if (tool) {
+      tools.push(tool);
+    } else {
+      console.warn(`[chat-service] Unknown tool in allowedTools: "${name}" — skipping`);
+    }
+  }
+  return tools;
+}
 
 // ---------------------------------------------------------------------------
 // Types

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -98,7 +98,36 @@ registry.registerPath({
 
 export const AppConfigRequestSchema = z
   .object({
-    systemPrompt: z.string().min(1, "systemPrompt is required"),
+    key: z.string().min(1, "key is required").openapi({
+      description:
+        "Config key — identifies which chat mode this config is for (e.g. 'workflow', 'feature', 'press-kit'). " +
+        "Each org can have multiple configs, one per key.",
+      example: "workflow",
+    }),
+    systemPrompt: z.string().min(1, "systemPrompt is required").openapi({
+      description: "System prompt sent to the LLM for this chat mode",
+      example:
+        "You are an AI assistant that helps users understand and modify their workflows.",
+    }),
+    allowedTools: z.array(z.string().min(1)).min(1, "allowedTools must contain at least one tool").openapi({
+      description:
+        "List of tool names the LLM is allowed to use in this chat mode. " +
+        "Only these tools will be provided to the model and executable server-side. " +
+        "Available tools: request_user_input, update_workflow, validate_workflow, " +
+        "get_workflow_details, generate_workflow, get_workflow_required_providers, list_workflows, " +
+        "update_workflow_node_config, get_prompt_template, update_prompt_template, " +
+        "list_services, list_service_endpoints, " +
+        "list_org_keys, get_key_source, list_key_sources, check_provider_requirements, " +
+        "create_feature, update_feature, list_features, get_feature, get_feature_inputs, " +
+        "prefill_feature, get_feature_stats",
+      example: [
+        "request_user_input",
+        "update_workflow",
+        "validate_workflow",
+        "get_workflow_details",
+        "list_workflows",
+      ],
+    }),
   })
   .strict()
   .openapi("AppConfigRequest");
@@ -106,7 +135,9 @@ export const AppConfigRequestSchema = z
 export const AppConfigResponseSchema = z
   .object({
     orgId: z.string(),
+    key: z.string(),
     systemPrompt: z.string(),
+    allowedTools: z.array(z.string()),
     createdAt: z.string(),
     updatedAt: z.string(),
   })
@@ -120,7 +151,19 @@ registry.registerPath({
   tags: ["App Config"],
   summary: "Register or update app configuration",
   description:
-    "Idempotent upsert of app configuration scoped by org (via x-org-id header). Includes system prompt. Call on every cold start.",
+    "Idempotent upsert of app configuration scoped by (orgId, key). Each key represents a chat mode " +
+    "(e.g. 'workflow', 'feature', 'press-kit'). The config defines the system prompt and which tools " +
+    "the LLM can use in that mode. Call on every cold start.\n\n" +
+    "**Example — workflow chat config:**\n" +
+    "```json\n" +
+    '{ "key": "workflow", "systemPrompt": "You help users understand and modify workflows...", ' +
+    '"allowedTools": ["request_user_input", "update_workflow", "validate_workflow", "get_workflow_details", "list_workflows", "update_workflow_node_config", "get_prompt_template", "update_prompt_template", "list_org_keys", "get_key_source", "list_key_sources", "check_provider_requirements", "list_services", "list_service_endpoints", "generate_workflow", "get_workflow_required_providers"] }\n' +
+    "```\n\n" +
+    "**Example — feature chat config:**\n" +
+    "```json\n" +
+    '{ "key": "feature", "systemPrompt": "You help users design and manage features...", ' +
+    '"allowedTools": ["request_user_input", "create_feature", "update_feature", "list_features", "get_feature", "get_feature_inputs", "prefill_feature", "get_feature_stats"] }\n' +
+    "```",
   request: {
     headers: z.object({
       "x-api-key": z.string().openapi({
@@ -165,14 +208,37 @@ registry.registerPath({
 
 export const PlatformConfigRequestSchema = z
   .object({
-    systemPrompt: z.string().min(1, "systemPrompt is required"),
+    key: z.string().min(1, "key is required").openapi({
+      description:
+        "Config key — identifies which chat mode this platform config is for. " +
+        "Used as fallback when no per-org config exists for this key.",
+      example: "workflow",
+    }),
+    systemPrompt: z.string().min(1, "systemPrompt is required").openapi({
+      description: "Default system prompt for all orgs without a per-org config for this key",
+      example:
+        "You are an AI assistant that helps users understand and modify their workflows.",
+    }),
+    allowedTools: z.array(z.string().min(1)).min(1, "allowedTools must contain at least one tool").openapi({
+      description:
+        "List of tool names the LLM is allowed to use. Same semantics as in PUT /config.",
+      example: [
+        "request_user_input",
+        "update_workflow",
+        "validate_workflow",
+        "get_workflow_details",
+        "list_workflows",
+      ],
+    }),
   })
   .strict()
   .openapi("PlatformConfigRequest");
 
 export const PlatformConfigResponseSchema = z
   .object({
+    key: z.string(),
     systemPrompt: z.string(),
+    allowedTools: z.array(z.string()),
     createdAt: z.string(),
     updatedAt: z.string(),
   })
@@ -186,7 +252,13 @@ registry.registerPath({
   tags: ["Platform Config"],
   summary: "Register or update platform-wide chat configuration",
   description:
-    "Idempotent upsert of a global chat configuration (not scoped to any org). Used as fallback when no per-org config exists. Auth: X-API-Key only — no x-org-id, x-user-id, or x-run-id required. Called on every cold start by api-service.",
+    "Idempotent upsert of a platform-wide chat configuration keyed by `key`. " +
+    "Used as fallback when no per-org config exists for the same key. " +
+    "Auth: X-API-Key only — no x-org-id, x-user-id, or x-run-id required. " +
+    "Called on every cold start by api-service.\n\n" +
+    "**Config resolution in POST /chat:** " +
+    "Per-org config `(orgId, configKey)` takes priority. If none exists, " +
+    "platform config `(configKey)` is used. If neither exists → 404.",
   request: {
     headers: z.object({
       "x-api-key": z.string().openapi({
@@ -341,13 +413,20 @@ Unlike POST /chat, this endpoint:
 
 export const ChatRequestSchema = z
   .object({
+    configKey: z.string().min(1, "configKey is required").openapi({
+      description:
+        "Which chat config to use for this request. Must match a key registered via PUT /config " +
+        "(per-org) or PUT /platform-config (platform-wide fallback). " +
+        "Examples: 'workflow', 'feature', 'press-kit'.",
+      example: "workflow",
+    }),
     message: z.string().min(1, "message is required").openapi({
       description: "The user's chat message",
       example: "What campaigns are performing best this week?",
     }),
     sessionId: z.string().uuid().nullish().openapi({
       description:
-        "UUID of an existing session to continue. Omit to create a new session. " +
+        "UUID of an existing session to continue. Omit or pass null to start a new conversation. " +
         "When omitted, the service creates a new session and returns its ID in the first SSE event " +
         '({"sessionId":"<uuid>"}). Use that ID in subsequent requests to continue the conversation. ' +
         "If a sessionId is provided but does not exist or belongs to a different org, the stream " +
@@ -356,12 +435,16 @@ export const ChatRequestSchema = z
     }),
     context: z.record(z.string(), z.unknown()).optional().openapi({
       description:
-        "Free-form JSON injected into the system prompt for this request only (not stored). " +
-        "Use this to pass dynamic data like brand URLs, campaign objectives, budgets, etc.",
+        "Free-form JSON context provided by the frontend (not user-editable). " +
+        "Injected into the system prompt for this request only (not stored). " +
+        "Re-send on every message — the service does not cache it. " +
+        "Use this to pass the current page state: workflow details, brand info, etc.",
       example: {
+        workflowId: "wf-550e8400-e29b-41d4-a716-446655440000",
+        workflowSlug: "cold-email-outreach",
+        workflowName: "Cold Email Outreach",
+        brandId: "brand-123",
         brandUrl: "https://example.com",
-        objective: "clicks",
-        budgetAmount: 500,
       },
     }),
   })
@@ -521,26 +604,35 @@ registry.registerPath({
   summary: "Stream AI chat response",
   description: `Send a message and receive a streamed AI response via Server-Sent Events (SSE).
 
+**Config resolution:**
+The \`configKey\` field selects which chat config to use. Resolution order:
+1. Per-org config: \`(orgId, configKey)\` from PUT /config
+2. Platform config: \`(configKey)\` from PUT /platform-config
+3. If neither exists → 404
+
+The selected config determines both the system prompt and which tools the LLM can use.
+
 **Session lifecycle:**
-- To start a new conversation, omit \`sessionId\`. The first SSE event will be \`{"sessionId":"<uuid>"}\` — store this ID.
+- To start a new conversation, omit \`sessionId\` (or pass \`null\`). The first SSE event will be \`{"sessionId":"<uuid>"}\` — store this ID.
 - To continue a conversation, pass that \`sessionId\` in subsequent requests.
-- If a provided \`sessionId\` does not exist or belongs to a different org, the stream returns an error and closes.
+- To reset a conversation (e.g. after a fork), omit \`sessionId\` and send a new \`context\`.
+
+**Context:**
+The \`context\` field is a free-form JSON object provided by the frontend on **every** message. It is injected into the system prompt but not stored. Re-send it on every request — the service does not cache it. After a fork (e.g. workflow updated → new workflow created), the frontend should update its context with the new IDs and either continue the session or start a new one.
 
 **SSE event order:**
 Each \`data:\` line contains a JSON object. Events arrive in this order:
 
 1. **Session** — \`{"sessionId":"<uuid>"}\` (always first)
-2. **Thinking** _(optional)_ — \`thinking_start\` → one or more \`thinking_delta\` → \`thinking_stop\`. May appear before tokens and after tool results.
-3. **Tokens** — \`{"type":"token","content":"..."}\` streamed incrementally as the AI generates text.
-4. **Tool calls** _(optional, repeatable)_ — \`tool_call\` followed by \`tool_result\`, then more thinking/tokens as the AI continues.
+2. **Thinking** _(optional)_ — \`thinking_start\` → one or more \`thinking_delta\` → \`thinking_stop\`.
+3. **Tokens** — \`{"type":"token","content":"..."}\` streamed incrementally.
+4. **Tool calls** _(optional, repeatable)_ — \`tool_call\` followed by \`tool_result\`, then more thinking/tokens.
 5. **Input request** _(optional)_ — \`input_request\` when the AI needs structured user input (terminates the response).
 6. **Buttons** _(optional)_ — \`{"type":"buttons","buttons":[...]}\` with quick-reply options, sent after all tokens.
-7. **Error** _(optional)_ — \`{"type":"error","message":"..."}\` if the AI model returns an empty response (context overflow, safety filter) or an unexpected error occurs. Sent before \`[DONE]\`.
+7. **Error** _(optional)_ — \`{"type":"error","message":"..."}\` if something goes wrong. Sent before \`[DONE]\`.
 8. **Done** — \`"[DONE]"\` (always last).
 
-See the SSE event schemas (SSESessionEvent, SSETokenEvent, SSEThinkingStartEvent, SSEThinkingDeltaEvent, SSEThinkingStopEvent, SSEToolCallEvent, SSEToolResultEvent, SSEInputRequestEvent, SSEButtonsEvent, SSEErrorEvent) in components/schemas for exact payload shapes.
-
-Requires app config to be registered first via PUT /config (or platform config via PUT /platform-config as fallback).`,
+**Available tools** depend on the config's \`allowedTools\`. The LLM only sees and can call the tools listed there. See PUT /config documentation for the full list of available tool names.`,
   request: {
     headers: z.object({
       "x-api-key": z.string().openapi({

--- a/tests/unit/anthropic.test.ts
+++ b/tests/unit/anthropic.test.ts
@@ -42,13 +42,13 @@ import {
   GET_FEATURE_TOOL,
   LIST_SERVICES_TOOL,
   LIST_SERVICE_ENDPOINTS_TOOL,
-  CALL_API_TOOL,
   LIST_ORG_KEYS_TOOL,
   GET_KEY_SOURCE_TOOL,
   LIST_KEY_SOURCES_TOOL,
   CHECK_PROVIDER_REQUIREMENTS_TOOL,
-  BUILTIN_TOOLS,
-  FEATURE_CREATOR_TOOLS,
+  TOOL_REGISTRY,
+  AVAILABLE_TOOL_NAMES,
+  resolveToolSet,
 } from "../../src/lib/anthropic.js";
 
 const TEST_PROMPT = "You are a test assistant.";
@@ -358,7 +358,7 @@ describe("streaming events", () => {
     });
     const stream = client.createStream(
       [{ role: "user", content: "show workflow" }],
-      BUILTIN_TOOLS,
+      resolveToolSet(AVAILABLE_TOOL_NAMES),
     );
 
     for await (const _ of stream) {
@@ -510,36 +510,34 @@ describe("VALIDATE_WORKFLOW_TOOL", () => {
   });
 });
 
-describe("BUILTIN_TOOLS", () => {
-  it("includes all built-in tools", () => {
-    const names = BUILTIN_TOOLS.map((t) => t.name);
-    // Workflow tools
-    expect(names).toContain("request_user_input");
-    expect(names).toContain("update_workflow");
-    expect(names).toContain("validate_workflow");
-    expect(names).toContain("get_prompt_template");
-    expect(names).toContain("update_prompt_template");
-    expect(names).toContain("update_workflow_node_config");
-    expect(names).toContain("get_workflow_details");
-    expect(names).toContain("get_workflow_required_providers");
-    expect(names).toContain("list_workflows");
-    // API Registry progressive disclosure
-    expect(names).toContain("list_services");
-    expect(names).toContain("list_service_endpoints");
-    expect(names).toContain("call_api");
-    // Key-service read tools
-    expect(names).toContain("list_org_keys");
-    expect(names).toContain("get_key_source");
-    expect(names).toContain("list_key_sources");
-    expect(names).toContain("check_provider_requirements");
-    // Removed
-    expect(names).not.toContain("list_available_services");
-    expect(names).not.toContain("generate_workflow");
-    expect(BUILTIN_TOOLS).toHaveLength(16);
+describe("TOOL_REGISTRY", () => {
+  it("contains all expected tools", () => {
+    expect(AVAILABLE_TOOL_NAMES).toContain("request_user_input");
+    expect(AVAILABLE_TOOL_NAMES).toContain("update_workflow");
+    expect(AVAILABLE_TOOL_NAMES).toContain("validate_workflow");
+    expect(AVAILABLE_TOOL_NAMES).toContain("get_prompt_template");
+    expect(AVAILABLE_TOOL_NAMES).toContain("update_prompt_template");
+    expect(AVAILABLE_TOOL_NAMES).toContain("update_workflow_node_config");
+    expect(AVAILABLE_TOOL_NAMES).toContain("get_workflow_details");
+    expect(AVAILABLE_TOOL_NAMES).toContain("generate_workflow");
+    expect(AVAILABLE_TOOL_NAMES).toContain("get_workflow_required_providers");
+    expect(AVAILABLE_TOOL_NAMES).toContain("list_workflows");
+    expect(AVAILABLE_TOOL_NAMES).toContain("list_services");
+    expect(AVAILABLE_TOOL_NAMES).toContain("list_service_endpoints");
+    expect(AVAILABLE_TOOL_NAMES).toContain("list_org_keys");
+    expect(AVAILABLE_TOOL_NAMES).toContain("get_key_source");
+    expect(AVAILABLE_TOOL_NAMES).toContain("list_key_sources");
+    expect(AVAILABLE_TOOL_NAMES).toContain("check_provider_requirements");
+    expect(AVAILABLE_TOOL_NAMES).toContain("create_feature");
+    expect(AVAILABLE_TOOL_NAMES).toContain("update_feature");
+  });
+
+  it("does NOT contain call_api (removed for security)", () => {
+    expect(AVAILABLE_TOOL_NAMES).not.toContain("call_api");
   });
 
   it("all tools use Anthropic input_schema format", () => {
-    for (const tool of BUILTIN_TOOLS) {
+    for (const tool of Object.values(TOOL_REGISTRY)) {
       expect(tool.input_schema).toBeDefined();
       expect(tool.input_schema.type).toBe("object");
       expect(tool).toHaveProperty("name");
@@ -562,14 +560,8 @@ describe("API Registry progressive disclosure tools", () => {
     expect(schema.required).toEqual(["service"]);
   });
 
-  it("CALL_API_TOOL requires service, method, path", () => {
-    expect(CALL_API_TOOL.name).toBe("call_api");
-    const schema = CALL_API_TOOL.input_schema as {
-      properties: Record<string, unknown>;
-      required: string[];
-    };
-    expect(schema.required).toEqual(["service", "method", "path"]);
-    expect(schema.properties).toHaveProperty("body");
+  it("call_api is NOT in the tool registry (removed for security)", () => {
+    expect(TOOL_REGISTRY["call_api"]).toBeUndefined();
   });
 });
 
@@ -688,25 +680,17 @@ describe("Feature-creator tools", () => {
   });
 });
 
-describe("FEATURE_CREATOR_TOOLS", () => {
-  it("includes all 8 feature-creator tools", () => {
-    const names = FEATURE_CREATOR_TOOLS.map((t) => t.name);
-    expect(names).toContain("request_user_input");
-    expect(names).toContain("create_feature");
-    expect(names).toContain("update_feature");
-    expect(names).toContain("list_features");
-    expect(names).toContain("get_feature");
-    expect(names).toContain("get_feature_inputs");
-    expect(names).toContain("prefill_feature");
-    expect(names).toContain("get_feature_stats");
-    expect(FEATURE_CREATOR_TOOLS).toHaveLength(8);
+describe("resolveToolSet", () => {
+  it("resolves a subset of tools from the registry", () => {
+    const tools = resolveToolSet(["request_user_input", "create_feature", "update_feature"]);
+    expect(tools).toHaveLength(3);
+    expect(tools.map((t) => t.name)).toEqual(["request_user_input", "create_feature", "update_feature"]);
   });
 
-  it("does not include workflow tools", () => {
-    const names = FEATURE_CREATOR_TOOLS.map((t) => t.name);
-    expect(names).not.toContain("update_workflow");
-    expect(names).not.toContain("list_workflows");
-    expect(names).not.toContain("get_workflow_details");
+  it("skips unknown tool names gracefully", () => {
+    const tools = resolveToolSet(["request_user_input", "nonexistent_tool"]);
+    expect(tools).toHaveLength(1);
+    expect(tools[0].name).toBe("request_user_input");
   });
 });
 

--- a/tests/unit/app-config.test.ts
+++ b/tests/unit/app-config.test.ts
@@ -2,28 +2,76 @@ import { describe, it, expect } from "vitest";
 import { AppConfigRequestSchema } from "../../src/schemas.js";
 
 describe("AppConfigRequestSchema", () => {
-  it("accepts valid config with systemPrompt only", () => {
+  it("accepts valid config with key, systemPrompt, and allowedTools", () => {
     const result = AppConfigRequestSchema.safeParse({
+      key: "workflow",
       systemPrompt: "You are a helpful assistant.",
+      allowedTools: ["request_user_input", "update_workflow"],
     });
     expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.key).toBe("workflow");
+      expect(result.data.systemPrompt).toBe("You are a helpful assistant.");
+      expect(result.data.allowedTools).toEqual(["request_user_input", "update_workflow"]);
+    }
+  });
+
+  it("rejects missing key", () => {
+    const result = AppConfigRequestSchema.safeParse({
+      systemPrompt: "You are a helpful assistant.",
+      allowedTools: ["request_user_input"],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty key", () => {
+    const result = AppConfigRequestSchema.safeParse({
+      key: "",
+      systemPrompt: "You are a helpful assistant.",
+      allowedTools: ["request_user_input"],
+    });
+    expect(result.success).toBe(false);
   });
 
   it("rejects empty systemPrompt", () => {
     const result = AppConfigRequestSchema.safeParse({
+      key: "workflow",
       systemPrompt: "",
+      allowedTools: ["request_user_input"],
     });
     expect(result.success).toBe(false);
   });
 
   it("rejects missing systemPrompt", () => {
-    const result = AppConfigRequestSchema.safeParse({});
+    const result = AppConfigRequestSchema.safeParse({
+      key: "workflow",
+      allowedTools: ["request_user_input"],
+    });
     expect(result.success).toBe(false);
   });
 
-  it("rejects unknown fields (e.g. deprecated mcpServerUrl)", () => {
+  it("rejects missing allowedTools", () => {
     const result = AppConfigRequestSchema.safeParse({
+      key: "workflow",
       systemPrompt: "You are a helpful assistant.",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty allowedTools array", () => {
+    const result = AppConfigRequestSchema.safeParse({
+      key: "workflow",
+      systemPrompt: "You are a helpful assistant.",
+      allowedTools: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects unknown fields (strict mode)", () => {
+    const result = AppConfigRequestSchema.safeParse({
+      key: "workflow",
+      systemPrompt: "You are a helpful assistant.",
+      allowedTools: ["request_user_input"],
       mcpServerUrl: "https://mcp.example.com",
     });
     expect(result.success).toBe(false);

--- a/tests/unit/platform-config.test.ts
+++ b/tests/unit/platform-config.test.ts
@@ -2,28 +2,75 @@ import { describe, it, expect } from "vitest";
 import { PlatformConfigRequestSchema } from "../../src/schemas.js";
 
 describe("PlatformConfigRequestSchema", () => {
-  it("accepts valid config with systemPrompt only", () => {
+  it("accepts valid config with key, systemPrompt, and allowedTools", () => {
     const result = PlatformConfigRequestSchema.safeParse({
+      key: "workflow",
       systemPrompt: "You are a helpful assistant.",
+      allowedTools: ["request_user_input", "update_workflow"],
     });
     expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.key).toBe("workflow");
+      expect(result.data.allowedTools).toEqual(["request_user_input", "update_workflow"]);
+    }
+  });
+
+  it("rejects missing key", () => {
+    const result = PlatformConfigRequestSchema.safeParse({
+      systemPrompt: "You are a helpful assistant.",
+      allowedTools: ["request_user_input"],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty key", () => {
+    const result = PlatformConfigRequestSchema.safeParse({
+      key: "",
+      systemPrompt: "You are a helpful assistant.",
+      allowedTools: ["request_user_input"],
+    });
+    expect(result.success).toBe(false);
   });
 
   it("rejects empty systemPrompt", () => {
     const result = PlatformConfigRequestSchema.safeParse({
+      key: "workflow",
       systemPrompt: "",
+      allowedTools: ["request_user_input"],
     });
     expect(result.success).toBe(false);
   });
 
   it("rejects missing systemPrompt", () => {
-    const result = PlatformConfigRequestSchema.safeParse({});
+    const result = PlatformConfigRequestSchema.safeParse({
+      key: "workflow",
+      allowedTools: ["request_user_input"],
+    });
     expect(result.success).toBe(false);
   });
 
-  it("rejects unknown fields (e.g. deprecated mcpServerUrl)", () => {
+  it("rejects missing allowedTools", () => {
     const result = PlatformConfigRequestSchema.safeParse({
+      key: "workflow",
       systemPrompt: "You are a helpful assistant.",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty allowedTools array", () => {
+    const result = PlatformConfigRequestSchema.safeParse({
+      key: "workflow",
+      systemPrompt: "You are a helpful assistant.",
+      allowedTools: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects unknown fields (strict mode)", () => {
+    const result = PlatformConfigRequestSchema.safeParse({
+      key: "workflow",
+      systemPrompt: "You are a helpful assistant.",
+      allowedTools: ["request_user_input"],
       mcpServerUrl: "https://mcp.example.com",
     });
     expect(result.success).toBe(false);

--- a/tests/unit/schemas.test.ts
+++ b/tests/unit/schemas.test.ts
@@ -2,12 +2,14 @@ import { describe, it, expect } from "vitest";
 import { ChatRequestSchema } from "../../src/schemas.js";
 
 describe("ChatRequestSchema", () => {
-  it("accepts valid request with message", () => {
+  it("accepts valid request with configKey and message", () => {
     const result = ChatRequestSchema.safeParse({
+      configKey: "workflow",
       message: "Hello",
     });
     expect(result.success).toBe(true);
     if (result.success) {
+      expect(result.data.configKey).toBe("workflow");
       expect(result.data.message).toBe("Hello");
       expect(result.data.sessionId).toBeUndefined();
       expect(result.data.context).toBeUndefined();
@@ -16,54 +18,67 @@ describe("ChatRequestSchema", () => {
 
   it("accepts valid request with all fields", () => {
     const result = ChatRequestSchema.safeParse({
+      configKey: "workflow",
       message: "Hello",
       sessionId: "550e8400-e29b-41d4-a716-446655440000",
-      context: { brandUrl: "https://example.com", budget: 500 },
+      context: { workflowId: "wf-123", brandUrl: "https://example.com" },
     });
     expect(result.success).toBe(true);
     if (result.success) {
+      expect(result.data.configKey).toBe("workflow");
       expect(result.data.context).toEqual({
+        workflowId: "wf-123",
         brandUrl: "https://example.com",
-        budget: 500,
       });
     }
   });
 
+  it("rejects missing configKey", () => {
+    const result = ChatRequestSchema.safeParse({
+      message: "Hello",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty configKey", () => {
+    const result = ChatRequestSchema.safeParse({
+      configKey: "",
+      message: "Hello",
+    });
+    expect(result.success).toBe(false);
+  });
+
   it("rejects empty message", () => {
     const result = ChatRequestSchema.safeParse({
+      configKey: "workflow",
       message: "",
     });
     expect(result.success).toBe(false);
   });
 
   it("rejects missing message", () => {
-    const result = ChatRequestSchema.safeParse({});
+    const result = ChatRequestSchema.safeParse({
+      configKey: "workflow",
+    });
     expect(result.success).toBe(false);
-  });
-
-  it("does not require appId (removed from contract)", () => {
-    const result = ChatRequestSchema.safeParse({ message: "Hello" });
-    expect(result.success).toBe(true);
   });
 
   it("accepts sessionId: null (reset chat sends null)", () => {
     const result = ChatRequestSchema.safeParse({
+      configKey: "feature",
       message: "Hello",
       sessionId: null,
-      context: { type: "workflow-viewer", workflowId: "wf-123" },
+      context: { featureSlug: "cold-email-outreach" },
     });
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.sessionId).toBeNull();
-      expect(result.data.context).toEqual({
-        type: "workflow-viewer",
-        workflowId: "wf-123",
-      });
     }
   });
 
   it("rejects non-uuid sessionId", () => {
     const result = ChatRequestSchema.safeParse({
+      configKey: "workflow",
       message: "Hello",
       sessionId: "not-a-uuid",
     });
@@ -72,6 +87,7 @@ describe("ChatRequestSchema", () => {
 
   it("accepts context with any JSON structure", () => {
     const result = ChatRequestSchema.safeParse({
+      configKey: "workflow",
       message: "Hello",
       context: {
         nested: { deep: true },
@@ -84,6 +100,7 @@ describe("ChatRequestSchema", () => {
 
   it("strips extra fields", () => {
     const result = ChatRequestSchema.safeParse({
+      configKey: "workflow",
       message: "Hello",
       extra: "field",
       appId: "leftover-app-id",

--- a/tests/unit/tool-registry.test.ts
+++ b/tests/unit/tool-registry.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { TOOL_REGISTRY, AVAILABLE_TOOL_NAMES, resolveToolSet } from "../../src/lib/anthropic.js";
+
+describe("TOOL_REGISTRY", () => {
+  it("contains all expected tools", () => {
+    expect(AVAILABLE_TOOL_NAMES).toContain("request_user_input");
+    expect(AVAILABLE_TOOL_NAMES).toContain("update_workflow");
+    expect(AVAILABLE_TOOL_NAMES).toContain("create_feature");
+    expect(AVAILABLE_TOOL_NAMES).toContain("list_services");
+  });
+
+  it("does NOT contain call_api (removed for security)", () => {
+    expect(AVAILABLE_TOOL_NAMES).not.toContain("call_api");
+    expect(TOOL_REGISTRY["call_api"]).toBeUndefined();
+  });
+
+  it("has matching names in registry keys and tool definitions", () => {
+    for (const [key, tool] of Object.entries(TOOL_REGISTRY)) {
+      expect(tool.name).toBe(key);
+    }
+  });
+});
+
+describe("resolveToolSet", () => {
+  it("resolves known tools to their definitions", () => {
+    const tools = resolveToolSet(["request_user_input", "update_workflow"]);
+    expect(tools).toHaveLength(2);
+    expect(tools[0].name).toBe("request_user_input");
+    expect(tools[1].name).toBe("update_workflow");
+  });
+
+  it("skips unknown tool names", () => {
+    const tools = resolveToolSet(["request_user_input", "nonexistent_tool"]);
+    expect(tools).toHaveLength(1);
+    expect(tools[0].name).toBe("request_user_input");
+  });
+
+  it("returns empty array for empty input", () => {
+    const tools = resolveToolSet([]);
+    expect(tools).toHaveLength(0);
+  });
+
+  it("returns all tools when given all names", () => {
+    const tools = resolveToolSet(AVAILABLE_TOOL_NAMES);
+    expect(tools).toHaveLength(AVAILABLE_TOOL_NAMES.length);
+  });
+});


### PR DESCRIPTION
## Summary

- **Keyed configs**: `PUT /config` and `PUT /platform-config` now accept `key` + `allowedTools`. Each org can register multiple configs (e.g. `"workflow"`, `"feature"`, `"press-kit"`), each with its own system prompt and tool set.
- **`configKey` in POST /chat**: Clients must specify which config to use. Resolution: per-org `(orgId, configKey)` → platform `(configKey)` → 404.
- **Tool guard**: `executeTool` rejects any tool call not in the config's `allowedTools`. No more hardcoded `BUILTIN_TOOLS` / `FEATURE_CREATOR_TOOLS` arrays.
- **Security fix**: Removed `call_api` tool entirely — it gave the LLM unrestricted admin-key access to all services via api-service.
- **DB migration**: `app_configs` unique on `(orgId, key)` instead of `(orgId)`. Both tables get `allowed_tools` jsonb column. Existing rows default to the old BUILTIN_TOOLS set.

## Breaking changes

- `POST /chat` body now **requires** `configKey` (string). Existing clients that don't send it will get 400.
- `PUT /config` body now **requires** `key` and `allowedTools`. Existing cold-start code must be updated.
- `PUT /platform-config` body now **requires** `key` and `allowedTools`.
- `call_api` tool no longer exists. Configs that included it will log a warning (tool skipped).

## Test plan

- [x] All 315 unit tests pass
- [x] Build + OpenAPI generation succeeds
- [ ] Integration tests (CI)
- [ ] API-service cold-start code updated to send `key` + `allowedTools`
- [ ] Dashboard POST /chat calls updated to include `configKey`

🤖 Generated with [Claude Code](https://claude.com/claude-code)