### PR TITLE
feat: require provider + model alias in POST /complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,10 +154,11 @@ Request body:
 {
   "message": "Given this brand context, generate 10 Google search queries...",
   "systemPrompt": "You are a PR research assistant...",
+  "provider": "anthropic",
+  "model": "haiku",
   "responseFormat": "json",
   "temperature": 0.3,
-  "maxTokens": 2000,
-  "model": "claude-haiku-4-5"
+  "maxTokens": 2000
 }
 ```
 
@@ -166,9 +167,10 @@ Request body:
 {
   "message": "Analyze this image and score it on: is_logo, is_product, is_team_photo, is_professional (0-1 each)",
   "systemPrompt": "You are an image classification assistant. Return JSON with scores.",
+  "provider": "google",
+  "model": "flash-lite",
   "imageUrl": "https://example.com/images/hero.jpg",
   "imageContext": { "alt": "Company hero banner", "title": "About Us", "sourceUrl": "https://example.com/about" },
-  "model": "gemini-3.1-flash-lite-preview",
   "responseFormat": "json",
   "temperature": 0,
   "maxTokens": 1024
@@ -177,11 +179,14 @@ Request body:
 
 - `message` (required) — the prompt to send to the LLM
 - `systemPrompt` (required) — inline system prompt (no pre-registered config needed)
+- `provider` (required) — LLM provider: `"anthropic"` or `"google"`
+- `model` (required) — version-free model alias. The service resolves the latest versioned model internally. Valid combinations:
+  - **anthropic**: `haiku` (fast/cheap), `sonnet` (balanced), `opus` (highest quality)
+  - **google**: `flash-lite` (cost-effective vision). Requires a Google API key in key-service.
 - `responseFormat` (optional) — set to `"json"` to instruct the model to return valid JSON. The parsed result appears in the `json` field.
 - `temperature` (optional) — sampling temperature, 0–2 (default: model default)
 - `maxTokens` (optional) — max output tokens, 1–64000 (default: 16000)
-- `model` (optional) — `claude-sonnet-4-6` (default), `claude-haiku-4-5` (cheaper text tasks), or `gemini-3.1-flash-lite-preview` (cost-effective vision). Gemini models require a Google API key configured in key-service (provider: `google`).
-- `imageUrl` (optional) — URL of an image to include as visual input. The image is fetched server-side. Supported by all models, but recommended with `gemini-3.1-flash-lite-preview` for cost-effective vision tasks.
+- `imageUrl` (optional) — URL of an image to include as visual input. The image is fetched server-side. Supported by all models, but recommended with `google` + `flash-lite` for cost-effective vision tasks.
 - `imageContext` (optional) — metadata about the image to help the model classify it: `{ alt?: string, title?: string, sourceUrl?: string }`. Injected into the prompt alongside the image. Only meaningful when `imageUrl` is provided.
 
 Response:
@@ -198,7 +203,7 @@ Response:
 - `content` — raw text response (always present). **Warning:** when `responseFormat: "json"`, this field may contain markdown code fences (e.g. `` ```json...``` ``). Do **not** use this field for JSON parsing.
 - `json` — parsed JSON object (present when `responseFormat: "json"`). **Always use this field** for structured data — markdown fences are already stripped and the JSON is pre-parsed. If the model returns non-parsable JSON, the endpoint returns **502** instead of silently omitting this field.
 - `tokensInput` / `tokensOutput` — token usage
-- `model` — model used
+- `model` — the versioned model ID that was actually used (resolved from the provider + alias)
 
 Unlike POST /chat, this endpoint is **stateless** (no sessions), accepts an **inline systemPrompt**, and returns **JSON** instead of SSE. Run tracking and billing work identically to POST /chat.
 

--- a/openapi.json
+++ b/openapi.json
@@ -480,7 +480,7 @@
           },
           "model": {
             "type": "string",
-            "description": "Model used for the completion",
+            "description": "Versioned model ID actually used for the completion (resolved by the service from the provider+model alias)",
             "example": "claude-sonnet-4-6"
           }
         },
@@ -551,15 +551,25 @@
             "description": "Maximum tokens in the response (default: 16000)",
             "example": 2000
           },
+          "provider": {
+            "type": "string",
+            "enum": [
+              "anthropic",
+              "google"
+            ],
+            "description": "LLM provider to use.",
+            "example": "anthropic"
+          },
           "model": {
             "type": "string",
             "enum": [
-              "claude-sonnet-4-6",
-              "claude-haiku-4-5",
-              "gemini-3.1-flash-lite-preview"
+              "haiku",
+              "sonnet",
+              "opus",
+              "flash-lite"
             ],
-            "description": "Model to use. Defaults to claude-sonnet-4-6. Use claude-haiku-4-5 for simpler tasks, or gemini-3.1-flash-lite-preview for cost-effective vision tasks (image analysis, classification).",
-            "example": "gemini-3.1-flash-lite-preview"
+            "description": "Model alias (version-free). The service resolves the latest versioned model internally.\n\n**Anthropic models:** `haiku` (fast/cheap), `sonnet` (balanced), `opus` (highest quality).\n**Google models:** `flash-lite` (cost-effective vision).\n\nThe model must match the provider: anthropic → haiku|sonnet|opus, google → flash-lite.",
+            "example": "sonnet"
           },
           "imageUrl": {
             "type": "string",
@@ -591,7 +601,9 @@
         },
         "required": [
           "message",
-          "systemPrompt"
+          "systemPrompt",
+          "provider",
+          "model"
         ]
       },
       "ChatRequest": {
@@ -898,7 +910,7 @@
           "Complete"
         ],
         "summary": "Synchronous LLM completion",
-        "description": "One-shot, non-streaming LLM call for service-to-service use. Returns a JSON response with the model output.\n\nUnlike POST /chat, this endpoint:\n- Does **not** create or use sessions (stateless, one-shot)\n- Accepts an inline `systemPrompt` (no pre-registered config required)\n- Returns JSON instead of SSE\n- Supports `responseFormat: \"json\"` — when set, the parsed object is returned in the `json` field (always use `json`, not `content`, for structured data)\n- Supports optional `temperature` and `maxTokens` overrides\n- Supports **vision** via the `imageUrl` field — the image is fetched server-side and sent as visual input to the model\n\n**Models:**\n- `claude-sonnet-4-6` (default) — general-purpose, high quality\n- `claude-haiku-4-5` — faster/cheaper for simple extraction and classification\n- `gemini-3.1-flash-lite-preview` — cost-effective vision model for image analysis, scoring, and classification. Requires a Google API key configured in key-service (provider: `google`).\n\n**Use cases:** generating search queries, scoring/analyzing text, image classification and scoring (with `imageUrl` + `gemini-3.1-flash-lite-preview`), any service that needs a quick LLM call without conversation context.",
+        "description": "One-shot, non-streaming LLM call for service-to-service use. Returns a JSON response with the model output.\n\nUnlike POST /chat, this endpoint:\n- Does **not** create or use sessions (stateless, one-shot)\n- Accepts an inline `systemPrompt` (no pre-registered config required)\n- Returns JSON instead of SSE\n- Supports `responseFormat: \"json\"` — when set, the parsed object is returned in the `json` field (always use `json`, not `content`, for structured data)\n- Supports optional `temperature` and `maxTokens` overrides\n- Supports **vision** via the `imageUrl` field — the image is fetched server-side and sent as visual input to the model\n\n**Provider + model (both required):**\nCallers specify a provider and a version-free model alias. The service resolves the latest versioned model ID internally.\n\n| provider | model | Description |\n|----------|-------|-------------|\n| `anthropic` | `sonnet` | General-purpose, high quality |\n| `anthropic` | `haiku` | Faster/cheaper for simple extraction and classification |\n| `anthropic` | `opus` | Highest quality for complex reasoning |\n| `google` | `flash-lite` | Cost-effective vision model for image analysis. Requires a Google API key in key-service. |\n\n**Use cases:** generating search queries, scoring/analyzing text, image classification and scoring (with `imageUrl` + `gemini-3.1-flash-lite-preview`), any service that needs a quick LLM call without conversation context.",
         "parameters": [
           {
             "schema": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,9 @@ import {
   MODEL,
   COST_PREFIX,
   costPrefixForModel,
+  resolveModel,
 } from "./lib/anthropic.js";
+import type { Provider, ModelAlias } from "./lib/anthropic.js";
 import { isGeminiModel, completeWithGemini } from "./lib/gemini.js";
 import {
   updateWorkflow,
@@ -191,12 +193,13 @@ app.post("/complete", requireAuth, async (req, res) => {
       .json({ error: "Invalid request", details: parsed.error.flatten() });
   }
 
-  const { message, systemPrompt, responseFormat, temperature, maxTokens, model: requestedModel, imageUrl, imageContext } = parsed.data;
+  const { message, systemPrompt, responseFormat, temperature, maxTokens, provider: requestedProvider, model: requestedModel, imageUrl, imageContext } = parsed.data;
 
-  // Determine provider from model
-  const effectiveModel = requestedModel ?? MODEL;
-  const isGemini = isGeminiModel(effectiveModel);
-  const provider = isGemini ? "google" : "anthropic";
+  // Resolve versioned model from (provider, alias) pair
+  const resolved = resolveModel(requestedProvider as Provider, requestedModel as ModelAlias);
+  const effectiveModel = resolved.apiModelId;
+  const isGemini = resolved.provider === "google";
+  const provider = resolved.provider;
 
   // Resolve API key per-request
   let resolvedKey: ResolvedKey;
@@ -216,8 +219,8 @@ app.post("/complete", requireAuth, async (req, res) => {
     });
   }
 
-  // Resolve cost prefix
-  const effectiveCostPrefix = costPrefixForModel(effectiveModel);
+  // Cost prefix from model resolution
+  const effectiveCostPrefix = resolved.costPrefix;
 
   // Credit authorization for platform keys
   if (resolvedKey.keySource === "platform") {

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -5,13 +5,61 @@ export const MODEL = "claude-sonnet-4-6";
 export const COST_PREFIX = "anthropic-sonnet-4.6";
 const MAX_TOKENS = 16_000;
 
+// ---------------------------------------------------------------------------
+// Provider + model alias → versioned API model ID + cost prefix
+// Callers specify version-free aliases (e.g. "sonnet"); the service resolves
+// the latest versioned model ID internally.
+// ---------------------------------------------------------------------------
+
+export type Provider = "anthropic" | "google";
+export type ModelAlias = "haiku" | "sonnet" | "opus" | "flash-lite";
+
+interface ResolvedModel {
+  /** Versioned model ID sent to the provider's API */
+  apiModelId: string;
+  /** Cost-name prefix for costs-service */
+  costPrefix: string;
+  /** Provider key used for key-service resolution */
+  provider: "anthropic" | "google";
+}
+
+const MODEL_MAP: Record<string, Record<string, ResolvedModel>> = {
+  anthropic: {
+    haiku: { apiModelId: "claude-haiku-4-5", costPrefix: "anthropic-haiku-4.5", provider: "anthropic" },
+    sonnet: { apiModelId: "claude-sonnet-4-6", costPrefix: "anthropic-sonnet-4.6", provider: "anthropic" },
+    opus: { apiModelId: "claude-opus-4-6", costPrefix: "anthropic-opus-4.6", provider: "anthropic" },
+  },
+  google: {
+    "flash-lite": { apiModelId: "gemini-3.1-flash-lite-preview", costPrefix: "google-flash-lite-3.1", provider: "google" },
+  },
+};
+
+/** Valid model aliases per provider — used for Zod validation. */
+export const PROVIDER_MODELS: Record<Provider, readonly ModelAlias[]> = {
+  anthropic: ["haiku", "sonnet", "opus"],
+  google: ["flash-lite"],
+};
+
 /**
- * Supported models and their costs-service prefixes.
- * Keys are Anthropic API model IDs; values are cost-name prefixes.
+ * Resolve a (provider, model alias) pair to the versioned API model ID,
+ * cost prefix, and provider string.
+ * Throws if the combination is invalid.
+ */
+export function resolveModel(provider: Provider, modelAlias: ModelAlias): ResolvedModel {
+  const providerMap = MODEL_MAP[provider];
+  if (!providerMap) throw new Error(`Unknown provider: ${provider}`);
+  const resolved = providerMap[modelAlias];
+  if (!resolved) throw new Error(`Unknown model "${modelAlias}" for provider "${provider}"`);
+  return resolved;
+}
+
+/**
+ * @deprecated — kept for backward compat during migration. Use resolveModel instead.
  */
 export const SUPPORTED_MODELS: Record<string, string> = {
   "claude-sonnet-4-6": "anthropic-sonnet-4.6",
   "claude-haiku-4-5": "anthropic-haiku-4.5",
+  "claude-opus-4-6": "anthropic-opus-4.6",
   "gemini-3.1-flash-lite-preview": "google-flash-lite-3.1",
 };
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -314,9 +314,17 @@ export const CompleteRequestSchema = z
       description: "Maximum tokens in the response (default: 16000)",
       example: 2000,
     }),
-    model: z.enum(["claude-sonnet-4-6", "claude-haiku-4-5", "gemini-3.1-flash-lite-preview"]).optional().openapi({
-      description: "Model to use. Defaults to claude-sonnet-4-6. Use claude-haiku-4-5 for simpler tasks, or gemini-3.1-flash-lite-preview for cost-effective vision tasks (image analysis, classification).",
-      example: "gemini-3.1-flash-lite-preview",
+    provider: z.enum(["anthropic", "google"]).openapi({
+      description: "LLM provider to use.",
+      example: "anthropic",
+    }),
+    model: z.enum(["haiku", "sonnet", "opus", "flash-lite"]).openapi({
+      description:
+        "Model alias (version-free). The service resolves the latest versioned model internally.\n\n" +
+        "**Anthropic models:** `haiku` (fast/cheap), `sonnet` (balanced), `opus` (highest quality).\n" +
+        "**Google models:** `flash-lite` (cost-effective vision).\n\n" +
+        "The model must match the provider: anthropic → haiku|sonnet|opus, google → flash-lite.",
+      example: "sonnet",
     }),
     imageUrl: z.string().url().optional().openapi({
       description: "URL of an image to include in the prompt. The image is fetched server-side and sent to the model as a visual input. Supported by all models, but recommended with gemini-3.1-flash-lite-preview for cost-effective vision tasks (image classification, scoring, analysis).",
@@ -339,6 +347,20 @@ export const CompleteRequestSchema = z
       description: "Optional metadata about the image (alt text, title, source page). Injected into the prompt alongside the image to help the model classify and score it more accurately. Only meaningful when imageUrl is provided.",
     }),
   })
+  .superRefine((data, ctx) => {
+    const validModels: Record<string, string[]> = {
+      anthropic: ["haiku", "sonnet", "opus"],
+      google: ["flash-lite"],
+    };
+    const allowed = validModels[data.provider];
+    if (allowed && !allowed.includes(data.model)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Model "${data.model}" is not valid for provider "${data.provider}". Valid models: ${allowed.join(", ")}`,
+        path: ["model"],
+      });
+    }
+  })
   .openapi("CompleteRequest");
 
 export const CompleteResponseSchema = z
@@ -360,7 +382,7 @@ export const CompleteResponseSchema = z
       example: 800,
     }),
     model: z.string().openapi({
-      description: "Model used for the completion",
+      description: "Versioned model ID actually used for the completion (resolved by the service from the provider+model alias)",
       example: "claude-sonnet-4-6",
     }),
   })
@@ -383,10 +405,15 @@ Unlike POST /chat, this endpoint:
 - Supports optional \`temperature\` and \`maxTokens\` overrides
 - Supports **vision** via the \`imageUrl\` field — the image is fetched server-side and sent as visual input to the model
 
-**Models:**
-- \`claude-sonnet-4-6\` (default) — general-purpose, high quality
-- \`claude-haiku-4-5\` — faster/cheaper for simple extraction and classification
-- \`gemini-3.1-flash-lite-preview\` — cost-effective vision model for image analysis, scoring, and classification. Requires a Google API key configured in key-service (provider: \`google\`).
+**Provider + model (both required):**
+Callers specify a provider and a version-free model alias. The service resolves the latest versioned model ID internally.
+
+| provider | model | Description |
+|----------|-------|-------------|
+| \`anthropic\` | \`sonnet\` | General-purpose, high quality |
+| \`anthropic\` | \`haiku\` | Faster/cheaper for simple extraction and classification |
+| \`anthropic\` | \`opus\` | Highest quality for complex reasoning |
+| \`google\` | \`flash-lite\` | Cost-effective vision model for image analysis. Requires a Google API key in key-service. |
 
 **Use cases:** generating search queries, scoring/analyzing text, image classification and scoring (with \`imageUrl\` + \`gemini-3.1-flash-lite-preview\`), any service that needs a quick LLM call without conversation context.`,
   request: {

--- a/tests/unit/complete.test.ts
+++ b/tests/unit/complete.test.ts
@@ -1,13 +1,15 @@
 import { describe, it, expect } from "vitest";
 import { CompleteRequestSchema } from "../../src/schemas.js";
 import { isGeminiModel, geminiCostPrefix, GEMINI_MODELS } from "../../src/lib/gemini.js";
-import { costPrefixForModel, SUPPORTED_MODELS } from "../../src/lib/anthropic.js";
+import { costPrefixForModel, SUPPORTED_MODELS, resolveModel } from "../../src/lib/anthropic.js";
 
 describe("CompleteRequestSchema", () => {
-  it("accepts valid request with message and systemPrompt", () => {
+  it("accepts valid request with provider and model", () => {
     const result = CompleteRequestSchema.safeParse({
       message: "Generate 10 search queries",
       systemPrompt: "You are a PR research assistant.",
+      provider: "anthropic",
+      model: "sonnet",
     });
     expect(result.success).toBe(true);
   });
@@ -16,6 +18,8 @@ describe("CompleteRequestSchema", () => {
     const result = CompleteRequestSchema.safeParse({
       message: "Generate queries",
       systemPrompt: "You are helpful.",
+      provider: "anthropic",
+      model: "sonnet",
       responseFormat: "json",
       temperature: 0.3,
       maxTokens: 2000,
@@ -31,6 +35,8 @@ describe("CompleteRequestSchema", () => {
   it("rejects missing message", () => {
     const result = CompleteRequestSchema.safeParse({
       systemPrompt: "You are helpful.",
+      provider: "anthropic",
+      model: "sonnet",
     });
     expect(result.success).toBe(false);
   });
@@ -39,6 +45,8 @@ describe("CompleteRequestSchema", () => {
     const result = CompleteRequestSchema.safeParse({
       message: "",
       systemPrompt: "You are helpful.",
+      provider: "anthropic",
+      model: "sonnet",
     });
     expect(result.success).toBe(false);
   });
@@ -46,6 +54,8 @@ describe("CompleteRequestSchema", () => {
   it("rejects missing systemPrompt", () => {
     const result = CompleteRequestSchema.safeParse({
       message: "Hello",
+      provider: "anthropic",
+      model: "sonnet",
     });
     expect(result.success).toBe(false);
   });
@@ -54,6 +64,26 @@ describe("CompleteRequestSchema", () => {
     const result = CompleteRequestSchema.safeParse({
       message: "Hello",
       systemPrompt: "",
+      provider: "anthropic",
+      model: "sonnet",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing provider", () => {
+    const result = CompleteRequestSchema.safeParse({
+      message: "Hello",
+      systemPrompt: "You are helpful.",
+      model: "sonnet",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing model", () => {
+    const result = CompleteRequestSchema.safeParse({
+      message: "Hello",
+      systemPrompt: "You are helpful.",
+      provider: "anthropic",
     });
     expect(result.success).toBe(false);
   });
@@ -62,6 +92,8 @@ describe("CompleteRequestSchema", () => {
     const result = CompleteRequestSchema.safeParse({
       message: "Hello",
       systemPrompt: "You are helpful.",
+      provider: "anthropic",
+      model: "sonnet",
       responseFormat: "xml",
     });
     expect(result.success).toBe(false);
@@ -71,6 +103,8 @@ describe("CompleteRequestSchema", () => {
     const below = CompleteRequestSchema.safeParse({
       message: "Hello",
       systemPrompt: "You are helpful.",
+      provider: "anthropic",
+      model: "sonnet",
       temperature: -0.1,
     });
     expect(below.success).toBe(false);
@@ -78,6 +112,8 @@ describe("CompleteRequestSchema", () => {
     const above = CompleteRequestSchema.safeParse({
       message: "Hello",
       systemPrompt: "You are helpful.",
+      provider: "anthropic",
+      model: "sonnet",
       temperature: 2.1,
     });
     expect(above.success).toBe(false);
@@ -87,6 +123,8 @@ describe("CompleteRequestSchema", () => {
     const zero = CompleteRequestSchema.safeParse({
       message: "Hello",
       systemPrompt: "You are helpful.",
+      provider: "anthropic",
+      model: "sonnet",
       maxTokens: 0,
     });
     expect(zero.success).toBe(false);
@@ -94,6 +132,8 @@ describe("CompleteRequestSchema", () => {
     const tooHigh = CompleteRequestSchema.safeParse({
       message: "Hello",
       systemPrompt: "You are helpful.",
+      provider: "anthropic",
+      model: "sonnet",
       maxTokens: 65000,
     });
     expect(tooHigh.success).toBe(false);
@@ -103,59 +143,101 @@ describe("CompleteRequestSchema", () => {
     const result = CompleteRequestSchema.safeParse({
       message: "Hello",
       systemPrompt: "You are helpful.",
+      provider: "anthropic",
+      model: "sonnet",
       maxTokens: 1000.5,
     });
     expect(result.success).toBe(false);
   });
 
-  it("accepts valid model override", () => {
+  // --- Provider + model validation ---
+
+  it("accepts anthropic + haiku", () => {
     const result = CompleteRequestSchema.safeParse({
       message: "Extract metadata",
       systemPrompt: "You are a metadata extractor.",
-      model: "claude-haiku-4-5",
+      provider: "anthropic",
+      model: "haiku",
     });
     expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.model).toBe("claude-haiku-4-5");
-    }
   });
 
-  it("accepts default model explicitly", () => {
+  it("accepts anthropic + sonnet", () => {
     const result = CompleteRequestSchema.safeParse({
       message: "Hello",
       systemPrompt: "You are helpful.",
-      model: "claude-sonnet-4-6",
+      provider: "anthropic",
+      model: "sonnet",
     });
     expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.model).toBe("claude-sonnet-4-6");
-    }
   });
 
-  it("rejects unsupported model", () => {
+  it("accepts anthropic + opus", () => {
+    const result = CompleteRequestSchema.safeParse({
+      message: "Complex reasoning task",
+      systemPrompt: "You are a reasoning expert.",
+      provider: "anthropic",
+      model: "opus",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts google + flash-lite", () => {
+    const result = CompleteRequestSchema.safeParse({
+      message: "Analyze this image",
+      systemPrompt: "You are an image classifier.",
+      provider: "google",
+      model: "flash-lite",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects anthropic + flash-lite (wrong provider)", () => {
     const result = CompleteRequestSchema.safeParse({
       message: "Hello",
       systemPrompt: "You are helpful.",
+      provider: "anthropic",
+      model: "flash-lite",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects google + sonnet (wrong provider)", () => {
+    const result = CompleteRequestSchema.safeParse({
+      message: "Hello",
+      systemPrompt: "You are helpful.",
+      provider: "google",
+      model: "sonnet",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects unsupported provider", () => {
+    const result = CompleteRequestSchema.safeParse({
+      message: "Hello",
+      systemPrompt: "You are helpful.",
+      provider: "openai",
       model: "gpt-4o",
     });
     expect(result.success).toBe(false);
   });
 
-  it("defaults model to undefined when omitted", () => {
+  it("rejects unsupported model alias", () => {
     const result = CompleteRequestSchema.safeParse({
       message: "Hello",
       systemPrompt: "You are helpful.",
+      provider: "anthropic",
+      model: "gpt-4o",
     });
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.model).toBeUndefined();
-    }
+    expect(result.success).toBe(false);
   });
 
   it("accepts temperature at boundaries (0 and 2)", () => {
     const atZero = CompleteRequestSchema.safeParse({
       message: "Hello",
       systemPrompt: "You are helpful.",
+      provider: "anthropic",
+      model: "sonnet",
       temperature: 0,
     });
     expect(atZero.success).toBe(true);
@@ -163,6 +245,8 @@ describe("CompleteRequestSchema", () => {
     const atTwo = CompleteRequestSchema.safeParse({
       message: "Hello",
       systemPrompt: "You are helpful.",
+      provider: "anthropic",
+      model: "sonnet",
       temperature: 2,
     });
     expect(atTwo.success).toBe(true);
@@ -170,23 +254,12 @@ describe("CompleteRequestSchema", () => {
 
   // --- Vision / imageUrl tests ---
 
-  it("accepts gemini-3.1-flash-lite-preview model", () => {
-    const result = CompleteRequestSchema.safeParse({
-      message: "Analyze this image",
-      systemPrompt: "You are an image classifier.",
-      model: "gemini-3.1-flash-lite-preview",
-    });
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.model).toBe("gemini-3.1-flash-lite-preview");
-    }
-  });
-
-  it("accepts imageUrl with gemini-3.1-flash-lite-preview", () => {
+  it("accepts google + flash-lite with imageUrl", () => {
     const result = CompleteRequestSchema.safeParse({
       message: "Score this image",
       systemPrompt: "You are an image scoring assistant.",
-      model: "gemini-3.1-flash-lite-preview",
+      provider: "google",
+      model: "flash-lite",
       imageUrl: "https://example.com/images/hero.jpg",
       responseFormat: "json",
       temperature: 0,
@@ -195,7 +268,6 @@ describe("CompleteRequestSchema", () => {
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.imageUrl).toBe("https://example.com/images/hero.jpg");
-      expect(result.data.model).toBe("gemini-3.1-flash-lite-preview");
     }
   });
 
@@ -203,7 +275,8 @@ describe("CompleteRequestSchema", () => {
     const result = CompleteRequestSchema.safeParse({
       message: "Describe this image",
       systemPrompt: "You are helpful.",
-      model: "claude-sonnet-4-6",
+      provider: "anthropic",
+      model: "sonnet",
       imageUrl: "https://example.com/photo.png",
     });
     expect(result.success).toBe(true);
@@ -212,23 +285,12 @@ describe("CompleteRequestSchema", () => {
     }
   });
 
-  it("accepts imageUrl without explicit model (defaults to claude)", () => {
-    const result = CompleteRequestSchema.safeParse({
-      message: "What do you see?",
-      systemPrompt: "You are helpful.",
-      imageUrl: "https://example.com/img.jpg",
-    });
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.imageUrl).toBe("https://example.com/img.jpg");
-      expect(result.data.model).toBeUndefined();
-    }
-  });
-
   it("rejects invalid imageUrl", () => {
     const result = CompleteRequestSchema.safeParse({
       message: "Analyze",
       systemPrompt: "You are helpful.",
+      provider: "anthropic",
+      model: "sonnet",
       imageUrl: "not-a-url",
     });
     expect(result.success).toBe(false);
@@ -238,7 +300,8 @@ describe("CompleteRequestSchema", () => {
     const result = CompleteRequestSchema.safeParse({
       message: "Just text",
       systemPrompt: "You are helpful.",
-      model: "gemini-3.1-flash-lite-preview",
+      provider: "google",
+      model: "flash-lite",
     });
     expect(result.success).toBe(true);
     if (result.success) {
@@ -252,7 +315,8 @@ describe("CompleteRequestSchema", () => {
     const result = CompleteRequestSchema.safeParse({
       message: "Score this image",
       systemPrompt: "You are an image classifier.",
-      model: "gemini-3.1-flash-lite-preview",
+      provider: "google",
+      model: "flash-lite",
       imageUrl: "https://example.com/hero.jpg",
       imageContext: {
         alt: "Company logo",
@@ -274,6 +338,8 @@ describe("CompleteRequestSchema", () => {
     const result = CompleteRequestSchema.safeParse({
       message: "Analyze",
       systemPrompt: "You are helpful.",
+      provider: "anthropic",
+      model: "sonnet",
       imageUrl: "https://example.com/img.jpg",
       imageContext: { alt: "Team photo" },
     });
@@ -289,6 +355,8 @@ describe("CompleteRequestSchema", () => {
     const result = CompleteRequestSchema.safeParse({
       message: "Analyze",
       systemPrompt: "You are helpful.",
+      provider: "anthropic",
+      model: "sonnet",
       imageUrl: "https://example.com/img.jpg",
       imageContext: {},
     });
@@ -302,12 +370,54 @@ describe("CompleteRequestSchema", () => {
     const result = CompleteRequestSchema.safeParse({
       message: "Analyze",
       systemPrompt: "You are helpful.",
+      provider: "anthropic",
+      model: "sonnet",
       imageUrl: "https://example.com/img.jpg",
     });
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.imageContext).toBeUndefined();
     }
+  });
+});
+
+// --- resolveModel tests ---
+
+describe("resolveModel", () => {
+  it("resolves anthropic + haiku to claude-haiku-4-5", () => {
+    const resolved = resolveModel("anthropic", "haiku");
+    expect(resolved.apiModelId).toBe("claude-haiku-4-5");
+    expect(resolved.costPrefix).toBe("anthropic-haiku-4.5");
+    expect(resolved.provider).toBe("anthropic");
+  });
+
+  it("resolves anthropic + sonnet to claude-sonnet-4-6", () => {
+    const resolved = resolveModel("anthropic", "sonnet");
+    expect(resolved.apiModelId).toBe("claude-sonnet-4-6");
+    expect(resolved.costPrefix).toBe("anthropic-sonnet-4.6");
+    expect(resolved.provider).toBe("anthropic");
+  });
+
+  it("resolves anthropic + opus to claude-opus-4-6", () => {
+    const resolved = resolveModel("anthropic", "opus");
+    expect(resolved.apiModelId).toBe("claude-opus-4-6");
+    expect(resolved.costPrefix).toBe("anthropic-opus-4.6");
+    expect(resolved.provider).toBe("anthropic");
+  });
+
+  it("resolves google + flash-lite to gemini-3.1-flash-lite-preview", () => {
+    const resolved = resolveModel("google", "flash-lite");
+    expect(resolved.apiModelId).toBe("gemini-3.1-flash-lite-preview");
+    expect(resolved.costPrefix).toBe("google-flash-lite-3.1");
+    expect(resolved.provider).toBe("google");
+  });
+
+  it("throws for invalid provider", () => {
+    expect(() => resolveModel("openai" as any, "sonnet")).toThrow();
+  });
+
+  it("throws for invalid model alias", () => {
+    expect(() => resolveModel("anthropic", "flash-lite")).toThrow();
   });
 });
 
@@ -342,5 +452,6 @@ describe("costPrefixForModel", () => {
   it("returns correct prefix for anthropic models", () => {
     expect(costPrefixForModel("claude-sonnet-4-6")).toBe("anthropic-sonnet-4.6");
     expect(costPrefixForModel("claude-haiku-4-5")).toBe("anthropic-haiku-4.5");
+    expect(costPrefixForModel("claude-opus-4-6")).toBe("anthropic-opus-4.6");
   });
 });


### PR DESCRIPTION
## Summary
- **Breaking change**: `POST /complete` now requires `provider` ("anthropic"|"google") and `model` (version-free alias: "haiku"|"sonnet"|"opus"|"flash-lite") instead of the old optional `model` field with versioned IDs
- The service resolves aliases to the latest versioned model ID internally — callers never track model versions
- Adds Opus model support for Anthropic
- Zod validation ensures provider/model combinations are valid (e.g. rejects `google` + `sonnet`)

## Test plan
- [x] Schema validation tests for all valid provider+model combos
- [x] Schema rejects invalid combos (wrong provider for model, missing fields)
- [x] `resolveModel()` unit tests for all aliases → versioned IDs
- [x] Existing cost prefix and Gemini helper tests still pass
- [x] OpenAPI spec regenerated
- [x] README updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)