### PR TITLE
fix: forbid list_workflows when workflow context is present

### DIFF
--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -841,15 +841,33 @@ export function buildSystemPrompt(
 
   if (context && Object.keys(context).length > 0) {
     const contextKeys = Object.keys(context);
-    prompt += [
+    const lines: string[] = [
       `\n\n---\n## Additional Context (this request only)`,
       JSON.stringify(context, null, 2),
       `\n## IMPORTANT: Context Usage Rules`,
       `The values above (${contextKeys.join(", ")}) are already known — use them directly when calling tools.`,
       `Do NOT call request_user_input to ask for any value that is already present in this context.`,
-      `For example, if workflowId is in context and you need to update or validate the workflow, pass it directly to the tool.`,
       `Only use request_user_input when you genuinely need information that is NOT available in context or conversation history.`,
-    ].join("\n");
+    ];
+
+    // Workflow-specific instructions: when we already have the workflow, forbid redundant lookups
+    if (context.workflowId || (context.workflow && typeof context.workflow === "object")) {
+      const wfId = (context.workflowId as string) ?? (context.workflow as Record<string, unknown>)?.id;
+      lines.push(
+        `\n## Workflow Context — CRITICAL`,
+        `The current workflow ID is: ${wfId}`,
+        `The workflow details (DAG, slug, metadata) are ALREADY provided in the context above.`,
+        `You MUST:`,
+        `- Pass "${wfId}" directly as workflowId to any tool that needs it (update_workflow, validate_workflow, update_workflow_node_config, get_prompt_template, update_prompt_template, etc.)`,
+        `- Use the DAG and metadata from the context above — do NOT call get_workflow_details to re-fetch what you already have`,
+        `You MUST NOT:`,
+        `- Call list_workflows to search for or find this workflow — you already have it`,
+        `- Call get_workflow_details to fetch details you already have in context (only call it AFTER making changes to see the updated state)`,
+        `- Call request_user_input to ask for the workflow ID — you already have it`,
+      );
+    }
+
+    prompt += lines.join("\n");
   }
 
   return prompt;

--- a/tests/unit/anthropic.test.ts
+++ b/tests/unit/anthropic.test.ts
@@ -413,6 +413,36 @@ describe("buildSystemPrompt", () => {
     expect(result).toContain("use them directly when calling tools");
   });
 
+  it("adds workflow-specific CRITICAL section when workflowId is in context", () => {
+    const result = buildSystemPrompt("Base prompt.", {
+      workflowId: "wf-abc-123",
+      workflow: { id: "wf-abc-123", slug: "cold-email" },
+      dag: { nodes: [] },
+    });
+    expect(result).toContain("## Workflow Context — CRITICAL");
+    expect(result).toContain('The current workflow ID is: wf-abc-123');
+    expect(result).toContain("MUST NOT");
+    expect(result).toContain("Call list_workflows");
+    expect(result).toContain("Call get_workflow_details to fetch details you already have");
+  });
+
+  it("extracts workflowId from nested workflow object when top-level workflowId missing", () => {
+    const result = buildSystemPrompt("Base prompt.", {
+      workflow: { id: "wf-nested-456", slug: "pr-outreach" },
+    });
+    expect(result).toContain("## Workflow Context — CRITICAL");
+    expect(result).toContain("wf-nested-456");
+    expect(result).toContain("Call list_workflows");
+  });
+
+  it("does NOT add workflow section when no workflow data in context", () => {
+    const result = buildSystemPrompt("Base prompt.", {
+      brandUrl: "https://example.com",
+    });
+    expect(result).not.toContain("## Workflow Context");
+    expect(result).not.toContain("list_workflows");
+  });
+
   it("appends campaign context section when provided", () => {
     const result = buildSystemPrompt("Base.", undefined, {
       angle: "sustainability",


### PR DESCRIPTION
## Summary
- **Root cause:** `buildSystemPrompt` injected the context as a JSON blob with generic rules ("don't call request_user_input for known values"), but never explicitly told the model to stop calling `list_workflows` or `get_workflow_details` when the workflow was already in context. The model had no strong directive connecting the JSON blob to specific tool behavior.
- **Fix:** When context contains `workflowId` or `workflow.id`, inject a `## Workflow Context — CRITICAL` section that states the workflow ID in plain text, explicitly forbids `list_workflows` and redundant `get_workflow_details`, and instructs the model to pass the ID directly to tools.
- Extracts `workflowId` from either top-level `context.workflowId` or nested `context.workflow.id` (covers both dashboard shapes)

## Test plan
- [x] 3 new unit tests: workflow-specific section present, nested ID extraction, no section for non-workflow context
- [x] All 318 unit tests pass
- [ ] Deploy and verify: send a chat message with workflow context → AI should use workflowId directly, not call list_workflows


🤖 Generated with [Claude Code](https://claude.com/claude-code)