### PR TITLE
feat: add campaign-prefill tools for Edit with AI chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,19 @@ Before using `/chat`, register a config for each chat mode your app needs. Each 
 }
 ```
 
+**Example — campaign-prefill chat:**
+```json
+{
+  "key": "campaign-prefill",
+  "systemPrompt": "You help users create campaigns by pre-filling form fields based on their brand...",
+  "allowedTools": [
+    "update_campaign_fields",
+    "extract_brand_fields",
+    "extract_brand_text"
+  ]
+}
+```
+
 Fields:
 - `key` (required) — config identifier, unique per org. Clients pass this as `configKey` in `POST /chat`.
 - `systemPrompt` (required) — the system prompt sent to Claude for this chat mode
@@ -307,6 +320,14 @@ The tools available in each chat session are determined by the `allowedTools` ar
 | `get_feature_inputs` | Gets input definitions only (lighter than get_feature) |
 | `prefill_feature` | Pre-fills feature inputs from brand data |
 | `get_feature_stats` | Gets computed stats for a feature |
+
+**Campaign-prefill tools:**
+
+| Tool | Description |
+|---|---|
+| `update_campaign_fields` | Passthrough tool — returns `{ fields }` so the frontend can apply values to the campaign form |
+| `extract_brand_fields` | Extracts arbitrary fields from a brand's website via brand-service AI (cached 30 days) |
+| `extract_brand_text` | Extracts full text content from a brand's public website pages |
 
 **UI tools:**
 

--- a/openapi.json
+++ b/openapi.json
@@ -358,7 +358,7 @@
               "minLength": 1
             },
             "minItems": 1,
-            "description": "List of tool names the LLM is allowed to use in this chat mode. Only these tools will be provided to the model and executable server-side. Available tools: request_user_input, update_workflow, validate_workflow, get_workflow_details, generate_workflow, get_workflow_required_providers, list_workflows, update_workflow_node_config, get_prompt_template, update_prompt_template, list_services, list_service_endpoints, list_org_keys, get_key_source, list_key_sources, check_provider_requirements, create_feature, update_feature, list_features, get_feature, get_feature_inputs, prefill_feature, get_feature_stats",
+            "description": "List of tool names the LLM is allowed to use in this chat mode. Only these tools will be provided to the model and executable server-side. Available tools: request_user_input, update_workflow, validate_workflow, get_workflow_details, generate_workflow, get_workflow_required_providers, list_workflows, update_workflow_node_config, get_prompt_template, update_prompt_template, list_services, list_service_endpoints, list_org_keys, get_key_source, list_key_sources, check_provider_requirements, create_feature, update_feature, list_features, get_feature, get_feature_inputs, prefill_feature, get_feature_stats, update_campaign_fields, extract_brand_fields, extract_brand_text",
             "example": [
               "request_user_input",
               "update_workflow",

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import { getPromptTemplate, updatePromptTemplate } from "./lib/content-generatio
 import { listServices, listServiceEndpoints } from "./lib/api-registry-client.js";
 import { createRun, updateRunStatus, addRunCosts } from "./lib/runs-client.js";
 import { createFeature, updateFeature, listFeatures, getFeature, getFeatureInputs, prefillFeature, getFeatureStats } from "./lib/features-client.js";
+import { extractBrandFields, extractBrandText } from "./lib/brand-client.js";
 import { formatToolError } from "./lib/tool-errors.js";
 import {
   resolveKey,
@@ -1004,6 +1005,35 @@ app.post("/chat", requireAuth, async (req, res) => {
             campaignId: args.campaignId as string | undefined,
             workflowSlug: args.workflowSlug as string | undefined,
           },
+          featureCallParams,
+        );
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
+      // Campaign-prefill tools
+      if (call.name === "update_campaign_fields") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const result = { fields: args.fields as Record<string, string> };
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
+      if (call.name === "extract_brand_fields") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const result = await extractBrandFields(
+          args.brandId as string,
+          args.fields as Array<{ key: string; description: string }>,
+          featureCallParams,
+        );
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
+      if (call.name === "extract_brand_text") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const result = await extractBrandText(
+          args.brandId as string,
           featureCallParams,
         );
         toolCalls.push({ name: call.name, args, result });

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -756,6 +756,78 @@ export const GET_FEATURE_STATS_TOOL: Anthropic.Tool = {
 };
 
 // ---------------------------------------------------------------------------
+// Campaign-prefill tools
+// ---------------------------------------------------------------------------
+
+export const UPDATE_CAMPAIGN_FIELDS_TOOL: Anthropic.Tool = {
+  name: "update_campaign_fields",
+  description:
+    "Update campaign form fields. Returns the fields object as-is so the frontend can apply the values to the form. Use this to pre-fill or modify campaign creation fields based on the conversation.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      fields: {
+        type: "object",
+        additionalProperties: { type: "string" },
+        description:
+          "Key-value map of campaign form fields to update. Keys are field names, values are the new string values.",
+      },
+    },
+    required: ["fields"],
+  },
+};
+
+export const EXTRACT_BRAND_FIELDS_TOOL: Anthropic.Tool = {
+  name: "extract_brand_fields",
+  description:
+    "Extract arbitrary fields from a brand's website using AI. Wraps brand-service extract-fields endpoint. Results are cached 30 days per field — safe to call repeatedly.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      brandId: {
+        type: "string",
+        description: "UUID of the brand to extract fields from.",
+      },
+      fields: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            key: {
+              type: "string",
+              description: "Machine-readable key for the field (e.g. 'industry', 'target_audience').",
+            },
+            description: {
+              type: "string",
+              description: "Human-readable description of what to extract (e.g. 'The brand\\'s primary industry vertical').",
+            },
+          },
+          required: ["key", "description"],
+        },
+        description: "List of fields to extract. Each field has a key and a description.",
+      },
+    },
+    required: ["brandId", "fields"],
+  },
+};
+
+export const EXTRACT_BRAND_TEXT_TOOL: Anthropic.Tool = {
+  name: "extract_brand_text",
+  description:
+    "Extract the full text content from a brand's public website pages. Returns the raw text of all scraped pages. Use this to read the brand's site content for analysis or to inform campaign creation.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      brandId: {
+        type: "string",
+        description: "UUID of the brand whose website text to extract.",
+      },
+    },
+    required: ["brandId"],
+  },
+};
+
+// ---------------------------------------------------------------------------
 // Tool registry — every tool the service knows how to execute.
 // Clients choose which subset to enable via allowedTools in their config.
 // ---------------------------------------------------------------------------
@@ -784,6 +856,9 @@ export const TOOL_REGISTRY: Record<string, Anthropic.Tool> = {
   get_feature_inputs: GET_FEATURE_INPUTS_TOOL,
   prefill_feature: PREFILL_FEATURE_TOOL,
   get_feature_stats: GET_FEATURE_STATS_TOOL,
+  update_campaign_fields: UPDATE_CAMPAIGN_FIELDS_TOOL,
+  extract_brand_fields: EXTRACT_BRAND_FIELDS_TOOL,
+  extract_brand_text: EXTRACT_BRAND_TEXT_TOOL,
 };
 
 /** All tool names available for use in allowedTools config. */

--- a/src/lib/brand-client.ts
+++ b/src/lib/brand-client.ts
@@ -1,0 +1,132 @@
+import { apiServiceFetch, type ApiCallParams } from "./api-client.js";
+
+export type BrandCallParams = ApiCallParams;
+
+// ---------------------------------------------------------------------------
+// POST /brands/{brandId}/extract-fields
+// ---------------------------------------------------------------------------
+
+export interface ExtractFieldDef {
+  key: string;
+  description: string;
+}
+
+export interface ExtractFieldResult {
+  key: string;
+  value: unknown;
+  cached: boolean;
+  extractedAt: string;
+  expiresAt: string | null;
+  sourceUrls: string[] | null;
+}
+
+export interface ExtractFieldsResponse {
+  brandId: string;
+  results: ExtractFieldResult[];
+}
+
+export async function extractBrandFields(
+  brandId: string,
+  fields: ExtractFieldDef[],
+  params: BrandCallParams,
+): Promise<ExtractFieldsResponse> {
+  const res = await apiServiceFetch(
+    `/v1/brands/${encodeURIComponent(brandId)}/extract-fields`,
+    "POST",
+    params,
+    { fields },
+  );
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "unknown error");
+    throw new Error(`[brand-client] extract-fields failed (${res.status}): ${text}`);
+  }
+
+  return res.json() as Promise<ExtractFieldsResponse>;
+}
+
+// ---------------------------------------------------------------------------
+// GET /public-information-map + POST /public-information-content
+// Used by extract_brand_text to get the full text of a brand's website.
+// ---------------------------------------------------------------------------
+
+interface PublicInfoMapEntry {
+  url: string;
+  source_type: string;
+  description?: string;
+}
+
+export async function getPublicInformationMap(
+  brandId: string,
+  params: BrandCallParams,
+): Promise<PublicInfoMapEntry[]> {
+  const res = await apiServiceFetch(
+    `/v1/brands/${encodeURIComponent(brandId)}/public-information-map`,
+    "GET",
+    params,
+  );
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "unknown error");
+    throw new Error(`[brand-client] public-information-map failed (${res.status}): ${text}`);
+  }
+
+  const data = await res.json() as { urls?: PublicInfoMapEntry[] } | PublicInfoMapEntry[];
+  return Array.isArray(data) ? data : (data.urls ?? []);
+}
+
+interface PublicInfoContentEntry {
+  url: string;
+  content: string;
+  source_type: string;
+}
+
+export async function getPublicInformationContent(
+  brandId: string,
+  selectedUrls: Array<{ url: string; source_type: string }>,
+  params: BrandCallParams,
+): Promise<PublicInfoContentEntry[]> {
+  const res = await apiServiceFetch(
+    `/v1/brands/${encodeURIComponent(brandId)}/public-information-content`,
+    "POST",
+    params,
+    { selected_urls: selectedUrls },
+  );
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "unknown error");
+    throw new Error(`[brand-client] public-information-content failed (${res.status}): ${text}`);
+  }
+
+  const data = await res.json() as { contents?: PublicInfoContentEntry[] } | PublicInfoContentEntry[];
+  return Array.isArray(data) ? data : (data.contents ?? []);
+}
+
+/**
+ * High-level: get the full text of a brand's public pages.
+ * Fetches the URL map, then fetches content for all scraped pages.
+ */
+export async function extractBrandText(
+  brandId: string,
+  params: BrandCallParams,
+): Promise<{ brandId: string; pages: Array<{ url: string; content: string }> }> {
+  const urlMap = await getPublicInformationMap(brandId, params);
+
+  // Filter to scraped pages only (skip LinkedIn posts, etc.)
+  const scrapedPages = urlMap.filter((entry) => entry.source_type === "scraped_page");
+
+  if (scrapedPages.length === 0) {
+    return { brandId, pages: [] };
+  }
+
+  const contents = await getPublicInformationContent(
+    brandId,
+    scrapedPages.map((entry) => ({ url: entry.url, source_type: entry.source_type })),
+    params,
+  );
+
+  return {
+    brandId,
+    pages: contents.map((c) => ({ url: c.url, content: c.content })),
+  };
+}

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -119,7 +119,8 @@ export const AppConfigRequestSchema = z
         "list_services, list_service_endpoints, " +
         "list_org_keys, get_key_source, list_key_sources, check_provider_requirements, " +
         "create_feature, update_feature, list_features, get_feature, get_feature_inputs, " +
-        "prefill_feature, get_feature_stats",
+        "prefill_feature, get_feature_stats, " +
+        "update_campaign_fields, extract_brand_fields, extract_brand_text",
       example: [
         "request_user_input",
         "update_workflow",

--- a/tests/unit/brand-client.test.ts
+++ b/tests/unit/brand-client.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  process.env.ADMIN_DISTRIBUTE_API_KEY = "test-api-svc-key";
+  process.env.API_SERVICE_URL = "https://api.test.local";
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.restoreAllMocks();
+});
+
+async function loadModule() {
+  vi.resetModules();
+  return import("../../src/lib/brand-client.js");
+}
+
+const baseParams = {
+  orgId: "org-1",
+  userId: "user-1",
+  runId: "run-1",
+};
+
+describe("extractBrandFields", () => {
+  it("calls POST /v1/brands/{brandId}/extract-fields via api-service", async () => {
+    const mockResponse = {
+      brandId: "brand-123",
+      results: [
+        { key: "industry", value: "SaaS", cached: false, extractedAt: "2026-01-01T00:00:00Z", expiresAt: "2026-01-31T00:00:00Z", sourceUrls: ["https://example.com"] },
+      ],
+    };
+
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    });
+
+    const { extractBrandFields } = await loadModule();
+    const result = await extractBrandFields(
+      "brand-123",
+      [{ key: "industry", description: "The brand's primary industry" }],
+      baseParams,
+    );
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.test.local/v1/brands/brand-123/extract-fields",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "x-org-id": "org-1",
+          "x-user-id": "user-1",
+          "x-run-id": "run-1",
+        }),
+        body: JSON.stringify({
+          fields: [{ key: "industry", description: "The brand's primary industry" }],
+        }),
+      }),
+    );
+
+    expect(result.brandId).toBe("brand-123");
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].key).toBe("industry");
+    expect(result.results[0].value).toBe("SaaS");
+  });
+
+  it("throws on non-OK response", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve("Brand not found"),
+    });
+
+    const { extractBrandFields } = await loadModule();
+
+    await expect(
+      extractBrandFields("brand-missing", [{ key: "x", description: "y" }], baseParams),
+    ).rejects.toThrow("[brand-client] extract-fields failed (404)");
+  });
+
+  it("forwards tracking headers when provided", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ brandId: "b-1", results: [] }),
+    });
+
+    const { extractBrandFields } = await loadModule();
+    await extractBrandFields("b-1", [{ key: "x", description: "y" }], {
+      ...baseParams,
+      trackingHeaders: { "x-campaign-id": "camp-1", "x-brand-id": "b-1" },
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-campaign-id": "camp-1",
+          "x-brand-id": "b-1",
+        }),
+      }),
+    );
+  });
+});
+
+describe("extractBrandText", () => {
+  it("fetches URL map then content for scraped pages", async () => {
+    const urlMap = [
+      { url: "https://example.com/", source_type: "scraped_page", description: "Home" },
+      { url: "https://example.com/about", source_type: "scraped_page", description: "About" },
+      { url: "https://linkedin.com/post/123", source_type: "linkedin_post", description: "Post" },
+    ];
+
+    const contents = [
+      { url: "https://example.com/", content: "Welcome to Example Inc.", source_type: "scraped_page" },
+      { url: "https://example.com/about", content: "We are a SaaS company.", source_type: "scraped_page" },
+    ];
+
+    (fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(urlMap),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(contents),
+      });
+
+    const { extractBrandText } = await loadModule();
+    const result = await extractBrandText("brand-123", baseParams);
+
+    expect(result.brandId).toBe("brand-123");
+    expect(result.pages).toHaveLength(2);
+    expect(result.pages[0].url).toBe("https://example.com/");
+    expect(result.pages[0].content).toBe("Welcome to Example Inc.");
+    expect(result.pages[1].url).toBe("https://example.com/about");
+
+    // First call: GET public-information-map
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.test.local/v1/brands/brand-123/public-information-map",
+      expect.objectContaining({ method: "GET" }),
+    );
+
+    // Second call: POST public-information-content — only scraped_page entries
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.test.local/v1/brands/brand-123/public-information-content",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          selected_urls: [
+            { url: "https://example.com/", source_type: "scraped_page" },
+            { url: "https://example.com/about", source_type: "scraped_page" },
+          ],
+        }),
+      }),
+    );
+  });
+
+  it("returns empty pages when no scraped pages in URL map", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve([]),
+    });
+
+    const { extractBrandText } = await loadModule();
+    const result = await extractBrandText("brand-empty", baseParams);
+
+    expect(result.brandId).toBe("brand-empty");
+    expect(result.pages).toHaveLength(0);
+    // Should NOT make a second fetch call
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles wrapped response format (object with urls/contents keys)", async () => {
+    (fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ urls: [{ url: "https://example.com/", source_type: "scraped_page" }] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ contents: [{ url: "https://example.com/", content: "Hello", source_type: "scraped_page" }] }),
+      });
+
+    const { extractBrandText } = await loadModule();
+    const result = await extractBrandText("brand-wrapped", baseParams);
+
+    expect(result.pages).toHaveLength(1);
+    expect(result.pages[0].content).toBe("Hello");
+  });
+
+  it("throws when URL map request fails", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("Internal error"),
+    });
+
+    const { extractBrandText } = await loadModule();
+
+    await expect(
+      extractBrandText("brand-err", baseParams),
+    ).rejects.toThrow("[brand-client] public-information-map failed (500)");
+  });
+});

--- a/tests/unit/tool-registry.test.ts
+++ b/tests/unit/tool-registry.test.ts
@@ -7,6 +7,9 @@ describe("TOOL_REGISTRY", () => {
     expect(AVAILABLE_TOOL_NAMES).toContain("update_workflow");
     expect(AVAILABLE_TOOL_NAMES).toContain("create_feature");
     expect(AVAILABLE_TOOL_NAMES).toContain("list_services");
+    expect(AVAILABLE_TOOL_NAMES).toContain("update_campaign_fields");
+    expect(AVAILABLE_TOOL_NAMES).toContain("extract_brand_fields");
+    expect(AVAILABLE_TOOL_NAMES).toContain("extract_brand_text");
   });
 
   it("does NOT contain call_api (removed for security)", () => {


### PR DESCRIPTION
## Summary
- Add 3 new tools for the `campaign-prefill` configKey: `update_campaign_fields`, `extract_brand_fields`, `extract_brand_text`
- `update_campaign_fields` is a passthrough — returns `{ fields }` so the frontend can apply values to the campaign form
- `extract_brand_fields` wraps brand-service `POST /brands/{brandId}/extract-fields` (cached 30 days)
- `extract_brand_text` fetches the brand's public page content via `public-information-map` + `public-information-content`
- New `src/lib/brand-client.ts` module with full test coverage

## Test plan
- [x] All existing unit tests pass (338 passed)
- [x] New `brand-client.test.ts` covers: extract-fields API call, error handling, tracking headers forwarding, extract-text happy path, empty URL map, wrapped response format, error propagation
- [x] `tool-registry.test.ts` updated to verify new tools are registered
- [x] Build passes, openapi.json regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)