### PR TITLE
fix: return partial content on Gemini MAX_TOKENS for non-JSON mode

### DIFF
--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -134,8 +134,11 @@ export async function completeWithGemini(options: GeminiCompleteOptions): Promis
   };
 
   const finishReason = data.candidates?.[0]?.finishReason;
-  if (finishReason === "MAX_TOKENS") {
+  if (finishReason === "MAX_TOKENS" && responseFormat === "json") {
     throw new Error(`[gemini] Output truncated: model hit max output token limit. Increase maxTokens or reduce prompt size.`);
+  }
+  if (finishReason === "MAX_TOKENS") {
+    console.warn(`[gemini] Output truncated (MAX_TOKENS) for model=${model}. Returning partial content.`);
   }
 
   const content =

--- a/tests/unit/gemini.test.ts
+++ b/tests/unit/gemini.test.ts
@@ -21,7 +21,7 @@ describe("completeWithGemini", () => {
     responseFormat: "json" as const,
   };
 
-  it("throws when finishReason is MAX_TOKENS (truncated output)", async () => {
+  it("throws when finishReason is MAX_TOKENS in JSON mode (truncated output)", async () => {
     fetchSpy.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
@@ -38,6 +38,30 @@ describe("completeWithGemini", () => {
     await expect(completeWithGemini(baseOptions)).rejects.toThrow(
       /Output truncated.*max output token limit/,
     );
+  });
+
+  it("returns partial content when finishReason is MAX_TOKENS in non-JSON mode", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        candidates: [
+          {
+            content: { parts: [{ text: "Here are the top outlets for your campaign: 1. TechCrun" }] },
+            finishReason: "MAX_TOKENS",
+          },
+        ],
+        usageMetadata: { promptTokenCount: 200, candidatesTokenCount: 1000 },
+      }),
+    });
+
+    const result = await completeWithGemini({
+      ...baseOptions,
+      responseFormat: undefined,
+    });
+
+    expect(result.content).toBe("Here are the top outlets for your campaign: 1. TechCrun");
+    expect(result.tokensInput).toBe(200);
+    expect(result.tokensOutput).toBe(1000);
   });
 
   it("returns content when finishReason is STOP (normal completion)", async () => {


### PR DESCRIPTION
## Summary
- Gemini was throwing unconditionally on `MAX_TOKENS`, turning ALL truncated responses into 502 errors — even when the partial content was usable (non-JSON mode)
- Anthropic already only throws for JSON mode and silently returns partial content otherwise
- This aligns Gemini with Anthropic's behavior: non-JSON callers now get a 200 with partial content + a `console.warn` log, instead of a 502
- JSON mode still correctly throws (truncated JSON is unparseable)

## Root cause
Outlets-service calls `POST /complete` with Gemini; the model occasionally hits the output token limit. For non-JSON requests, the partial output is still useful but was being discarded as a 502, cascading failures through lead-service and workflow-service.

## Test plan
- [x] Existing test updated: `throws when finishReason is MAX_TOKENS` now scoped to JSON mode
- [x] New test: `returns partial content when finishReason is MAX_TOKENS in non-JSON mode`
- [x] All 378 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)