### PR TITLE
feat: add vision support to /complete (gemini-2.0-flash + imageUrl)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,12 +148,26 @@ Request body:
 }
 ```
 
+**Vision example (image analysis):**
+```json
+{
+  "message": "Analyze this image and score it on: is_logo, is_product, is_team_photo, is_professional (0-1 each)",
+  "systemPrompt": "You are an image classification assistant. Return JSON with scores.",
+  "imageUrl": "https://example.com/images/hero.jpg",
+  "model": "gemini-2.0-flash",
+  "responseFormat": "json",
+  "temperature": 0,
+  "maxTokens": 1024
+}
+```
+
 - `message` (required) — the prompt to send to the LLM
 - `systemPrompt` (required) — inline system prompt (no pre-registered config needed)
 - `responseFormat` (optional) — set to `"json"` to instruct the model to return valid JSON. The parsed result appears in the `json` field.
 - `temperature` (optional) — sampling temperature, 0–2 (default: model default)
 - `maxTokens` (optional) — max output tokens, 1–64000 (default: 16000)
-- `model` (optional) — Anthropic model to use: `claude-sonnet-4-6` (default) or `claude-haiku-4-5`. Use Haiku for simpler tasks (extraction, classification) to reduce cost.
+- `model` (optional) — `claude-sonnet-4-6` (default), `claude-haiku-4-5` (cheaper text tasks), or `gemini-2.0-flash` (cost-effective vision). Gemini models require a Google API key configured in key-service (provider: `google`).
+- `imageUrl` (optional) — URL of an image to include as visual input. The image is fetched server-side. Supported by all models, but recommended with `gemini-2.0-flash` for cost-effective vision tasks.
 
 Response:
 ```json
@@ -447,6 +461,7 @@ src/
     schema.ts       # sessions + messages + app_configs + platform_configs table definitions
   lib/
     anthropic.ts       # Claude AI client (Sonnet 4.6), streaming + non-streaming, tool calling, adaptive thinking, context management (compaction), built-in tool declarations
+    gemini.ts          # Gemini REST API client (Flash 2.0) for vision tasks — lightweight, no SDK dependency
     merge-messages.ts  # Ensures alternating user/assistant roles by merging orphaned consecutive same-role messages
     billing-client.ts  # Billing-service client for credit authorization before platform-key operations
     key-client.ts      # Key-service client: resolveKey (decrypt), listOrgKeys, getKeySource, listKeySources, checkProviderRequirements

--- a/openapi.json
+++ b/openapi.json
@@ -555,10 +555,17 @@
             "type": "string",
             "enum": [
               "claude-sonnet-4-6",
-              "claude-haiku-4-5"
+              "claude-haiku-4-5",
+              "gemini-2.0-flash"
             ],
-            "description": "Anthropic model to use. Defaults to claude-sonnet-4-6. Use claude-haiku-4-5 for simpler tasks (extraction, classification) to reduce cost.",
-            "example": "claude-haiku-4-5"
+            "description": "Model to use. Defaults to claude-sonnet-4-6. Use claude-haiku-4-5 for simpler tasks, or gemini-2.0-flash for vision tasks (image analysis, classification).",
+            "example": "gemini-2.0-flash"
+          },
+          "imageUrl": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL of an image to include in the prompt. The image is fetched server-side and sent to the model as a visual input. Supported by all models, but recommended with gemini-2.0-flash for cost-effective vision tasks (image classification, scoring, analysis).",
+            "example": "https://example.com/images/hero.jpg"
           }
         },
         "required": [
@@ -869,7 +876,7 @@
           "Complete"
         ],
         "summary": "Synchronous LLM completion",
