### PR TITLE
fix: detect truncated LLM output in JSON mode

### DIFF
--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -1103,6 +1103,10 @@ export function createAnthropicClient({ apiKey, systemPrompt }: AnthropicOptions
 
       const response = await client.messages.create(params);
 
+      if (response.stop_reason === "max_tokens" && options?.responseFormat === "json") {
+        throw new Error(`[anthropic] Output truncated: model hit max output token limit. Increase maxTokens or reduce prompt size.`);
+      }
+
       // Extract text from content blocks
       const textBlocks = response.content.filter(
         (b): b is Anthropic.TextBlock => b.type === "text",

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -125,12 +125,18 @@ export async function completeWithGemini(options: GeminiCompleteOptions): Promis
   const data = (await res.json()) as {
     candidates?: Array<{
       content?: { parts?: Array<{ text?: string }> };
+      finishReason?: string;
     }>;
     usageMetadata?: {
       promptTokenCount?: number;
       candidatesTokenCount?: number;
     };
   };
+
+  const finishReason = data.candidates?.[0]?.finishReason;
+  if (finishReason === "MAX_TOKENS") {
+    throw new Error(`[gemini] Output truncated: model hit max output token limit. Increase maxTokens or reduce prompt size.`);
+  }
 
   const content =
     data.candidates?.[0]?.content?.parts

--- a/tests/unit/anthropic-truncation.test.ts
+++ b/tests/unit/anthropic-truncation.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from "vitest";
+
+/**
+ * Tests that complete() throws when Anthropic returns stop_reason: "max_tokens"
+ * with responseFormat: "json", preventing truncated JSON from reaching callers.
+ */
+
+let mockCreateResponse: Record<string, unknown>;
+
+vi.mock("@anthropic-ai/sdk", () => {
+  return {
+    default: class MockAnthropic {
+      messages = {
+        create: async () => mockCreateResponse,
+        stream: () => {
+          throw new Error("stream not implemented in mock");
+        },
+      };
+    },
+  };
+});
+
+const { createAnthropicClient } = await import("../../src/lib/anthropic.js");
+
+describe("anthropic complete() truncation detection", () => {
+  it("throws when stop_reason is max_tokens and responseFormat is json", async () => {
+    mockCreateResponse = {
+      stop_reason: "max_tokens",
+      content: [{ type: "text", text: '{"partial": "dat' }],
+      usage: { input_tokens: 100, output_tokens: 16000 },
+    };
+
+    const claude = createAnthropicClient({ apiKey: "test-key", systemPrompt: "You are helpful." });
+
+    await expect(
+      claude.complete("Return JSON", { responseFormat: "json" }),
+    ).rejects.toThrow(/Output truncated.*max output token limit/);
+  });
+
+  it("does NOT throw when stop_reason is max_tokens without responseFormat json", async () => {
+    mockCreateResponse = {
+      stop_reason: "max_tokens",
+      content: [{ type: "text", text: "some long text that got cut off" }],
+      usage: { input_tokens: 100, output_tokens: 16000 },
+    };
+
+    const claude = createAnthropicClient({ apiKey: "test-key", systemPrompt: "You are helpful." });
+    const result = await claude.complete("Write a long essay");
+
+    expect(result.content).toBe("some long text that got cut off");
+  });
+
+  it("does NOT throw when stop_reason is end_turn with responseFormat json", async () => {
+    mockCreateResponse = {
+      stop_reason: "end_turn",
+      content: [{ type: "text", text: '{"complete": true}' }],
+      usage: { input_tokens: 50, output_tokens: 20 },
+    };
+
+    const claude = createAnthropicClient({ apiKey: "test-key", systemPrompt: "You are helpful." });
+    const result = await claude.complete("Return JSON", { responseFormat: "json" });
+
+    expect(result.content).toBe('{"complete": true}');
+  });
+});

--- a/tests/unit/gemini.test.ts
+++ b/tests/unit/gemini.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { completeWithGemini } from "../../src/lib/gemini.js";
+
+describe("completeWithGemini", () => {
+  const fetchSpy = vi.fn();
+
+  beforeEach(() => {
+    fetchSpy.mockReset();
+    vi.stubGlobal("fetch", fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const baseOptions = {
+    apiKey: "test-key",
+    model: "gemini-3-flash-preview",
+    message: "Return URLs as JSON",
+    systemPrompt: "You are helpful.",
+    responseFormat: "json" as const,
+  };
+
+  it("throws when finishReason is MAX_TOKENS (truncated output)", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        candidates: [
+          {
+            content: { parts: [{ text: '["https://example.com", "https://truncat' }] },
+            finishReason: "MAX_TOKENS",
+          },
+        ],
+        usageMetadata: { promptTokenCount: 100, candidatesTokenCount: 500 },
+      }),
+    });
+
+    await expect(completeWithGemini(baseOptions)).rejects.toThrow(
+      /Output truncated.*max output token limit/,
+    );
+  });
+
+  it("returns content when finishReason is STOP (normal completion)", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        candidates: [
+          {
+            content: { parts: [{ text: '["https://example.com"]' }] },
+            finishReason: "STOP",
+          },
+        ],
+        usageMetadata: { promptTokenCount: 100, candidatesTokenCount: 50 },
+      }),
+    });
+
+    const result = await completeWithGemini(baseOptions);
+    expect(result.content).toBe('["https://example.com"]');
+    expect(result.tokensInput).toBe(100);
+    expect(result.tokensOutput).toBe(50);
+  });
+});


### PR DESCRIPTION
## Summary
- Gemini: check `finishReason === "MAX_TOKENS"` before returning content — throws clear error on truncation
- Anthropic: check `stop_reason === "max_tokens"` when `responseFormat: "json"` — throws clear error on truncation
- Previously, truncated JSON (e.g. model hitting output token limit) produced a confusing "non-parsable JSON" error at the `JSON.parse` step

## Test plan
- [x] New `tests/unit/gemini.test.ts` — verifies MAX_TOKENS throws, STOP returns normally
- [x] New `tests/unit/anthropic-truncation.test.ts` — verifies max_tokens+json throws, max_tokens without json passes, end_turn+json passes
- [x] All 374 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)