### PR TITLE
docs: clarify json vs content field usage in /complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ Response:
 }
 ```
 
-- `content` — raw text response (always present)
-- `json` — parsed JSON object (only when `responseFormat: "json"` and model returned valid JSON)
+- `content` — raw text response (always present). **Warning:** when `responseFormat: "json"`, this field may contain markdown code fences (e.g. `` ```json...``` ``). Do **not** use this field for JSON parsing.
+- `json` — parsed JSON object (only when `responseFormat: "json"` and model returned valid JSON). **Always use this field** for structured data — markdown fences are already stripped and the JSON is pre-parsed.
 - `tokensInput` / `tokensOutput` — token usage
 - `model` — model used
 

--- a/openapi.json
+++ b/openapi.json
@@ -449,14 +449,24 @@
         "properties": {
           "content": {
             "type": "string",
-            "description": "Raw text response from the model"
+            "description": "Raw text response from the model. WARNING: when responseFormat is \"json\", this field may contain markdown code fences (e.g. ```json...```). Do NOT use this field for JSON parsing — use the `json` field instead.",
+            "example": "{\"subject\": \"Quick question\", \"emails\": [{\"body\": \"Hi...\", \"daysSinceLastStep\": 0}]}"
           },
           "json": {
             "type": "object",
             "additionalProperties": {
               "nullable": true
             },
-            "description": "Parsed JSON object — present only when responseFormat is \"json\" and the model returned valid JSON"
+            "description": "Parsed JSON object — present only when responseFormat is \"json\" and the model returned valid JSON. IMPORTANT: always use this field (not `content`) when you need structured data. Markdown fences are already stripped and the JSON is pre-parsed.",
+            "example": {
+              "subject": "Quick question",
+              "emails": [
+                {
+                  "body": "Hi there, I noticed...",
+                  "daysSinceLastStep": 0
+                }
+              ]
+            }
           },
           "tokensInput": {
             "type": "number",
@@ -859,7 +869,7 @@
           "Complete"
         ],
         "summary": "Synchronous LLM completion",
-        "description": "One-shot, non-streaming LLM call for service-to-service use. Returns a JSON response with the model output.\n\nUnlike POST /chat, this endpoint:\n- Does **not** create or use sessions (stateless, one-shot)\n- Accepts an inline `systemPrompt` (no pre-registered config required)\n- Returns JSON instead of SSE\n- Supports `responseFormat: \"json\"` to guarantee parsable JSON output\n- Supports optional `temperature` and `maxTokens` overrides\n\n**Use cases:** generating search queries, scoring/analyzing text, any service that needs a quick LLM call without conversation context.",
+        "description": "One-shot, non-streaming LLM call for service-to-service use. Returns a JSON response with the model output.\n\nUnlike POST /chat, this endpoint:\n- Does **not** create or use sessions (stateless, one-shot)\n- Accepts an inline `systemPrompt` (no pre-registered config required)\n- Returns JSON instead of SSE\n- Supports `responseFormat: \"json\"` — when set, the parsed object is returned in the `json` field (always use `json`, not `content`, for structured data)\n- Supports optional `temperature` and `maxTokens` overrides\n\n**Use cases:** generating search queries, scoring/analyzing text, any service that needs a quick LLM call without conversation context.",
         "parameters": [
           {
             "schema": {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -322,10 +322,12 @@ export const CompleteRequestSchema = z
 export const CompleteResponseSchema = z
   .object({
     content: z.string().openapi({
-      description: "Raw text response from the model",
+      description: "Raw text response from the model. WARNING: when responseFormat is \"json\", this field may contain markdown code fences (e.g. ```json...```). Do NOT use this field for JSON parsing — use the `json` field instead.",
+      example: '{"subject": "Quick question", "emails": [{"body": "Hi...", "daysSinceLastStep": 0}]}',
     }),
     json: z.record(z.string(), z.unknown()).optional().openapi({
-      description: "Parsed JSON object — present only when responseFormat is \"json\" and the model returned valid JSON",
+      description: "Parsed JSON object — present only when responseFormat is \"json\" and the model returned valid JSON. IMPORTANT: always use this field (not `content`) when you need structured data. Markdown fences are already stripped and the JSON is pre-parsed.",
+      example: { subject: "Quick question", emails: [{ body: "Hi there, I noticed...", daysSinceLastStep: 0 }] },
     }),
     tokensInput: z.number().openapi({
       description: "Number of input tokens consumed",
@@ -355,7 +357,7 @@ Unlike POST /chat, this endpoint:
 - Does **not** create or use sessions (stateless, one-shot)
 - Accepts an inline \`systemPrompt\` (no pre-registered config required)
 - Returns JSON instead of SSE
-- Supports \`responseFormat: "json"\` to guarantee parsable JSON output
+- Supports \`responseFormat: "json"\` — when set, the parsed object is returned in the \`json\` field (always use \`json\`, not \`content\`, for structured data)
 - Supports optional \`temperature\` and \`maxTokens\` overrides
 
 **Use cases:** generating search queries, scoring/analyzing text, any service that needs a quick LLM call without conversation context.`,


### PR DESCRIPTION
## Summary
- Updated OpenAPI schema descriptions for `content` and `json` fields to explicitly warn that `content` may contain markdown code fences when `responseFormat: "json"`
- Added examples to both fields in the OpenAPI spec
- Updated README with the same guidance

This addresses a production error in content-generation-service where `data.content` was being used instead of `data.json`, causing `JSON.parse()` failures on markdown-fenced LLM output.

## Test plan
- [x] All existing unit tests pass
- [x] OpenAPI spec regenerated
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)