### PR TITLE
fix: remove redundant LLM instructions from context injection

### DIFF
--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -840,34 +840,10 @@ export function buildSystemPrompt(
   }
 
   if (context && Object.keys(context).length > 0) {
-    const contextKeys = Object.keys(context);
-    const lines: string[] = [
+    prompt += [
       `\n\n---\n## Additional Context (this request only)`,
       JSON.stringify(context, null, 2),
-      `\n## IMPORTANT: Context Usage Rules`,
-      `The values above (${contextKeys.join(", ")}) are already known — use them directly when calling tools.`,
-      `Do NOT call request_user_input to ask for any value that is already present in this context.`,
-      `Only use request_user_input when you genuinely need information that is NOT available in context or conversation history.`,
-    ];
-
-    // Workflow-specific instructions: when we already have the workflow, forbid redundant lookups
-    if (context.workflowId || (context.workflow && typeof context.workflow === "object")) {
-      const wfId = (context.workflowId as string) ?? (context.workflow as Record<string, unknown>)?.id;
-      lines.push(
-        `\n## Workflow Context — CRITICAL`,
-        `The current workflow ID is: ${wfId}`,
-        `The workflow details (DAG, slug, metadata) are ALREADY provided in the context above.`,
-        `You MUST:`,
-        `- Pass "${wfId}" directly as workflowId to any tool that needs it (update_workflow, validate_workflow, update_workflow_node_config, get_prompt_template, update_prompt_template, etc.)`,
-        `- Use the DAG and metadata from the context above — do NOT call get_workflow_details to re-fetch what you already have`,
-        `You MUST NOT:`,
-        `- Call list_workflows to search for or find this workflow — you already have it`,
-        `- Call get_workflow_details to fetch details you already have in context (only call it AFTER making changes to see the updated state)`,
-        `- Call request_user_input to ask for the workflow ID — you already have it`,
-      );
-    }
-
-    prompt += lines.join("\n");
+    ].join("\n");
   }
 
   return prompt;

--- a/tests/unit/anthropic.test.ts
+++ b/tests/unit/anthropic.test.ts
@@ -394,53 +394,13 @@ describe("buildSystemPrompt", () => {
     expect(result).toContain("https://example.com");
   });
 
-  it("includes context usage rules that reference the context keys", () => {
+  it("includes context JSON with all provided fields", () => {
     const result = buildSystemPrompt("Base prompt.", {
       workflowId: "wf-123",
       brandUrl: "https://example.com",
     });
-    expect(result).toContain("## IMPORTANT: Context Usage Rules");
-    expect(result).toContain("workflowId, brandUrl");
-    expect(result).toContain("Do NOT call request_user_input");
-  });
-
-  it("instructs LLM to use workflowId directly from context", () => {
-    const result = buildSystemPrompt("Base prompt.", {
-      workflowId: "wf-abc-123",
-    });
-    expect(result).toContain("wf-abc-123");
-    expect(result).toContain("workflowId");
-    expect(result).toContain("use them directly when calling tools");
-  });
-
-  it("adds workflow-specific CRITICAL section when workflowId is in context", () => {
-    const result = buildSystemPrompt("Base prompt.", {
-      workflowId: "wf-abc-123",
-      workflow: { id: "wf-abc-123", slug: "cold-email" },
-      dag: { nodes: [] },
-    });
-    expect(result).toContain("## Workflow Context — CRITICAL");
-    expect(result).toContain('The current workflow ID is: wf-abc-123');
-    expect(result).toContain("MUST NOT");
-    expect(result).toContain("Call list_workflows");
-    expect(result).toContain("Call get_workflow_details to fetch details you already have");
-  });
-
-  it("extracts workflowId from nested workflow object when top-level workflowId missing", () => {
-    const result = buildSystemPrompt("Base prompt.", {
-      workflow: { id: "wf-nested-456", slug: "pr-outreach" },
-    });
-    expect(result).toContain("## Workflow Context — CRITICAL");
-    expect(result).toContain("wf-nested-456");
-    expect(result).toContain("Call list_workflows");
-  });
-
-  it("does NOT add workflow section when no workflow data in context", () => {
-    const result = buildSystemPrompt("Base prompt.", {
-      brandUrl: "https://example.com",
-    });
-    expect(result).not.toContain("## Workflow Context");
-    expect(result).not.toContain("list_workflows");
+    expect(result).toContain('"workflowId": "wf-123"');
+    expect(result).toContain('"brandUrl": "https://example.com"');
   });
 
   it("appends campaign context section when provided", () => {


### PR DESCRIPTION
## Summary
- Removes the `## IMPORTANT: Context Usage Rules` and `## Workflow Context — CRITICAL` blocks that `buildSystemPrompt` was appending after the context JSON
- These were redundant: the platform system prompt (registered via PUT /platform-config, stored in DB) already contains explicit, detailed rules about using context values, never calling `list_workflows`, being locked to the current workflow, etc.
- The extra instructions risked confusing the model with repetition or subtle contradictions
- Context injection now simply appends the JSON blob under `## Additional Context (this request only)` — the base system prompt handles all behavioral rules

## Context
Investigating why the AI calls `list_workflows` despite the system prompt explicitly forbidding it. The redundant instructions were a red herring — the real diagnostic depends on Railway logs (PR #112 added `[chat-service] context received:` logging) to confirm whether the context arrives at all.

## Test plan
- [x] All 314 unit tests pass
- [ ] Check Railway logs after deploy for `[chat-service] context received:` to confirm context arrival


🤖 Generated with [Claude Code](https://claude.com/claude-code)