### PR TITLE
fix: make configKey optional with default for backwards compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Request body:
 }
 ```
 
-- `configKey` (required) — which config to use (must match a key from `PUT /config` or `PUT /platform-config`)
+- `configKey` (optional, default `"default"`) — which config to use (must match a key from `PUT /config` or `PUT /platform-config`)
 - `message` (required) — the user's chat message
 - `sessionId` (optional, nullable) — UUID of an existing session to continue. **Omit or pass `null` to start a new conversation** — the service creates the session and returns its ID in the first SSE event (`{"sessionId":"<uuid>"}`). Store that ID and pass it in subsequent requests. If a provided `sessionId` does not exist or belongs to a different org, the stream returns `"Session not found."` and closes. **Do not generate your own UUID** — always use the one returned by the service.
 - `context` (optional) — free-form JSON provided by the **frontend** (not user-editable). Injected into the system prompt for this request only (not stored). **Re-send on every message** — the service does not cache it. After a fork (e.g. workflow updated → new workflow created), update the context with the new IDs.

--- a/openapi.json
+++ b/openapi.json
@@ -562,7 +562,8 @@
           "configKey": {
             "type": "string",
             "minLength": 1,
-            "description": "Which chat config to use for this request. Must match a key registered via PUT /config (per-org) or PUT /platform-config (platform-wide fallback). Examples: 'workflow', 'feature', 'press-kit'.",
+            "default": "default",
+            "description": "Which chat config to use for this request. Must match a key registered via PUT /config (per-org) or PUT /platform-config (platform-wide fallback). Defaults to 'default' if omitted. Examples: 'workflow', 'feature', 'press-kit'.",
             "example": "workflow"
           },
           "message": {
@@ -594,7 +595,6 @@
           }
         },
         "required": [
-          "configKey",
           "message"
         ]
       }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -413,11 +413,11 @@ Unlike POST /chat, this endpoint:
 
 export const ChatRequestSchema = z
   .object({
-    configKey: z.string().min(1, "configKey is required").openapi({
+    configKey: z.string().min(1).default("default").openapi({
       description:
         "Which chat config to use for this request. Must match a key registered via PUT /config " +
         "(per-org) or PUT /platform-config (platform-wide fallback). " +
-        "Examples: 'workflow', 'feature', 'press-kit'.",
+        "Defaults to 'default' if omitted. Examples: 'workflow', 'feature', 'press-kit'.",
       example: "workflow",
     }),
     message: z.string().min(1, "message is required").openapi({

--- a/tests/unit/schemas.test.ts
+++ b/tests/unit/schemas.test.ts
@@ -33,11 +33,14 @@ describe("ChatRequestSchema", () => {
     }
   });
 
-  it("rejects missing configKey", () => {
+  it("defaults configKey to 'default' when omitted", () => {
     const result = ChatRequestSchema.safeParse({
       message: "Hello",
     });
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.configKey).toBe("default");
+    }
   });
 
   it("rejects empty configKey", () => {


### PR DESCRIPTION
## Summary
- PR #108 made `configKey` a required field on `POST /chat`, but the frontend hasn't been updated to send it yet
- This caused all chat requests from the dashboard to fail with 400 validation errors
- Makes `configKey` optional with a default of `"default"` so existing clients continue to work

## Test plan
- [x] Unit test updated: "rejects missing configKey" → "defaults configKey to 'default' when omitted"
- [x] All 316 unit tests pass
- [x] OpenAPI spec regenerated
- [x] README updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)