### PR TITLE
fix: use Anthropic structured outputs for JSON mode

### DIFF
--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -1034,6 +1034,19 @@ export function createAnthropicClient({ apiKey, systemPrompt }: AnthropicOptions
         system: systemPrompt,
         messages: [{ role: "user", content: userContent }],
         ...(options?.temperature != null ? { temperature: options.temperature } : {}),
+        ...(options?.responseFormat === "json"
+          ? {
+              output_config: {
+                format: {
+                  type: "json_schema" as const,
+                  schema: {
+                    type: "object",
+                    additionalProperties: true,
+                  },
+                },
+              },
+            }
+          : {}),
       };
 
       const response = await client.messages.create(params);

--- a/tests/unit/anthropic-output-config.test.ts
+++ b/tests/unit/anthropic-output-config.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Tests that createAnthropicClient().complete() passes output_config
+ * with json_schema when responseFormat: "json" is requested, ensuring
+ * Anthropic's constrained decoding produces valid JSON (no fences, no
+ * malformed output).
+ */
+
+// Capture the params passed to client.messages.create
+let capturedParams: Record<string, unknown> | undefined;
+
+vi.mock("@anthropic-ai/sdk", () => {
+  return {
+    default: class MockAnthropic {
+      messages = {
+        create: async (params: Record<string, unknown>) => {
+          capturedParams = params;
+          return {
+            content: [{ type: "text", text: '{"ok":true}' }],
+            usage: { input_tokens: 10, output_tokens: 5 },
+          };
+        },
+        stream: () => {
+          throw new Error("stream not implemented in mock");
+        },
+      };
+    },
+  };
+});
+
+// Import after mock is set up
+const { createAnthropicClient } = await import("../../src/lib/anthropic.js");
+
+describe("anthropic complete() output_config", () => {
+  beforeEach(() => {
+    capturedParams = undefined;
+  });
+
+  it("passes output_config with json_schema when responseFormat is json", async () => {
+    const claude = createAnthropicClient({ apiKey: "test-key", systemPrompt: "You are helpful." });
+    await claude.complete("Return JSON", { responseFormat: "json" });
+
+    expect(capturedParams).toBeDefined();
+    expect(capturedParams!.output_config).toEqual({
+      format: {
+        type: "json_schema",
+        schema: {
+          type: "object",
+          additionalProperties: true,
+        },
+      },
+    });
+  });
+
+  it("does NOT pass output_config when responseFormat is omitted", async () => {
+    const claude = createAnthropicClient({ apiKey: "test-key", systemPrompt: "You are helpful." });
+    await claude.complete("Hello");
+
+    expect(capturedParams).toBeDefined();
+    expect(capturedParams!.output_config).toBeUndefined();
+  });
+
+  it("returns parsed content from text blocks", async () => {
+    const claude = createAnthropicClient({ apiKey: "test-key", systemPrompt: "You are helpful." });
+    const result = await claude.complete("Return JSON", { responseFormat: "json" });
+
+    expect(result.content).toBe('{"ok":true}');
+    expect(result.tokensInput).toBe(10);
+    expect(result.tokensOutput).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary
- Pass `output_config.format` with `json_schema` to the Anthropic API when `responseFormat: "json"` is requested
- This enables constrained decoding — the model is hard-constrained to produce valid JSON, eliminating code fences and malformed output
- Root cause fix for `/complete` returning `json: undefined` when callers request JSON format

## What changed
- `src/lib/anthropic.ts`: Added `output_config` with `json_schema` format to `complete()` params when `responseFormat: "json"`
- `tests/unit/anthropic-output-config.test.ts`: New tests verifying `output_config` is passed/omitted correctly

## Test plan
- [x] New unit tests verify output_config is passed when responseFormat is "json"
- [x] New unit tests verify output_config is NOT passed when responseFormat is omitted
- [x] Full test suite passes (349 tests)
- [ ] Deploy and verify /complete with responseFormat: "json" returns populated json field

🤖 Generated with [Claude Code](https://claude.com/claude-code)