### PR TITLE
fix: align Flash cost prefix with costs-service

### DIFF
--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -31,7 +31,7 @@ const MODEL_MAP: Record<string, Record<string, ResolvedModel>> = {
   },
   google: {
     "flash-lite": { apiModelId: "gemini-3.1-flash-lite-preview", costPrefix: "google-flash-lite-3.1", provider: "google" },
-    "flash": { apiModelId: "gemini-3-flash-preview", costPrefix: "google-flash-3.0", provider: "google" },
+    "flash": { apiModelId: "gemini-3-flash-preview", costPrefix: "google-flash-3", provider: "google" },
     "pro": { apiModelId: "gemini-3.1-pro-preview", costPrefix: "google-pro-3.1", provider: "google" },
   },
 };
@@ -63,7 +63,7 @@ export const SUPPORTED_MODELS: Record<string, string> = {
   "claude-haiku-4-5": "anthropic-haiku-4.5",
   "claude-opus-4-6": "anthropic-opus-4.6",
   "gemini-3.1-flash-lite-preview": "google-flash-lite-3.1",
-  "gemini-3-flash-preview": "google-flash-3.0",
+  "gemini-3-flash-preview": "google-flash-3",
   "gemini-3.1-pro-preview": "google-pro-3.1",
 };
 

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -7,7 +7,7 @@ const GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta";
 
 export const GEMINI_MODELS: Record<string, string> = {
   "gemini-3.1-flash-lite-preview": "google-flash-lite-3.1",
-  "gemini-3-flash-preview": "google-flash-3.0",
+  "gemini-3-flash-preview": "google-flash-3",
   "gemini-3.1-pro-preview": "google-pro-3.1",
 };
 

--- a/tests/unit/complete.test.ts
+++ b/tests/unit/complete.test.ts
@@ -455,7 +455,7 @@ describe("resolveModel", () => {
   it("resolves google + flash to gemini-3-flash-preview", () => {
     const resolved = resolveModel("google", "flash");
     expect(resolved.apiModelId).toBe("gemini-3-flash-preview");
-    expect(resolved.costPrefix).toBe("google-flash-3.0");
+    expect(resolved.costPrefix).toBe("google-flash-3");
     expect(resolved.provider).toBe("google");
   });
 
@@ -506,7 +506,7 @@ describe("geminiCostPrefix", () => {
   });
 
   it("returns correct prefix for gemini-3-flash-preview", () => {
-    expect(geminiCostPrefix("gemini-3-flash-preview")).toBe("google-flash-3.0");
+    expect(geminiCostPrefix("gemini-3-flash-preview")).toBe("google-flash-3");
   });
 
   it("returns correct prefix for gemini-3.1-pro-preview", () => {
@@ -526,7 +526,7 @@ describe("costPrefixForModel", () => {
   });
 
   it("returns correct prefix for all gemini models", () => {
-    expect(costPrefixForModel("gemini-3-flash-preview")).toBe("google-flash-3.0");
+    expect(costPrefixForModel("gemini-3-flash-preview")).toBe("google-flash-3");
     expect(costPrefixForModel("gemini-3.1-pro-preview")).toBe("google-pro-3.1");
   });
 });


### PR DESCRIPTION
## Summary
- Fixes cost prefix mismatch: `google-flash-3.0` → `google-flash-3` to match what costs-service created
- Without this fix, billing for Gemini Flash calls would silently fail to match cost entries

## Test plan
- [x] Unit tests updated for new prefix
- [x] All 370 tests pass
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)