### PR TITLE
feat: add Gemini Flash and Pro models

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Request body:
 - `provider` (required) — LLM provider: `"anthropic"` or `"google"`
 - `model` (required) — version-free model alias. The service resolves the latest versioned model internally. Valid combinations:
   - **anthropic**: `haiku` (fast/cheap), `sonnet` (balanced), `opus` (highest quality)
-  - **google**: `flash-lite` (cost-effective vision). Requires a Google API key in key-service.
+  - **google**: `flash-lite` (cheapest, vision), `flash` (balanced, reasoning), `pro` (most powerful). All require a Google API key in key-service.
 - `responseFormat` (optional) — set to `"json"` to instruct the model to return valid JSON. The parsed result appears in the `json` field.
 - `temperature` (optional) — sampling temperature, 0–2 (default: model default)
 - `maxTokens` (optional) — max output tokens, 1–64000 (default: 16000)

--- a/openapi.json
+++ b/openapi.json
@@ -566,9 +566,11 @@
               "haiku",
               "sonnet",
               "opus",
-              "flash-lite"
+              "flash-lite",
+              "flash",
+              "pro"
             ],
-            "description": "Model alias (version-free). The service resolves the latest versioned model internally.\n\n**Anthropic models:** `haiku` (fast/cheap), `sonnet` (balanced), `opus` (highest quality).\n**Google models:** `flash-lite` (cost-effective vision).\n\nThe model must match the provider: anthropic → haiku|sonnet|opus, google → flash-lite.",
+            "description": "Model alias (version-free). The service resolves the latest versioned model internally.\n\n**Anthropic models:** `haiku` (fast/cheap), `sonnet` (balanced), `opus` (highest quality).\n**Google models:** `flash-lite` (cheapest, vision), `flash` (balanced, reasoning), `pro` (most powerful).\n\nThe model must match the provider: anthropic → haiku|sonnet|opus, google → flash-lite|flash|pro.",
             "example": "sonnet"
           },
           "imageUrl": {
@@ -910,7 +912,7 @@
           "Complete"
         ],
         "summary": "Synchronous LLM completion",
