### PR TITLE
fix: disable Gemini thinking to prevent output token exhaustion

### DIFF
--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -99,6 +99,10 @@ export async function completeWithGemini(options: GeminiCompleteOptions): Promis
   }
 
   // Build request body
+  // Disable thinking (internal reasoning) — thinking tokens share the
+  // maxOutputTokens budget and can consume it entirely, leaving nothing for
+  // the actual response.  POST /complete is used for extraction tasks that
+  // don't benefit from chain-of-thought reasoning.
   const body: Record<string, unknown> = {
     contents: [{ parts }],
     systemInstruction: { parts: [{ text: systemPrompt }] },
@@ -106,6 +110,7 @@ export async function completeWithGemini(options: GeminiCompleteOptions): Promis
       ...(temperature != null ? { temperature } : {}),
       maxOutputTokens: maxTokens ?? 64_000,
       ...(responseFormat === "json" ? { responseMimeType: "application/json" } : {}),
+      thinkingConfig: { thinkingBudget: 0 },
     },
   };
 

--- a/tests/unit/gemini.test.ts
+++ b/tests/unit/gemini.test.ts
@@ -99,6 +99,21 @@ describe("completeWithGemini", () => {
     expect(requestBody.generationConfig.maxOutputTokens).toBe(64_000);
   });
 
+  it("disables thinking via thinkingConfig.thinkingBudget: 0", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        candidates: [{ content: { parts: [{ text: '{}' }] }, finishReason: "STOP" }],
+        usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5 },
+      }),
+    });
+
+    await completeWithGemini(baseOptions);
+
+    const requestBody = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    expect(requestBody.generationConfig.thinkingConfig).toEqual({ thinkingBudget: 0 });
+  });
+
   it("uses client-provided maxTokens when specified", async () => {
     fetchSpy.mockResolvedValueOnce({
       ok: true,


### PR DESCRIPTION
## Summary
- Gemini Flash/Pro models have **thinking (internal reasoning) enabled by default**
- Thinking tokens share the `maxOutputTokens` budget — the model can burn 50K+ tokens reasoning internally, leaving nothing for the actual response
- This causes `finishReason: "MAX_TOKENS"` with empty/truncated content → 502 errors cascading through outlets-service → lead-service → workflow failures
- Fix: set `thinkingConfig: { thinkingBudget: 0 }` in `generationConfig` — POST /complete is used for extraction tasks that don't need chain-of-thought reasoning

## Root cause
The Gemini API docs confirm that thinking tokens count against `maxOutputTokens`. With our 64K budget, the model could spend most of it on internal reasoning before producing any visible output. This is why raising maxTokens from 16K to 64K (#131) didn't fix the issue — thinking just consumed the larger budget too.

## Test plan
- [x] New test: verifies `thinkingConfig.thinkingBudget: 0` is sent in every Gemini request
- [x] All 379 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)