### PR TITLE
feat: switch vision model to gemini-3.1-flash-lite-preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Request body:
   "systemPrompt": "You are an image classification assistant. Return JSON with scores.",
   "imageUrl": "https://example.com/images/hero.jpg",
   "imageContext": { "alt": "Company hero banner", "title": "About Us", "sourceUrl": "https://example.com/about" },
-  "model": "gemini-2.5-flash",
+  "model": "gemini-3.1-flash-lite-preview",
   "responseFormat": "json",
   "temperature": 0,
   "maxTokens": 1024
@@ -167,8 +167,8 @@ Request body:
 - `responseFormat` (optional) — set to `"json"` to instruct the model to return valid JSON. The parsed result appears in the `json` field.
 - `temperature` (optional) — sampling temperature, 0–2 (default: model default)
 - `maxTokens` (optional) — max output tokens, 1–64000 (default: 16000)
-- `model` (optional) — `claude-sonnet-4-6` (default), `claude-haiku-4-5` (cheaper text tasks), or `gemini-2.5-flash` (cost-effective vision). Gemini models require a Google API key configured in key-service (provider: `google`).
-- `imageUrl` (optional) — URL of an image to include as visual input. The image is fetched server-side. Supported by all models, but recommended with `gemini-2.5-flash` for cost-effective vision tasks.
+- `model` (optional) — `claude-sonnet-4-6` (default), `claude-haiku-4-5` (cheaper text tasks), or `gemini-3.1-flash-lite-preview` (cost-effective vision). Gemini models require a Google API key configured in key-service (provider: `google`).
+- `imageUrl` (optional) — URL of an image to include as visual input. The image is fetched server-side. Supported by all models, but recommended with `gemini-3.1-flash-lite-preview` for cost-effective vision tasks.
 - `imageContext` (optional) — metadata about the image to help the model classify it: `{ alt?: string, title?: string, sourceUrl?: string }`. Injected into the prompt alongside the image. Only meaningful when `imageUrl` is provided.
 
 Response:

--- a/openapi.json
+++ b/openapi.json
@@ -556,15 +556,15 @@
             "enum": [
               "claude-sonnet-4-6",
               "claude-haiku-4-5",
-              "gemini-2.5-flash"
+              "gemini-3.1-flash-lite-preview"
             ],
-            "description": "Model to use. Defaults to claude-sonnet-4-6. Use claude-haiku-4-5 for simpler tasks, or gemini-2.5-flash for cost-effective vision tasks (image analysis, classification).",
-            "example": "gemini-2.5-flash"
+            "description": "Model to use. Defaults to claude-sonnet-4-6. Use claude-haiku-4-5 for simpler tasks, or gemini-3.1-flash-lite-preview for cost-effective vision tasks (image analysis, classification).",
+            "example": "gemini-3.1-flash-lite-preview"
           },
           "imageUrl": {
             "type": "string",
             "format": "uri",
-            "description": "URL of an image to include in the prompt. The image is fetched server-side and sent to the model as a visual input. Supported by all models, but recommended with gemini-2.5-flash for cost-effective vision tasks (image classification, scoring, analysis).",
+            "description": "URL of an image to include in the prompt. The image is fetched server-side and sent to the model as a visual input. Supported by all models, but recommended with gemini-3.1-flash-lite-preview for cost-effective vision tasks (image classification, scoring, analysis).",
             "example": "https://example.com/images/hero.jpg"
           },
           "imageContext": {
@@ -897,7 +897,7 @@
           "Complete"
         ],
         "summary": "Synchronous LLM completion",
