### PR TITLE
fix: trim whitespace before JSON fence-stripping, fail loud on parse errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Response:
 ```
 
 - `content` — raw text response (always present). **Warning:** when `responseFormat: "json"`, this field may contain markdown code fences (e.g. `` ```json...``` ``). Do **not** use this field for JSON parsing.
-- `json` — parsed JSON object (only when `responseFormat: "json"` and model returned valid JSON). **Always use this field** for structured data — markdown fences are already stripped and the JSON is pre-parsed.
+- `json` — parsed JSON object (present when `responseFormat: "json"`). **Always use this field** for structured data — markdown fences are already stripped and the JSON is pre-parsed. If the model returns non-parsable JSON, the endpoint returns **502** instead of silently omitting this field.
 - `tokensInput` / `tokensOutput` — token usage
 - `model` — model used
 

--- a/openapi.json
+++ b/openapi.json
@@ -457,7 +457,7 @@
             "additionalProperties": {
               "nullable": true
             },
-            "description": "Parsed JSON object — present only when responseFormat is \"json\" and the model returned valid JSON. IMPORTANT: always use this field (not `content`) when you need structured data. Markdown fences are already stripped and the JSON is pre-parsed.",
+            "description": "Parsed JSON object — present when responseFormat is \"json\". IMPORTANT: always use this field (not `content`) when you need structured data. Markdown fences are already stripped and the JSON is pre-parsed. If the model returns non-parsable JSON, the endpoint returns 502 instead of silently omitting this field.",
             "example": {
               "subject": "Quick question",
               "emails": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -333,15 +333,16 @@ app.post("/complete", requireAuth, async (req, res) => {
 
     // Parse JSON if requested
     if (responseFormat === "json") {
+      const trimmed = result.content.trim();
       try {
-        response.json = JSON.parse(result.content);
+        response.json = JSON.parse(trimmed);
       } catch {
         // LLM sometimes wraps JSON in markdown fences — strip and retry
-        const stripped = result.content.replace(/^```(?:json)?\s*\n?/i, "").replace(/\n?```\s*$/i, "");
+        const stripped = trimmed.replace(/^```(?:json)?\s*\n?/i, "").replace(/\n?```\s*$/i, "").trim();
         try {
           response.json = JSON.parse(stripped);
         } catch {
-          // Model returned non-parsable content despite JSON mode — return raw content only
+          throw new Error(`Model returned non-parsable JSON despite responseFormat: "json". Content: ${result.content.slice(0, 500)}`);
         }
       }
     }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -348,7 +348,7 @@ export const CompleteResponseSchema = z
       example: '{"subject": "Quick question", "emails": [{"body": "Hi...", "daysSinceLastStep": 0}]}',
     }),
     json: z.record(z.string(), z.unknown()).optional().openapi({
-      description: "Parsed JSON object — present only when responseFormat is \"json\" and the model returned valid JSON. IMPORTANT: always use this field (not `content`) when you need structured data. Markdown fences are already stripped and the JSON is pre-parsed.",
+      description: "Parsed JSON object — present when responseFormat is \"json\". IMPORTANT: always use this field (not `content`) when you need structured data. Markdown fences are already stripped and the JSON is pre-parsed. If the model returns non-parsable JSON, the endpoint returns 502 instead of silently omitting this field.",
       example: { subject: "Quick question", emails: [{ body: "Hi there, I noticed...", daysSinceLastStep: 0 }] },
     }),
     tokensInput: z.number().openapi({

--- a/tests/unit/json-markdown-strip.test.ts
+++ b/tests/unit/json-markdown-strip.test.ts
@@ -3,16 +3,18 @@ import { describe, it, expect } from "vitest";
 /**
  * Mirrors the markdown-fence stripping logic in src/index.ts /complete handler.
  * If JSON.parse fails on raw content, strip ```json fences and retry.
+ * Throws on truly unparsable content (no silent fallback).
  */
-function parseJsonWithFenceStrip(content: string): unknown | null {
+function parseJsonWithFenceStrip(content: string): unknown {
+  const trimmed = content.trim();
   try {
-    return JSON.parse(content);
+    return JSON.parse(trimmed);
   } catch {
-    const stripped = content.replace(/^```(?:json)?\s*\n?/i, "").replace(/\n?```\s*$/i, "");
+    const stripped = trimmed.replace(/^```(?:json)?\s*\n?/i, "").replace(/\n?```\s*$/i, "").trim();
     try {
       return JSON.parse(stripped);
     } catch {
-      return null;
+      throw new Error(`Model returned non-parsable JSON. Content: ${content.slice(0, 500)}`);
     }
   }
 }
@@ -47,20 +49,46 @@ describe("JSON markdown fence stripping", () => {
     expect(result).toEqual([{ id: 1 }, { id: 2 }]);
   });
 
-  it("returns null for truly unparsable content", () => {
-    const result = parseJsonWithFenceStrip("This is not JSON at all");
-    expect(result).toBeNull();
+  it("throws for truly unparsable content", () => {
+    expect(() => parseJsonWithFenceStrip("This is not JSON at all")).toThrow(
+      "Model returned non-parsable JSON",
+    );
   });
 
-  it("returns null for fenced non-JSON content", () => {
+  it("throws for fenced non-JSON content", () => {
     const content = '```json\nnot actually json\n```';
-    const result = parseJsonWithFenceStrip(content);
-    expect(result).toBeNull();
+    expect(() => parseJsonWithFenceStrip(content)).toThrow(
+      "Model returned non-parsable JSON",
+    );
   });
 
   it("handles fences with no trailing newline", () => {
     const content = '```json\n{"ok": true}```';
     const result = parseJsonWithFenceStrip(content);
     expect(result).toEqual({ ok: true });
+  });
+
+  it("handles leading/trailing whitespace around fences", () => {
+    const content = '\n```json\n{"isArticle": false, "authors": [], "publishedAt": null}\n```\n';
+    const result = parseJsonWithFenceStrip(content);
+    expect(result).toEqual({ isArticle: false, authors: [], publishedAt: null });
+  });
+
+  it("handles leading/trailing whitespace around plain JSON", () => {
+    const content = '  \n{"key": "value"}\n  ';
+    const result = parseJsonWithFenceStrip(content);
+    expect(result).toEqual({ key: "value" });
+  });
+
+  it("handles whitespace inside fences around JSON", () => {
+    const content = '```json\n\n  {"key": "value"}\n\n```';
+    const result = parseJsonWithFenceStrip(content);
+    expect(result).toEqual({ key: "value" });
+  });
+
+  it("handles \\r\\n line endings", () => {
+    const content = '```json\r\n{"key": "value"}\r\n```';
+    const result = parseJsonWithFenceStrip(content);
+    expect(result).toEqual({ key: "value" });
   });
 });


### PR DESCRIPTION
## Summary
- **Root cause**: `/complete` with `responseFormat: "json"` used `^`/`$` regex anchors to strip markdown fences, but never `.trim()`ed first. Leading/trailing whitespace in LLM output caused the regex to miss entirely, making `JSON.parse` fail on both attempts.
- **Silent fallback**: When parsing failed, the `json` field was silently omitted (`undefined`), causing downstream callers (articles-service, outlets-service) to lose entire batches without errors.
- **Fix**: Trim content before fence-stripping, and throw (→ 502) instead of silently dropping the `json` field.

## Changes
- `src/index.ts`: `.trim()` before regex, `.trim()` after strip, throw on final parse failure
- `tests/unit/json-markdown-strip.test.ts`: Added 4 regression tests (leading/trailing whitespace, inner whitespace, \r\n, error throwing)
- `src/schemas.ts` + `openapi.json`: Updated `json` field description to document 502 behavior
- `README.md`: Updated response field docs

## Test plan
- [x] New tests cover the exact reproduction case from the bug report (`\n```json\n{...}\n```\n`)
- [x] All 12 fence-strip tests pass
- [x] Full test suite passes (346 tests)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)