### PR TITLE
feat: support multi-brand x-brand-id CSV header

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ All endpoints (except `/health` and `/openapi.json`) require these headers:
 | `x-user-id` | Internal user UUID from client-service |
 | `x-run-id` | Caller's run ID — used as `parentRunId` when creating this service's own run in runs-service |
 | `x-campaign-id` | _(optional)_ Campaign ID — injected automatically by workflow-service |
-| `x-brand-id` | _(optional)_ Brand ID — injected automatically by workflow-service |
+| `x-brand-id` | _(optional)_ Brand ID(s) — injected automatically by workflow-service. May be a single UUID or a comma-separated list of UUIDs for multi-brand campaigns (e.g. `uuid1,uuid2,uuid3`). |
 | `x-workflow-slug` | _(optional)_ Workflow slug — injected automatically by workflow-service |
 | `x-feature-slug` | _(optional)_ Feature slug — propagated through the entire service chain |
 
@@ -416,7 +416,7 @@ Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token st
 Uses PostgreSQL via Drizzle ORM. Three tables:
 
 - **sessions** — conversation sessions scoped by `orgId` and `userId`
-- **messages** — chat messages with role, content, optional `toolCalls`, `buttons`, `contentBlocks` JSONB (stores full Anthropic content blocks for context management), `runId` linking to RunsService, and optional `campaign_id`, `brand_id`, `workflow_slug`, `feature_slug` for workflow tracking
+- **messages** — chat messages with role, content, optional `toolCalls`, `buttons`, `contentBlocks` JSONB (stores full Anthropic content blocks for context management), `runId` linking to RunsService, and optional `campaign_id`, `brand_ids` (text array for multi-brand support), `workflow_slug`, `feature_slug` for workflow tracking
 - **app_configs** — per-org configuration keyed by `(orgId, key)`. Each entry defines a system prompt and `allowedTools` for a specific chat mode.
 - **platform_configs** — platform-wide configuration keyed by `key`. Fallback when no per-org config exists for the same key.
 

--- a/drizzle/0011_migrate_brand_id_to_brand_ids.sql
+++ b/drizzle/0011_migrate_brand_id_to_brand_ids.sql
@@ -1,0 +1,11 @@
+-- Migrate brand_id (text) to brand_ids (text[]) on messages table
+ALTER TABLE "messages" ADD COLUMN "brand_ids" text[];
+
+-- Migrate existing single-brand data into the array column
+UPDATE "messages" SET "brand_ids" = ARRAY["brand_id"] WHERE "brand_id" IS NOT NULL;
+
+-- Drop the old column
+ALTER TABLE "messages" DROP COLUMN "brand_id";
+
+-- Add GIN index for efficient ANY() queries on brand_ids
+CREATE INDEX "messages_brand_ids_idx" ON "messages" USING GIN ("brand_ids");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1774972800000,
       "tag": "0010_add_config_key_and_allowed_tools",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1775059200000,
+      "tag": "0011_migrate_brand_id_to_brand_ids",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -758,10 +758,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID — injected automatically by workflow-service"
+              "description": "Brand ID(s) — injected automatically by workflow-service. May be a single UUID or a comma-separated list of UUIDs for multi-brand campaigns (e.g. 'uuid1,uuid2,uuid3').",
+              "example": "550e8400-e29b-41d4-a716-446655440000,660f9500-f30c-52e5-b827-557766551111"
             },
             "required": false,
-            "description": "Brand ID — injected automatically by workflow-service",
+            "description": "Brand ID(s) — injected automatically by workflow-service. May be a single UUID or a comma-separated list of UUIDs for multi-brand campaigns (e.g. 'uuid1,uuid2,uuid3').",
             "name": "x-brand-id",
             "in": "header"
           },
@@ -953,10 +954,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID — injected automatically by workflow-service"
+              "description": "Brand ID(s) — injected automatically by workflow-service. May be a single UUID or a comma-separated list of UUIDs for multi-brand campaigns (e.g. 'uuid1,uuid2,uuid3').",
+              "example": "550e8400-e29b-41d4-a716-446655440000,660f9500-f30c-52e5-b827-557766551111"
             },
             "required": false,
-            "description": "Brand ID — injected automatically by workflow-service",
+            "description": "Brand ID(s) — injected automatically by workflow-service. May be a single UUID or a comma-separated list of UUIDs for multi-brand campaigns (e.g. 'uuid1,uuid2,uuid3').",
             "name": "x-brand-id",
             "in": "header"
           },
@@ -1106,10 +1108,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID — injected automatically by workflow-service"
+              "description": "Brand ID(s) — injected automatically by workflow-service. May be a single UUID or a comma-separated list of UUIDs for multi-brand campaigns (e.g. 'uuid1,uuid2,uuid3').",
+              "example": "550e8400-e29b-41d4-a716-446655440000,660f9500-f30c-52e5-b827-557766551111"
             },
             "required": false,