-        "description": "One-shot, non-streaming LLM call for service-to-service use. Returns a JSON response with the model output.\n\nUnlike POST /chat, this endpoint:\n- Does **not** create or use sessions (stateless, one-shot)\n- Accepts an inline `systemPrompt` (no pre-registered config required)\n- Returns JSON instead of SSE\n- Supports `responseFormat: \"json\"` — when set, the parsed object is returned in the `json` field (always use `json`, not `content`, for structured data)\n- Supports optional `temperature` and `maxTokens` overrides\n- Supports **vision** via the `imageUrl` field — the image is fetched server-side and sent as visual input to the model\n\n**Models:**\n- `claude-sonnet-4-6` (default) — general-purpose, high quality\n- `claude-haiku-4-5` — faster/cheaper for simple extraction and classification\n- `gemini-2.5-flash` — cost-effective vision model for image analysis, scoring, and classification. Requires a Google API key configured in key-service (provider: `google`).\n\n**Use cases:** generating search queries, scoring/analyzing text, image classification and scoring (with `imageUrl` + `gemini-2.5-flash`), any service that needs a quick LLM call without conversation context.",
+        "description": "One-shot, non-streaming LLM call for service-to-service use. Returns a JSON response with the model output.\n\nUnlike POST /chat, this endpoint:\n- Does **not** create or use sessions (stateless, one-shot)\n- Accepts an inline `systemPrompt` (no pre-registered config required)\n- Returns JSON instead of SSE\n- Supports `responseFormat: \"json\"` — when set, the parsed object is returned in the `json` field (always use `json`, not `content`, for structured data)\n- Supports optional `temperature` and `maxTokens` overrides\n- Supports **vision** via the `imageUrl` field — the image is fetched server-side and sent as visual input to the model\n\n**Models:**\n- `claude-sonnet-4-6` (default) — general-purpose, high quality\n- `claude-haiku-4-5` — faster/cheaper for simple extraction and classification\n- `gemini-3.1-flash-lite-preview` — cost-effective vision model for image analysis, scoring, and classification. Requires a Google API key configured in key-service (provider: `google`).\n\n**Use cases:** generating search queries, scoring/analyzing text, image classification and scoring (with `imageUrl` + `gemini-3.1-flash-lite-preview`), any service that needs a quick LLM call without conversation context.",
         "parameters": [
           {
             "schema": {

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -12,7 +12,7 @@ const MAX_TOKENS = 16_000;
 export const SUPPORTED_MODELS: Record<string, string> = {
   "claude-sonnet-4-6": "anthropic-sonnet-4.6",
   "claude-haiku-4-5": "anthropic-haiku-4.5",
-  "gemini-2.5-flash": "google-flash-2.5",
+  "gemini-3.1-flash-lite-preview": "google-flash-lite-3.1",
 };
 
 /** Resolve the cost prefix for a given model ID (falls back to default). */

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -1,12 +1,12 @@
 // ---------------------------------------------------------------------------
 // Gemini REST API client — lightweight, no SDK dependency
-// Used by POST /complete for vision tasks (gemini-2.5-flash)
+// Used by POST /complete for vision tasks (gemini-3.1-flash-lite-preview)
 // ---------------------------------------------------------------------------
 
 const GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta";
 
 export const GEMINI_MODELS: Record<string, string> = {
-  "gemini-2.5-flash": "google-flash-2.5",
+  "gemini-3.1-flash-lite-preview": "google-flash-lite-3.1",
 };
 
 /** Check if a model ID is a Gemini model. */
@@ -16,7 +16,7 @@ export function isGeminiModel(model: string): boolean {
 
 /** Get cost-name prefix for a Gemini model. */
 export function geminiCostPrefix(model: string): string {
-  return GEMINI_MODELS[model] ?? "google-flash-2.5";
+  return GEMINI_MODELS[model] ?? "google-flash-lite-3.1";
 }
 
 export interface ImageContext {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -312,12 +312,12 @@ export const CompleteRequestSchema = z
       description: "Maximum tokens in the response (default: 16000)",
       example: 2000,
     }),
-    model: z.enum(["claude-sonnet-4-6", "claude-haiku-4-5", "gemini-2.5-flash"]).optional().openapi({
-      description: "Model to use. Defaults to claude-sonnet-4-6. Use claude-haiku-4-5 for simpler tasks, or gemini-2.5-flash for cost-effective vision tasks (image analysis, classification).",
-      example: "gemini-2.5-flash",
+    model: z.enum(["claude-sonnet-4-6", "claude-haiku-4-5", "gemini-3.1-flash-lite-preview"]).optional().openapi({
+      description: "Model to use. Defaults to claude-sonnet-4-6. Use claude-haiku-4-5 for simpler tasks, or gemini-3.1-flash-lite-preview for cost-effective vision tasks (image analysis, classification).",
+      example: "gemini-3.1-flash-lite-preview",
     }),
     imageUrl: z.string().url().optional().openapi({
-      description: "URL of an image to include in the prompt. The image is fetched server-side and sent to the model as a visual input. Supported by all models, but recommended with gemini-2.5-flash for cost-effective vision tasks (image classification, scoring, analysis).",
+      description: "URL of an image to include in the prompt. The image is fetched server-side and sent to the model as a visual input. Supported by all models, but recommended with gemini-3.1-flash-lite-preview for cost-effective vision tasks (image classification, scoring, analysis).",
       example: "https://example.com/images/hero.jpg",
     }),
     imageContext: z.object({
@@ -384,9 +384,9 @@ Unlike POST /chat, this endpoint:
 **Models:**
 - \`claude-sonnet-4-6\` (default) — general-purpose, high quality
 - \`claude-haiku-4-5\` — faster/cheaper for simple extraction and classification
-- \`gemini-2.5-flash\` — cost-effective vision model for image analysis, scoring, and classification. Requires a Google API key configured in key-service (provider: \`google\`).
+- \`gemini-3.1-flash-lite-preview\` — cost-effective vision model for image analysis, scoring, and classification. Requires a Google API key configured in key-service (provider: \`google\`).
 
-**Use cases:** generating search queries, scoring/analyzing text, image classification and scoring (with \`imageUrl\` + \`gemini-2.5-flash\`), any service that needs a quick LLM call without conversation context.`,
+**Use cases:** generating search queries, scoring/analyzing text, image classification and scoring (with \`imageUrl\` + \`gemini-3.1-flash-lite-preview\`), any service that needs a quick LLM call without conversation context.`,
   request: {
     headers: z.object({
       "x-api-key": z.string().openapi({

--- a/tests/unit/complete.test.ts
+++ b/tests/unit/complete.test.ts
@@ -170,23 +170,23 @@ describe("CompleteRequestSchema", () => {
 
   // --- Vision / imageUrl tests ---
 
-  it("accepts gemini-2.5-flash model", () => {
+  it("accepts gemini-3.1-flash-lite-preview model", () => {
     const result = CompleteRequestSchema.safeParse({
       message: "Analyze this image",
       systemPrompt: "You are an image classifier.",
-      model: "gemini-2.5-flash",
+      model: "gemini-3.1-flash-lite-preview",
     });
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data.model).toBe("gemini-2.5-flash");
+      expect(result.data.model).toBe("gemini-3.1-flash-lite-preview");
     }
   });
 
-  it("accepts imageUrl with gemini-2.5-flash", () => {
+  it("accepts imageUrl with gemini-3.1-flash-lite-preview", () => {
     const result = CompleteRequestSchema.safeParse({
       message: "Score this image",
       systemPrompt: "You are an image scoring assistant.",
-      model: "gemini-2.5-flash",
+      model: "gemini-3.1-flash-lite-preview",
       imageUrl: "https://example.com/images/hero.jpg",
       responseFormat: "json",
       temperature: 0,
@@ -195,7 +195,7 @@ describe("CompleteRequestSchema", () => {
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.imageUrl).toBe("https://example.com/images/hero.jpg");
-      expect(result.data.model).toBe("gemini-2.5-flash");
+      expect(result.data.model).toBe("gemini-3.1-flash-lite-preview");
     }
   });
 
@@ -238,7 +238,7 @@ describe("CompleteRequestSchema", () => {
     const result = CompleteRequestSchema.safeParse({
       message: "Just text",
       systemPrompt: "You are helpful.",
-      model: "gemini-2.5-flash",
+      model: "gemini-3.1-flash-lite-preview",
     });
     expect(result.success).toBe(true);
     if (result.success) {
@@ -252,7 +252,7 @@ describe("CompleteRequestSchema", () => {
     const result = CompleteRequestSchema.safeParse({
       message: "Score this image",
       systemPrompt: "You are an image classifier.",
-      model: "gemini-2.5-flash",
+      model: "gemini-3.1-flash-lite-preview",
       imageUrl: "https://example.com/hero.jpg",
       imageContext: {
         alt: "Company logo",
@@ -314,8 +314,8 @@ describe("CompleteRequestSchema", () => {
 // --- Gemini model helpers ---
 
 describe("isGeminiModel", () => {
-  it("returns true for gemini-2.5-flash", () => {
-    expect(isGeminiModel("gemini-2.5-flash")).toBe(true);
+  it("returns true for gemini-3.1-flash-lite-preview", () => {
+    expect(isGeminiModel("gemini-3.1-flash-lite-preview")).toBe(true);
   });
 
   it("returns false for anthropic models", () => {
@@ -329,14 +329,14 @@ describe("isGeminiModel", () => {
 });
 
 describe("geminiCostPrefix", () => {
-  it("returns correct prefix for gemini-2.5-flash", () => {
-    expect(geminiCostPrefix("gemini-2.5-flash")).toBe("google-flash-2.5");
+  it("returns correct prefix for gemini-3.1-flash-lite-preview", () => {
+    expect(geminiCostPrefix("gemini-3.1-flash-lite-preview")).toBe("google-flash-lite-3.1");
   });
 });
 
 describe("costPrefixForModel", () => {
-  it("returns correct prefix for gemini-2.5-flash", () => {
-    expect(costPrefixForModel("gemini-2.5-flash")).toBe("google-flash-2.5");
+  it("returns correct prefix for gemini-3.1-flash-lite-preview", () => {
+    expect(costPrefixForModel("gemini-3.1-flash-lite-preview")).toBe("google-flash-lite-3.1");
   });
 
   it("returns correct prefix for anthropic models", () => {


### PR DESCRIPTION
## Summary
- Replaces `gemini-2.5-flash` with `gemini-3.1-flash-lite-preview` as the Gemini vision model on `/complete`
- Latest Gemini 3.1 series Flash Lite with vision support (preview)
- Updates model enum, cost prefixes, schemas, OpenAPI spec, tests, and README

## Test plan
- [x] All 330 unit tests pass
- [x] TypeScript builds cleanly
- [x] OpenAPI spec regenerated
- [ ] Verify vision calls work in staging with `gemini-3.1-flash-lite-preview`

🤖 Generated with [Claude Code](https://claude.com/claude-code)