-        "description": "One-shot, non-streaming LLM call for service-to-service use. Returns a JSON response with the model output.\n\nUnlike POST /chat, this endpoint:\n- Does **not** create or use sessions (stateless, one-shot)\n- Accepts an inline `systemPrompt` (no pre-registered config required)\n- Returns JSON instead of SSE\n- Supports `responseFormat: \"json\"` — when set, the parsed object is returned in the `json` field (always use `json`, not `content`, for structured data)\n- Supports optional `temperature` and `maxTokens` overrides\n- Supports **vision** via the `imageUrl` field — the image is fetched server-side and sent as visual input to the model\n\n**Provider + model (both required):**\nCallers specify a provider and a version-free model alias. The service resolves the latest versioned model ID internally.\n\n| provider | model | Description |\n|----------|-------|-------------|\n| `anthropic` | `sonnet` | General-purpose, high quality |\n| `anthropic` | `haiku` | Faster/cheaper for simple extraction and classification |\n| `anthropic` | `opus` | Highest quality for complex reasoning |\n| `google` | `flash-lite` | Cost-effective vision model for image analysis. Requires a Google API key in key-service. |\n\n**Use cases:** generating search queries, scoring/analyzing text, image classification and scoring (with `imageUrl` + `gemini-3.1-flash-lite-preview`), any service that needs a quick LLM call without conversation context.",
+        "description": "One-shot, non-streaming LLM call for service-to-service use. Returns a JSON response with the model output.\n\nUnlike POST /chat, this endpoint:\n- Does **not** create or use sessions (stateless, one-shot)\n- Accepts an inline `systemPrompt` (no pre-registered config required)\n- Returns JSON instead of SSE\n- Supports `responseFormat: \"json\"` — when set, the parsed object is returned in the `json` field (always use `json`, not `content`, for structured data)\n- Supports optional `temperature` and `maxTokens` overrides\n- Supports **vision** via the `imageUrl` field — the image is fetched server-side and sent as visual input to the model\n\n**Provider + model (both required):**\nCallers specify a provider and a version-free model alias. The service resolves the latest versioned model ID internally.\n\n| provider | model | Description |\n|----------|-------|-------------|\n| `anthropic` | `sonnet` | General-purpose, high quality |\n| `anthropic` | `haiku` | Faster/cheaper for simple extraction and classification |\n| `anthropic` | `opus` | Highest quality for complex reasoning |\n| `google` | `flash-lite` | Cheapest, cost-effective vision model for image analysis |\n| `google` | `flash` | Balanced price-performance with reasoning capabilities |\n| `google` | `pro` | Most powerful Google model for complex tasks |\n\nAll Google models require a Google API key configured in key-service (provider: `google`).\n\n**Use cases:** generating search queries, scoring/analyzing text, image classification and scoring (with `imageUrl` + `gemini-3.1-flash-lite-preview`), any service that needs a quick LLM call without conversation context.",
         "parameters": [
           {
             "schema": {

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -12,7 +12,7 @@ const MAX_TOKENS = 16_000;
 // ---------------------------------------------------------------------------
 
 export type Provider = "anthropic" | "google";
-export type ModelAlias = "haiku" | "sonnet" | "opus" | "flash-lite";
+export type ModelAlias = "haiku" | "sonnet" | "opus" | "flash-lite" | "flash" | "pro";
 
 interface ResolvedModel {
   /** Versioned model ID sent to the provider's API */
@@ -31,13 +31,15 @@ const MODEL_MAP: Record<string, Record<string, ResolvedModel>> = {
   },
   google: {
     "flash-lite": { apiModelId: "gemini-3.1-flash-lite-preview", costPrefix: "google-flash-lite-3.1", provider: "google" },
+    "flash": { apiModelId: "gemini-2.5-flash", costPrefix: "google-flash-2.5", provider: "google" },
+    "pro": { apiModelId: "gemini-3.1-pro-preview", costPrefix: "google-pro-3.1", provider: "google" },
   },
 };
 
 /** Valid model aliases per provider — used for Zod validation. */
 export const PROVIDER_MODELS: Record<Provider, readonly ModelAlias[]> = {
   anthropic: ["haiku", "sonnet", "opus"],
-  google: ["flash-lite"],
+  google: ["flash-lite", "flash", "pro"],
 };
 
 /**
@@ -61,6 +63,8 @@ export const SUPPORTED_MODELS: Record<string, string> = {
   "claude-haiku-4-5": "anthropic-haiku-4.5",
   "claude-opus-4-6": "anthropic-opus-4.6",
   "gemini-3.1-flash-lite-preview": "google-flash-lite-3.1",
+  "gemini-2.5-flash": "google-flash-2.5",
+  "gemini-3.1-pro-preview": "google-pro-3.1",
 };
 
 /** Resolve the cost prefix for a given model ID (falls back to default). */

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -7,6 +7,8 @@ const GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta";
 
 export const GEMINI_MODELS: Record<string, string> = {
   "gemini-3.1-flash-lite-preview": "google-flash-lite-3.1",
+  "gemini-2.5-flash": "google-flash-2.5",
+  "gemini-3.1-pro-preview": "google-pro-3.1",
 };
 
 /** Check if a model ID is a Gemini model. */

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -318,12 +318,12 @@ export const CompleteRequestSchema = z
       description: "LLM provider to use.",
       example: "anthropic",
     }),
-    model: z.enum(["haiku", "sonnet", "opus", "flash-lite"]).openapi({
+    model: z.enum(["haiku", "sonnet", "opus", "flash-lite", "flash", "pro"]).openapi({
       description:
         "Model alias (version-free). The service resolves the latest versioned model internally.\n\n" +
         "**Anthropic models:** `haiku` (fast/cheap), `sonnet` (balanced), `opus` (highest quality).\n" +
-        "**Google models:** `flash-lite` (cost-effective vision).\n\n" +
-        "The model must match the provider: anthropic → haiku|sonnet|opus, google → flash-lite.",
+        "**Google models:** `flash-lite` (cheapest, vision), `flash` (balanced, reasoning), `pro` (most powerful).\n\n" +
+        "The model must match the provider: anthropic → haiku|sonnet|opus, google → flash-lite|flash|pro.",
       example: "sonnet",
     }),
     imageUrl: z.string().url().optional().openapi({
@@ -350,7 +350,7 @@ export const CompleteRequestSchema = z
   .superRefine((data, ctx) => {
     const validModels: Record<string, string[]> = {
       anthropic: ["haiku", "sonnet", "opus"],
-      google: ["flash-lite"],
+      google: ["flash-lite", "flash", "pro"],
     };
     const allowed = validModels[data.provider];
     if (allowed && !allowed.includes(data.model)) {
@@ -413,7 +413,11 @@ Callers specify a provider and a version-free model alias. The service resolves 
 | \`anthropic\` | \`sonnet\` | General-purpose, high quality |
 | \`anthropic\` | \`haiku\` | Faster/cheaper for simple extraction and classification |
 | \`anthropic\` | \`opus\` | Highest quality for complex reasoning |
-| \`google\` | \`flash-lite\` | Cost-effective vision model for image analysis. Requires a Google API key in key-service. |
+| \`google\` | \`flash-lite\` | Cheapest, cost-effective vision model for image analysis |
+| \`google\` | \`flash\` | Balanced price-performance with reasoning capabilities |
+| \`google\` | \`pro\` | Most powerful Google model for complex tasks |
+
+All Google models require a Google API key configured in key-service (provider: \`google\`).
 
 **Use cases:** generating search queries, scoring/analyzing text, image classification and scoring (with \`imageUrl\` + \`gemini-3.1-flash-lite-preview\`), any service that needs a quick LLM call without conversation context.`,
   request: {

--- a/tests/unit/complete.test.ts
+++ b/tests/unit/complete.test.ts
@@ -192,6 +192,46 @@ describe("CompleteRequestSchema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts google + flash", () => {
+    const result = CompleteRequestSchema.safeParse({
+      message: "Reason about this",
+      systemPrompt: "You are helpful.",
+      provider: "google",
+      model: "flash",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts google + pro", () => {
+    const result = CompleteRequestSchema.safeParse({
+      message: "Complex analysis",
+      systemPrompt: "You are an expert analyst.",
+      provider: "google",
+      model: "pro",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects anthropic + flash (wrong provider)", () => {
+    const result = CompleteRequestSchema.safeParse({
+      message: "Hello",
+      systemPrompt: "You are helpful.",
+      provider: "anthropic",
+      model: "flash",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects anthropic + pro (wrong provider)", () => {
+    const result = CompleteRequestSchema.safeParse({
+      message: "Hello",
+      systemPrompt: "You are helpful.",
+      provider: "anthropic",
+      model: "pro",
+    });
+    expect(result.success).toBe(false);
+  });
+
   it("rejects anthropic + flash-lite (wrong provider)", () => {
     const result = CompleteRequestSchema.safeParse({
       message: "Hello",
@@ -412,6 +452,20 @@ describe("resolveModel", () => {
     expect(resolved.provider).toBe("google");
   });
 
+  it("resolves google + flash to gemini-2.5-flash", () => {
+    const resolved = resolveModel("google", "flash");
+    expect(resolved.apiModelId).toBe("gemini-2.5-flash");
+    expect(resolved.costPrefix).toBe("google-flash-2.5");
+    expect(resolved.provider).toBe("google");
+  });
+
+  it("resolves google + pro to gemini-3.1-pro-preview", () => {
+    const resolved = resolveModel("google", "pro");
+    expect(resolved.apiModelId).toBe("gemini-3.1-pro-preview");
+    expect(resolved.costPrefix).toBe("google-pro-3.1");
+    expect(resolved.provider).toBe("google");
+  });
+
   it("throws for invalid provider", () => {
     expect(() => resolveModel("openai" as any, "sonnet")).toThrow();
   });
@@ -428,6 +482,14 @@ describe("isGeminiModel", () => {
     expect(isGeminiModel("gemini-3.1-flash-lite-preview")).toBe(true);
   });
 
+  it("returns true for gemini-2.5-flash", () => {
+    expect(isGeminiModel("gemini-2.5-flash")).toBe(true);
+  });
+
+  it("returns true for gemini-3.1-pro-preview", () => {
+    expect(isGeminiModel("gemini-3.1-pro-preview")).toBe(true);
+  });
+
   it("returns false for anthropic models", () => {
     expect(isGeminiModel("claude-sonnet-4-6")).toBe(false);
     expect(isGeminiModel("claude-haiku-4-5")).toBe(false);
@@ -442,6 +504,14 @@ describe("geminiCostPrefix", () => {
   it("returns correct prefix for gemini-3.1-flash-lite-preview", () => {
     expect(geminiCostPrefix("gemini-3.1-flash-lite-preview")).toBe("google-flash-lite-3.1");
   });
+
+  it("returns correct prefix for gemini-2.5-flash", () => {
+    expect(geminiCostPrefix("gemini-2.5-flash")).toBe("google-flash-2.5");
+  });
+
+  it("returns correct prefix for gemini-3.1-pro-preview", () => {
+    expect(geminiCostPrefix("gemini-3.1-pro-preview")).toBe("google-pro-3.1");
+  });
 });
 
 describe("costPrefixForModel", () => {
@@ -453,5 +523,10 @@ describe("costPrefixForModel", () => {
     expect(costPrefixForModel("claude-sonnet-4-6")).toBe("anthropic-sonnet-4.6");
     expect(costPrefixForModel("claude-haiku-4-5")).toBe("anthropic-haiku-4.5");
     expect(costPrefixForModel("claude-opus-4-6")).toBe("anthropic-opus-4.6");
+  });
+
+  it("returns correct prefix for all gemini models", () => {
+    expect(costPrefixForModel("gemini-2.5-flash")).toBe("google-flash-2.5");
+    expect(costPrefixForModel("gemini-3.1-pro-preview")).toBe("google-pro-3.1");
   });
 });


### PR DESCRIPTION
## Summary
- Adds `flash` (→ `gemini-2.5-flash`) and `pro` (→ `gemini-3.1-pro-preview`) as new Google model aliases
- Zod validation ensures these are only valid with `provider: "google"`
- Cost prefixes: `google-flash-2.5` and `google-pro-3.1`

## Full model matrix after this PR

| provider | model | Resolves to |
|----------|-------|-------------|
| `anthropic` | `haiku` | `claude-haiku-4-5` |
| `anthropic` | `sonnet` | `claude-sonnet-4-6` |
| `anthropic` | `opus` | `claude-opus-4-6` |
| `google` | `flash-lite` | `gemini-3.1-flash-lite-preview` |
| `google` | `flash` | `gemini-2.5-flash` |
| `google` | `pro` | `gemini-3.1-pro-preview` |

## Test plan
- [x] Schema validates google + flash and google + pro
- [x] Schema rejects anthropic + flash and anthropic + pro
- [x] resolveModel() returns correct API IDs and cost prefixes
- [x] isGeminiModel() recognizes new model IDs
- [x] Cost prefix helpers updated
- [x] OpenAPI spec regenerated
- [x] README updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)