-            "description": "Brand ID — injected automatically by workflow-service",
+            "description": "Brand ID(s) — injected automatically by workflow-service. May be a single UUID or a comma-separated list of UUIDs for multi-brand campaigns (e.g. 'uuid1,uuid2,uuid3').",
             "name": "x-brand-id",
             "in": "header"
           },

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -21,7 +21,7 @@ export const messages = pgTable("messages", {
   tokenCount: integer("token_count"),
   runId: uuid("run_id"),
   campaignId: text("campaign_id"),
-  brandId: text("brand_id"),
+  brandIds: text("brand_ids").array(),
   workflowSlug: text("workflow_slug"),
   featureSlug: text("feature_slug"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -593,7 +593,7 @@ app.post("/chat", requireAuth, async (req, res) => {
       role: "user",
       content: message.trim(),
       campaignId: workflowTracking.campaignId ?? null,
-      brandId: workflowTracking.brandId ?? null,
+      brandIds: workflowTracking.brandId ? workflowTracking.brandId.split(",").map(s => s.trim()).filter(Boolean) : null,
       workflowSlug: workflowTracking.workflowSlug ?? null,
       featureSlug: workflowTracking.featureSlug ?? null,
     });
@@ -1022,7 +1022,6 @@ app.post("/chat", requireAuth, async (req, res) => {
       if (call.name === "extract_brand_fields") {
         const args = (call.args as Record<string, unknown>) || {};
         const result = await extractBrandFields(
-          args.brandId as string,
           args.fields as Array<{ key: string; description: string }>,
           featureCallParams,
         );
@@ -1237,7 +1236,7 @@ app.post("/chat", requireAuth, async (req, res) => {
       tokenCount: totalPromptTokens + totalOutputTokens || null,
       runId,
       campaignId: workflowTracking.campaignId ?? null,
-      brandId: workflowTracking.brandId ?? null,
+      brandIds: workflowTracking.brandId ? workflowTracking.brandId.split(",").map(s => s.trim()).filter(Boolean) : null,
       workflowSlug: workflowTracking.workflowSlug ?? null,
       featureSlug: workflowTracking.featureSlug ?? null,
     });

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -780,14 +780,10 @@ export const UPDATE_CAMPAIGN_FIELDS_TOOL: Anthropic.Tool = {
 export const EXTRACT_BRAND_FIELDS_TOOL: Anthropic.Tool = {
   name: "extract_brand_fields",
   description:
-    "Extract arbitrary fields from a brand's website using AI. Wraps brand-service extract-fields endpoint. Results are cached 30 days per field — safe to call repeatedly.",
+    "Extract arbitrary fields from the brand's website using AI. Uses the brand(s) from the x-brand-id header (no brandId parameter needed). Wraps brand-service extract-fields endpoint. Results are cached 30 days per field — safe to call repeatedly.",
   input_schema: {
     type: "object" as const,
     properties: {
-      brandId: {
-        type: "string",
-        description: "UUID of the brand to extract fields from.",
-      },
       fields: {
         type: "array",
         items: {
@@ -807,7 +803,7 @@ export const EXTRACT_BRAND_FIELDS_TOOL: Anthropic.Tool = {
         description: "List of fields to extract. Each field has a key and a description.",
       },
     },
-    required: ["brandId", "fields"],
+    required: ["fields"],
   },
 };
 

--- a/src/lib/brand-client.ts
+++ b/src/lib/brand-client.ts
@@ -3,7 +3,7 @@ import { apiServiceFetch, type ApiCallParams } from "./api-client.js";
 export type BrandCallParams = ApiCallParams;
 
 // ---------------------------------------------------------------------------
-// POST /brands/{brandId}/extract-fields
+// POST /brands/extract-fields  (reads x-brand-id from forwarded headers)
 // ---------------------------------------------------------------------------
 
 export interface ExtractFieldDef {
@@ -26,12 +26,11 @@ export interface ExtractFieldsResponse {
 }
 
 export async function extractBrandFields(
-  brandId: string,
   fields: ExtractFieldDef[],
   params: BrandCallParams,
 ): Promise<ExtractFieldsResponse> {
   const res = await apiServiceFetch(
-    `/v1/brands/${encodeURIComponent(brandId)}/extract-fields`,
+    `/v1/brands/extract-fields`,
     "POST",
     params,
     { fields },

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -15,7 +15,8 @@ const workflowTrackingHeaders = {
     description: "Campaign ID — injected automatically by workflow-service",
   }),
   "x-brand-id": z.string().optional().openapi({
-    description: "Brand ID — injected automatically by workflow-service",
+    description: "Brand ID(s) — injected automatically by workflow-service. May be a single UUID or a comma-separated list of UUIDs for multi-brand campaigns (e.g. 'uuid1,uuid2,uuid3').",
+    example: "550e8400-e29b-41d4-a716-446655440000,660f9500-f30c-52e5-b827-557766551111",
   }),
   "x-workflow-slug": z.string().optional().openapi({
     description: "Workflow slug — injected automatically by workflow-service",

--- a/tests/unit/brand-client.test.ts
+++ b/tests/unit/brand-client.test.ts
@@ -25,7 +25,7 @@ const baseParams = {
 };
 
 describe("extractBrandFields", () => {
-  it("calls POST /v1/brands/{brandId}/extract-fields via api-service", async () => {
+  it("calls POST /v1/brands/extract-fields via api-service (no brandId in path)", async () => {
     const mockResponse = {
       brandId: "brand-123",
       results: [
@@ -40,19 +40,19 @@ describe("extractBrandFields", () => {
 
     const { extractBrandFields } = await loadModule();
     const result = await extractBrandFields(
-      "brand-123",
       [{ key: "industry", description: "The brand's primary industry" }],
-      baseParams,
+      { ...baseParams, trackingHeaders: { "x-brand-id": "brand-123" } },
     );
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://api.test.local/v1/brands/brand-123/extract-fields",
+      "https://api.test.local/v1/brands/extract-fields",
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({
           "x-org-id": "org-1",
           "x-user-id": "user-1",
           "x-run-id": "run-1",
+          "x-brand-id": "brand-123",
         }),
         body: JSON.stringify({
           fields: [{ key: "industry", description: "The brand's primary industry" }],
@@ -76,20 +76,20 @@ describe("extractBrandFields", () => {
     const { extractBrandFields } = await loadModule();
 
     await expect(
-      extractBrandFields("brand-missing", [{ key: "x", description: "y" }], baseParams),
+      extractBrandFields([{ key: "x", description: "y" }], baseParams),
     ).rejects.toThrow("[brand-client] extract-fields failed (404)");
   });
 
-  it("forwards tracking headers when provided", async () => {
+  it("forwards tracking headers including multi-brand CSV x-brand-id", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ brandId: "b-1", results: [] }),
     });
 
     const { extractBrandFields } = await loadModule();
-    await extractBrandFields("b-1", [{ key: "x", description: "y" }], {
+    await extractBrandFields([{ key: "x", description: "y" }], {
       ...baseParams,
-      trackingHeaders: { "x-campaign-id": "camp-1", "x-brand-id": "b-1" },
+      trackingHeaders: { "x-campaign-id": "camp-1", "x-brand-id": "b-1,b-2,b-3" },
     });
 
     expect(fetch).toHaveBeenCalledWith(
@@ -97,7 +97,7 @@ describe("extractBrandFields", () => {
       expect.objectContaining({
         headers: expect.objectContaining({
           "x-campaign-id": "camp-1",
-          "x-brand-id": "b-1",
+          "x-brand-id": "b-1,b-2,b-3",
         }),
       }),
     );

--- a/tests/unit/workflow-tracking.test.ts
+++ b/tests/unit/workflow-tracking.test.ts
@@ -21,7 +21,7 @@ const BASE_HEADERS = {
 };
 
 describe("workflow tracking headers in auth middleware", () => {
-  it("extracts all three tracking headers when present", () => {
+  it("extracts all tracking headers when present", () => {
     const { req, res, next } = mockReqRes({
       ...BASE_HEADERS,
       "x-campaign-id": "camp-abc",
@@ -37,6 +37,19 @@ describe("workflow tracking headers in auth middleware", () => {
       brandId: "brand-xyz",
       workflowSlug: "outreach-v2",
       featureSlug: "pr-outreach",
+    });
+  });
+
+  it("preserves CSV x-brand-id header as-is for multi-brand campaigns", () => {
+    const { req, res, next } = mockReqRes({
+      ...BASE_HEADERS,
+      "x-brand-id": "brand-1,brand-2,brand-3",
+    });
+    requireAuth(req, res, next);
+    expect(next).toHaveBeenCalled();
+    const locals = res.locals as unknown as AuthLocals;
+    expect(locals.workflowTracking).toEqual({
+      brandId: "brand-1,brand-2,brand-3",
     });
   });
 


### PR DESCRIPTION
## Summary
- Parse `x-brand-id` header as CSV (comma-separated UUIDs) for multi-brand campaign support
- Migrate `brand_id` column → `brand_ids text[]` with GIN index on messages table
- Switch `extractBrandFields` to new `POST /brands/extract-fields` endpoint (reads brand from x-brand-id header instead of path param)
- Remove `brandId` from `extract_brand_fields` tool definition (header-driven now)
- Update OpenAPI spec and README with CSV format documentation

## Test plan
- [x] Unit tests pass — brand-client, workflow-tracking, tool-registry, schemas, openapi
- [x] New test: multi-brand CSV header preserved in workflow tracking
- [x] Updated brand-client tests for new endpoint path and multi-brand header forwarding
- [ ] Run migration on staging DB and verify `brand_ids` array column works
- [ ] Verify single-brand campaigns still work (single UUID in header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)