### PR TITLE
fix: remove verbose run-created logs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -262,7 +262,6 @@ app.post("/complete", requireAuth, async (req, res) => {
       trackingHeaders,
     );
     runId = run.id;
-    console.log(`[complete] org="${orgId}" run="${runId}" created`);
   } catch (runErr) {
     console.error(`[complete] org="${orgId}" run creation failed:`, runErr);
     return res.status(502).json({
@@ -537,7 +536,6 @@ app.post("/chat", requireAuth, async (req, res) => {
         trackingHeaders,
       );
       runId = run.id;
-      console.log(`[chat] session="${currentSessionId}" run="${runId}" created`);
     } catch (runErr) {
       console.error(`[chat] session="${currentSessionId}" run creation failed:`, runErr);
       sendSSE(res, {


### PR DESCRIPTION
## Summary
- Remove `[complete] org="..." run="..." created` log from `/complete` endpoint
- Remove `[chat] session="..." run="..." created` log from `/chat` endpoint
- These fire on every request and add no diagnostic value — error logs on failure are kept

## Test plan
- [x] Build passes
- [x] All unit tests pass (342/342)

🤖 Generated with [Claude Code](https://claude.com/claude-code)