### PR TITLE
fix: increase body-parser limit to 10mb for vision requests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ import { mergeConsecutiveMessages, stripToolUseBlocks } from "./lib/merge-messag
 
 const app = express();
 app.use(cors());
-app.use(express.json());
+app.use(express.json({ limit: "10mb" }));
 
 const PORT = parseInt(process.env.PORT || "3002", 10);
 

--- a/tests/unit/body-parser-limit.test.ts
+++ b/tests/unit/body-parser-limit.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import express from "express";
+import http from "http";
+
+/**
+ * Regression test for PayloadTooLargeError.
+ *
+ * The default Express body-parser limit is 100kb, which is too small for
+ * vision requests that include large system prompts, conversation history,
+ * or imageContext fields. This caused 100% of /complete vision calls to fail
+ * silently with 413 PayloadTooLargeError.
+ *
+ * Fix: express.json({ limit: "10mb" }) in src/index.ts.
+ */
+
+function createTestApp(limit?: string) {
+  const app = express();
+  app.use(express.json(limit ? { limit } : {}));
+  app.post("/echo", (req, res) => {
+    res.json({ size: JSON.stringify(req.body).length });
+  });
+  return app;
+}
+
+function postJSON(
+  server: http.Server,
+  body: string
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const addr = server.address();
+    if (!addr || typeof addr === "string") return reject(new Error("no address"));
+    const req = http.request(
+      { hostname: "127.0.0.1", port: addr.port, path: "/echo", method: "POST", headers: { "content-type": "application/json" } },
+      (res) => {
+        let data = "";
+        res.on("data", (chunk) => (data += chunk));
+        res.on("end", () => resolve({ status: res.statusCode ?? 0, body: data }));
+      }
+    );
+    req.on("error", reject);
+    req.end(body);
+  });
+}
+
+function listenOnRandomPort(app: express.Express): Promise<http.Server> {
+  return new Promise((resolve) => {
+    const server = app.listen(0, "127.0.0.1", () => resolve(server));
+  });
+}
+
+describe("body-parser limit", () => {
+  it("rejects >100kb payload with default Express limit", async () => {
+    const app = createTestApp(); // default 100kb
+    const server = await listenOnRandomPort(app);
+    try {
+      const largePayload = JSON.stringify({ data: "x".repeat(200_000) });
+      const res = await postJSON(server, largePayload);
+      expect(res.status).toBe(413);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("accepts >100kb payload with 10mb limit (the fix)", async () => {
+    const app = createTestApp("10mb");
+    const server = await listenOnRandomPort(app);
+    try {
+      const largePayload = JSON.stringify({ data: "x".repeat(200_000) });
+      const res = await postJSON(server, largePayload);
+      expect(res.status).toBe(200);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("accepts 1mb payload with 10mb limit", async () => {
+    const app = createTestApp("10mb");
+    const server = await listenOnRandomPort(app);
+    try {
+      const largePayload = JSON.stringify({ data: "x".repeat(1_000_000) });
+      const res = await postJSON(server, largePayload);
+      expect(res.status).toBe(200);
+    } finally {
+      server.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Default Express `express.json()` limit is 100kb — too small for `/complete` vision requests
- Brand-service sends `POST /complete` with `imageUrl` + conversation context that exceeds 100kb
- All vision calls failed silently with `413 PayloadTooLargeError` (brand-service sees 0 results from `batchAnalyzeImages` because `Promise.allSettled` swallows errors)
- Fix: `express.json({ limit: "10mb" })`

## Test plan
- [x] Regression test verifying >100kb payloads are rejected with default limit
- [x] Regression test verifying >100kb payloads accepted with 10mb limit
- [x] Regression test verifying 1mb payload accepted with 10mb limit
- [x] All existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)