### PR TITLE
feat: log full context JSON for debugging context injection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -377,7 +377,10 @@ app.post("/chat", requireAuth, async (req, res) => {
 
   // Debug: log what the client sent for context
   const contextKeys = context ? Object.keys(context) : [];
-  console.log(`[chat-service] configKey="${configKey}" sessionId=${sessionId ?? "new"} context=${contextKeys.length > 0 ? `{${contextKeys.join(", ")}} (${JSON.stringify(context).length} chars)` : "EMPTY"}`);
+  console.log(`[chat-service] POST /chat configKey="${configKey}" sessionId=${sessionId ?? "new"} context=${contextKeys.length > 0 ? `{${contextKeys.join(", ")}} (${JSON.stringify(context).length} chars)` : "EMPTY"}`);
+  if (context && contextKeys.length > 0) {
+    console.log(`[chat-service] context received: ${JSON.stringify(context)}`);
+  }
 
   // Look up app config by (orgId, configKey), fall back to platform config by configKey
   const [orgConfig] = await db
@@ -475,7 +478,7 @@ app.post("/chat", requireAuth, async (req, res) => {
 
   // Build system prompt with optional context and campaign feature inputs
   const systemPrompt = buildSystemPrompt(appConfig.systemPrompt, context, campaignFeatureInputs);
-  console.log(`[chat-service] systemPrompt length=${systemPrompt.length} chars, has context block=${systemPrompt.includes("Additional Context")}`);
+  console.log(`[chat-service] systemPrompt length=${systemPrompt.length} chars, has context block=${systemPrompt.includes("Additional Context")}, has campaign block=${systemPrompt.includes("Campaign Context")}`);
   const claude = createAnthropicClient({ apiKey: resolvedKey.key, systemPrompt });
 
   let runId: string | null = null;


### PR DESCRIPTION
## Summary
- Adds `[chat-service] context received: <full JSON>` log when context is present in POST /chat, so we can verify in Railway logs whether api-service forwards the `context` field correctly
- Adds `has campaign block=` to the system prompt summary log for completeness

## Test plan
- [x] Unit tests pass (existing buildSystemPrompt tests cover injection logic)
- [ ] Deploy, then trigger a POST /chat with `configKey: "workflow"` and a `context` containing `workflowId` — verify the full JSON appears in Railway logs


🤖 Generated with [Claude Code](https://claude.com/claude-code)