-        "description": "One-shot, non-streaming LLM call for service-to-service use. Returns a JSON response with the model output.\n\nUnlike POST /chat, this endpoint:\n- Does **not** create or use sessions (stateless, one-shot)\n- Accepts an inline `systemPrompt` (no pre-registered config required)\n- Returns JSON instead of SSE\n- Supports `responseFormat: \"json\"` — when set, the parsed object is returned in the `json` field (always use `json`, not `content`, for structured data)\n- Supports optional `temperature` and `maxTokens` overrides\n\n**Use cases:** generating search queries, scoring/analyzing text, any service that needs a quick LLM call without conversation context.",
+        "description": "One-shot, non-streaming LLM call for service-to-service use. Returns a JSON response with the model output.\n\nUnlike POST /chat, this endpoint:\n- Does **not** create or use sessions (stateless, one-shot)\n- Accepts an inline `systemPrompt` (no pre-registered config required)\n- Returns JSON instead of SSE\n- Supports `responseFormat: \"json\"` — when set, the parsed object is returned in the `json` field (always use `json`, not `content`, for structured data)\n- Supports optional `temperature` and `maxTokens` overrides\n- Supports **vision** via the `imageUrl` field — the image is fetched server-side and sent as visual input to the model\n\n**Models:**\n- `claude-sonnet-4-6` (default) — general-purpose, high quality\n- `claude-haiku-4-5` — faster/cheaper for simple extraction and classification\n- `gemini-2.0-flash` — cost-effective vision model for image analysis, scoring, and classification. Requires a Google API key configured in key-service (provider: `google`).\n\n**Use cases:** generating search queries, scoring/analyzing text, image classification and scoring (with `imageUrl` + `gemini-2.0-flash`), any service that needs a quick LLM call without conversation context.",
         "parameters": [
           {
             "schema": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import {
   COST_PREFIX,
   costPrefixForModel,
 } from "./lib/anthropic.js";
+import { isGeminiModel, completeWithGemini } from "./lib/gemini.js";
 import {
   updateWorkflow,
   validateWorkflow,
@@ -189,13 +190,18 @@ app.post("/complete", requireAuth, async (req, res) => {
       .json({ error: "Invalid request", details: parsed.error.flatten() });
   }
 
-  const { message, systemPrompt, responseFormat, temperature, maxTokens, model: requestedModel } = parsed.data;
+  const { message, systemPrompt, responseFormat, temperature, maxTokens, model: requestedModel, imageUrl } = parsed.data;
 
-  // Resolve Anthropic API key per-request
+  // Determine provider from model
+  const effectiveModel = requestedModel ?? MODEL;
+  const isGemini = isGeminiModel(effectiveModel);
+  const provider = isGemini ? "google" : "anthropic";
+
+  // Resolve API key per-request
   let resolvedKey: ResolvedKey;
   try {
     resolvedKey = await resolveKey({
-      provider: "anthropic",
+      provider,
       orgId,
       userId,
       runId: callerRunId,
@@ -203,14 +209,13 @@ app.post("/complete", requireAuth, async (req, res) => {
       trackingHeaders,
     });
   } catch (err) {
-    console.error(`[complete] Failed to resolve Anthropic key for org="${orgId}":`, err);
+    console.error(`[complete] Failed to resolve ${provider} key for org="${orgId}":`, err);
     return res.status(502).json({
-      error: "Failed to resolve Anthropic API key. Ensure the key is configured in key-service.",
+      error: `Failed to resolve ${provider} API key. Ensure the key is configured in key-service.`,
     });
   }
 
-  // Resolve model and its cost prefix
-  const effectiveModel = requestedModel ?? MODEL;
+  // Resolve cost prefix
   const effectiveCostPrefix = costPrefixForModel(effectiveModel);
 
   // Credit authorization for platform keys
@@ -290,14 +295,29 @@ app.post("/complete", requireAuth, async (req, res) => {
       effectiveSystemPrompt += `\n\nIMPORTANT: You MUST respond with valid JSON only. No markdown, no code fences, no extra text — just a single JSON object or array.`;
     }
 
-    const claude = createAnthropicClient({ apiKey: resolvedKey.key, systemPrompt: effectiveSystemPrompt });
+    let result: { content: string; tokensInput: number; tokensOutput: number; model: string };
 
-    const result = await claude.complete(message, {
-      responseFormat,
-      temperature,
-      maxTokens,
-      model: effectiveModel,
-    });
+    if (isGemini) {
+      result = await completeWithGemini({
+        apiKey: resolvedKey.key,
+        model: effectiveModel,
+        message,
+        systemPrompt: effectiveSystemPrompt,
+        imageUrl,
+        responseFormat,
+        temperature,
+        maxTokens,
+      });
+    } else {
+      const claude = createAnthropicClient({ apiKey: resolvedKey.key, systemPrompt: effectiveSystemPrompt });
+      result = await claude.complete(message, {
+        responseFormat,
+        temperature,
+        maxTokens,
+        model: effectiveModel,
+        imageUrl,
+      });
+    }
 
     totalPromptTokens = result.tokensInput;
     totalOutputTokens = result.tokensOutput;

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -12,6 +12,7 @@ const MAX_TOKENS = 16_000;
 export const SUPPORTED_MODELS: Record<string, string> = {
   "claude-sonnet-4-6": "anthropic-sonnet-4.6",
   "claude-haiku-4-5": "anthropic-haiku-4.5",
+  "gemini-2.0-flash": "google-flash-2.0",
 };
 
 /** Resolve the cost prefix for a given model ID (falls back to default). */
@@ -932,6 +933,7 @@ export function createAnthropicClient({ apiKey, systemPrompt }: AnthropicOptions
         temperature?: number;
         maxTokens?: number;
         model?: string;
+        imageUrl?: string;
       },
     ): Promise<{
       content: string;
@@ -940,11 +942,26 @@ export function createAnthropicClient({ apiKey, systemPrompt }: AnthropicOptions
       model: string;
     }> {
       const effectiveModel = options?.model ?? MODEL;
+
+      // Build user content — multimodal when imageUrl is provided
+      let userContent: Anthropic.MessageCreateParamsNonStreaming["messages"][0]["content"];
+      if (options?.imageUrl) {
+        userContent = [
+          {
+            type: "image",
+            source: { type: "url", url: options.imageUrl },
+          },
+          { type: "text", text: message },
+        ];
+      } else {
+        userContent = message;
+      }
+
       const params: Anthropic.MessageCreateParamsNonStreaming = {
         model: effectiveModel,
         max_tokens: options?.maxTokens ?? MAX_TOKENS,
         system: systemPrompt,
-        messages: [{ role: "user", content: message }],
+        messages: [{ role: "user", content: userContent }],
         ...(options?.temperature != null ? { temperature: options.temperature } : {}),
       };
 

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -1,0 +1,128 @@
+// ---------------------------------------------------------------------------
+// Gemini REST API client — lightweight, no SDK dependency
+// Used by POST /complete for vision tasks (gemini-2.0-flash)
+// ---------------------------------------------------------------------------
+
+const GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta";
+
+export const GEMINI_MODELS: Record<string, string> = {
+  "gemini-2.0-flash": "google-flash-2.0",
+};
+
+/** Check if a model ID is a Gemini model. */
+export function isGeminiModel(model: string): boolean {
+  return model in GEMINI_MODELS;
+}
+
+/** Get cost-name prefix for a Gemini model. */
+export function geminiCostPrefix(model: string): string {
+  return GEMINI_MODELS[model] ?? "google-flash-2.0";
+}
+
+interface GeminiCompleteOptions {
+  apiKey: string;
+  model: string;
+  message: string;
+  systemPrompt: string;
+  imageUrl?: string;
+  responseFormat?: "json";
+  temperature?: number;
+  maxTokens?: number;
+}
+
+interface GeminiCompleteResult {
+  content: string;
+  tokensInput: number;
+  tokensOutput: number;
+  model: string;
+}
+
+/**
+ * Fetch an image from a URL and return base64-encoded data + MIME type.
+ */
+async function fetchImageAsBase64(url: string): Promise<{ data: string; mimeType: string }> {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`[gemini] Failed to fetch image from ${url}: ${res.status} ${res.statusText}`);
+  }
+  const contentType = res.headers.get("content-type") ?? "image/jpeg";
+  const buffer = await res.arrayBuffer();
+  const data = Buffer.from(buffer).toString("base64");
+  return { data, mimeType: contentType.split(";")[0].trim() };
+}
+
+/**
+ * Non-streaming completion via the Gemini REST API.
+ * Supports multimodal (text + image) input.
+ */
+export async function completeWithGemini(options: GeminiCompleteOptions): Promise<GeminiCompleteResult> {
+  const {
+    apiKey,
+    model,
+    message,
+    systemPrompt,
+    imageUrl,
+    responseFormat,
+    temperature,
+    maxTokens,
+  } = options;
+
+  // Build content parts
+  const parts: Array<Record<string, unknown>> = [{ text: message }];
+
+  if (imageUrl) {
+    const image = await fetchImageAsBase64(imageUrl);
+    parts.push({
+      inline_data: {
+        mime_type: image.mimeType,
+        data: image.data,
+      },
+    });
+  }
+
+  // Build request body
+  const body: Record<string, unknown> = {
+    contents: [{ parts }],
+    systemInstruction: { parts: [{ text: systemPrompt }] },
+    generationConfig: {
+      ...(temperature != null ? { temperature } : {}),
+      ...(maxTokens != null ? { maxOutputTokens: maxTokens } : {}),
+      ...(responseFormat === "json" ? { responseMimeType: "application/json" } : {}),
+    },
+  };
+
+  const url = `${GEMINI_API_BASE}/models/${encodeURIComponent(model)}:generateContent?key=${encodeURIComponent(apiKey)}`;
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => "unknown error");
+    throw new Error(`[gemini] API error ${res.status}: ${errorText}`);
+  }
+
+  const data = (await res.json()) as {
+    candidates?: Array<{
+      content?: { parts?: Array<{ text?: string }> };
+    }>;
+    usageMetadata?: {
+      promptTokenCount?: number;
+      candidatesTokenCount?: number;
+    };
+  };
+
+  const content =
+    data.candidates?.[0]?.content?.parts
+      ?.map((p) => p.text ?? "")
+      .join("") ?? "";
+
+  return {
+    content,
+    tokensInput: data.usageMetadata?.promptTokenCount ?? 0,
+    tokensOutput: data.usageMetadata?.candidatesTokenCount ?? 0,
+    model,
+  };
+}

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -312,9 +312,13 @@ export const CompleteRequestSchema = z
       description: "Maximum tokens in the response (default: 16000)",
       example: 2000,
     }),
-    model: z.enum(["claude-sonnet-4-6", "claude-haiku-4-5"]).optional().openapi({
-      description: "Anthropic model to use. Defaults to claude-sonnet-4-6. Use claude-haiku-4-5 for simpler tasks (extraction, classification) to reduce cost.",
-      example: "claude-haiku-4-5",
+    model: z.enum(["claude-sonnet-4-6", "claude-haiku-4-5", "gemini-2.0-flash"]).optional().openapi({
+      description: "Model to use. Defaults to claude-sonnet-4-6. Use claude-haiku-4-5 for simpler tasks, or gemini-2.0-flash for vision tasks (image analysis, classification).",
+      example: "gemini-2.0-flash",
+    }),
+    imageUrl: z.string().url().optional().openapi({
+      description: "URL of an image to include in the prompt. The image is fetched server-side and sent to the model as a visual input. Supported by all models, but recommended with gemini-2.0-flash for cost-effective vision tasks (image classification, scoring, analysis).",
+      example: "https://example.com/images/hero.jpg",
     }),
   })
   .openapi("CompleteRequest");
@@ -359,8 +363,14 @@ Unlike POST /chat, this endpoint:
 - Returns JSON instead of SSE
 - Supports \`responseFormat: "json"\` — when set, the parsed object is returned in the \`json\` field (always use \`json\`, not \`content\`, for structured data)
 - Supports optional \`temperature\` and \`maxTokens\` overrides
+- Supports **vision** via the \`imageUrl\` field — the image is fetched server-side and sent as visual input to the model
 
-**Use cases:** generating search queries, scoring/analyzing text, any service that needs a quick LLM call without conversation context.`,
+**Models:**
+- \`claude-sonnet-4-6\` (default) — general-purpose, high quality
+- \`claude-haiku-4-5\` — faster/cheaper for simple extraction and classification
+- \`gemini-2.0-flash\` — cost-effective vision model for image analysis, scoring, and classification. Requires a Google API key configured in key-service (provider: \`google\`).
+
+**Use cases:** generating search queries, scoring/analyzing text, image classification and scoring (with \`imageUrl\` + \`gemini-2.0-flash\`), any service that needs a quick LLM call without conversation context.`,
   request: {
     headers: z.object({
       "x-api-key": z.string().openapi({

--- a/tests/unit/complete.test.ts
+++ b/tests/unit/complete.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { CompleteRequestSchema } from "../../src/schemas.js";
+import { isGeminiModel, geminiCostPrefix, GEMINI_MODELS } from "../../src/lib/gemini.js";
+import { costPrefixForModel, SUPPORTED_MODELS } from "../../src/lib/anthropic.js";
 
 describe("CompleteRequestSchema", () => {
   it("accepts valid request with message and systemPrompt", () => {
@@ -164,5 +166,117 @@ describe("CompleteRequestSchema", () => {
       temperature: 2,
     });
     expect(atTwo.success).toBe(true);
+  });
+
+  // --- Vision / imageUrl tests ---
+
+  it("accepts gemini-2.0-flash model", () => {
+    const result = CompleteRequestSchema.safeParse({
+      message: "Analyze this image",
+      systemPrompt: "You are an image classifier.",
+      model: "gemini-2.0-flash",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.model).toBe("gemini-2.0-flash");
+    }
+  });
+
+  it("accepts imageUrl with gemini-2.0-flash", () => {
+    const result = CompleteRequestSchema.safeParse({
+      message: "Score this image",
+      systemPrompt: "You are an image scoring assistant.",
+      model: "gemini-2.0-flash",
+      imageUrl: "https://example.com/images/hero.jpg",
+      responseFormat: "json",
+      temperature: 0,
+      maxTokens: 1024,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.imageUrl).toBe("https://example.com/images/hero.jpg");
+      expect(result.data.model).toBe("gemini-2.0-flash");
+    }
+  });
+
+  it("accepts imageUrl with anthropic models", () => {
+    const result = CompleteRequestSchema.safeParse({
+      message: "Describe this image",
+      systemPrompt: "You are helpful.",
+      model: "claude-sonnet-4-6",
+      imageUrl: "https://example.com/photo.png",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.imageUrl).toBe("https://example.com/photo.png");
+    }
+  });
+
+  it("accepts imageUrl without explicit model (defaults to claude)", () => {
+    const result = CompleteRequestSchema.safeParse({
+      message: "What do you see?",
+      systemPrompt: "You are helpful.",
+      imageUrl: "https://example.com/img.jpg",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.imageUrl).toBe("https://example.com/img.jpg");
+      expect(result.data.model).toBeUndefined();
+    }
+  });
+
+  it("rejects invalid imageUrl", () => {
+    const result = CompleteRequestSchema.safeParse({
+      message: "Analyze",
+      systemPrompt: "You are helpful.",
+      imageUrl: "not-a-url",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts request without imageUrl (vision is optional)", () => {
+    const result = CompleteRequestSchema.safeParse({
+      message: "Just text",
+      systemPrompt: "You are helpful.",
+      model: "gemini-2.0-flash",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.imageUrl).toBeUndefined();
+    }
+  });
+});
+
+// --- Gemini model helpers ---
+
+describe("isGeminiModel", () => {
+  it("returns true for gemini-2.0-flash", () => {
+    expect(isGeminiModel("gemini-2.0-flash")).toBe(true);
+  });
+
+  it("returns false for anthropic models", () => {
+    expect(isGeminiModel("claude-sonnet-4-6")).toBe(false);
+    expect(isGeminiModel("claude-haiku-4-5")).toBe(false);
+  });
+
+  it("returns false for unknown models", () => {
+    expect(isGeminiModel("gpt-4o")).toBe(false);
+  });
+});
+
+describe("geminiCostPrefix", () => {
+  it("returns correct prefix for gemini-2.0-flash", () => {
+    expect(geminiCostPrefix("gemini-2.0-flash")).toBe("google-flash-2.0");
+  });
+});
+
+describe("costPrefixForModel", () => {
+  it("returns correct prefix for gemini-2.0-flash", () => {
+    expect(costPrefixForModel("gemini-2.0-flash")).toBe("google-flash-2.0");
+  });
+
+  it("returns correct prefix for anthropic models", () => {
+    expect(costPrefixForModel("claude-sonnet-4-6")).toBe("anthropic-sonnet-4.6");
+    expect(costPrefixForModel("claude-haiku-4-5")).toBe("anthropic-haiku-4.5");
   });
 });


### PR DESCRIPTION
## Summary

- Adds `gemini-2.0-flash` to the `/complete` model enum for cost-effective vision tasks
- Adds optional `imageUrl` field — image is fetched server-side and sent as visual input
- Creates `src/lib/gemini.ts` — lightweight Gemini REST API client (no new npm dependency)
- Routes to Gemini API when a Gemini model is selected; supports imageUrl with Anthropic models too
- Resolves Google API key from key-service (provider: `google`) for Gemini models
- Cost tracking uses `google-flash-2.0` prefix for runs-service

## Motivation

Brand-service needs to analyze scraped images (logos, product photos, hero images) to classify and score them. This requires a vision-capable model at low cost — `gemini-2.0-flash` is ideal (~20-50 calls per brand extraction).

## Test plan

- [x] Schema validation tests: gemini model accepted, imageUrl validated as URL, rejects invalid URLs
- [x] `isGeminiModel` / `geminiCostPrefix` / `costPrefixForModel` helper tests
- [x] All 327 existing tests still pass
- [ ] Integration: call `/complete` with `imageUrl` + `gemini-2.0-flash` against a real image
- [ ] Verify Google API key resolution from key-service works in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)