### PR TITLE
feat: add debug logs for context injection in /chat

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -375,6 +375,10 @@ app.post("/chat", requireAuth, async (req, res) => {
 
   const { configKey, message, sessionId, context } = parsed.data;
 
+  // Debug: log what the client sent for context
+  const contextKeys = context ? Object.keys(context) : [];
+  console.log(`[chat-service] configKey="${configKey}" sessionId=${sessionId ?? "new"} context=${contextKeys.length > 0 ? `{${contextKeys.join(", ")}} (${JSON.stringify(context).length} chars)` : "EMPTY"}`);
+
   // Look up app config by (orgId, configKey), fall back to platform config by configKey
   const [orgConfig] = await db
     .select()
@@ -471,6 +475,7 @@ app.post("/chat", requireAuth, async (req, res) => {
 
   // Build system prompt with optional context and campaign feature inputs
   const systemPrompt = buildSystemPrompt(appConfig.systemPrompt, context, campaignFeatureInputs);
+  console.log(`[chat-service] systemPrompt length=${systemPrompt.length} chars, has context block=${systemPrompt.includes("Additional Context")}`);
   const claude = createAnthropicClient({ apiKey: resolvedKey.key, systemPrompt });
 
   let runId: string | null = null;


### PR DESCRIPTION
## Summary
- Adds two `console.log` lines in the `/chat` endpoint to trace context injection
- Logs: `configKey`, `sessionId`, context keys + size, and whether the system prompt contains the context block
- Helps diagnose the reported issue where the LLM ignores feature context

## Test plan
- [x] All unit tests pass
- [ ] Deploy to staging, send a chat with `configKey: "feature"` and a `context` object, verify logs show context keys and size
- [ ] Send a chat without context, verify logs show `context=EMPTY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)