### PR TITLE
feat: expose thinkingBudget on POST /complete for Gemini

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -573,6 +573,13 @@
             "description": "Model alias (version-free). The service resolves the latest versioned model internally.\n\n**Anthropic models:** `haiku` (fast/cheap), `sonnet` (balanced), `opus` (highest quality).\n**Google models:** `flash-lite` (cheapest, vision), `flash` (balanced, reasoning), `pro` (most powerful).\n\nThe model must match the provider: anthropic → haiku|sonnet|opus, google → flash-lite|flash|pro.",
             "example": "sonnet"
           },
+          "thinkingBudget": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 32000,
+            "description": "Thinking token budget for Gemini models. When set to a value > 0, enables internal reasoning (chain-of-thought) before the model produces its response. Thinking tokens share the maxOutputTokens budget — set maxTokens high enough to accommodate both thinking and the response. Default: 0 (thinking disabled). Only applies to provider: \"google\"; ignored for Anthropic.",
+            "example": 8000
+          },
           "imageUrl": {
             "type": "string",
             "format": "uri",

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,7 +193,7 @@ app.post("/complete", requireAuth, async (req, res) => {
       .json({ error: "Invalid request", details: parsed.error.flatten() });
   }
 
-  const { message, systemPrompt, responseFormat, temperature, maxTokens, provider: requestedProvider, model: requestedModel, imageUrl, imageContext } = parsed.data;
+  const { message, systemPrompt, responseFormat, temperature, maxTokens, thinkingBudget, provider: requestedProvider, model: requestedModel, imageUrl, imageContext } = parsed.data;
 
   // Resolve versioned model from (provider, alias) pair
   const resolved = resolveModel(requestedProvider as Provider, requestedModel as ModelAlias);
@@ -311,6 +311,7 @@ app.post("/complete", requireAuth, async (req, res) => {
         responseFormat,
         temperature,
         maxTokens,
+        thinkingBudget,
       });
     } else {
       const claude = createAnthropicClient({ apiKey: resolvedKey.key, systemPrompt: effectiveSystemPrompt });

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -37,6 +37,7 @@ interface GeminiCompleteOptions {
   responseFormat?: "json";
   temperature?: number;
   maxTokens?: number;
+  thinkingBudget?: number;
 }
 
 interface GeminiCompleteResult {
@@ -75,6 +76,7 @@ export async function completeWithGemini(options: GeminiCompleteOptions): Promis
     responseFormat,
     temperature,
     maxTokens,
+    thinkingBudget,
   } = options;
 
   // Build content parts — inject image metadata into the text if provided
@@ -99,10 +101,10 @@ export async function completeWithGemini(options: GeminiCompleteOptions): Promis
   }
 
   // Build request body
-  // Disable thinking (internal reasoning) — thinking tokens share the
-  // maxOutputTokens budget and can consume it entirely, leaving nothing for
-  // the actual response.  POST /complete is used for extraction tasks that
-  // don't benefit from chain-of-thought reasoning.
+  // Thinking (internal reasoning) is disabled by default (thinkingBudget: 0)
+  // because thinking tokens share the maxOutputTokens budget and can consume
+  // it entirely.  Callers can opt in via the thinkingBudget option.
+  const effectiveThinkingBudget = thinkingBudget ?? 0;
   const body: Record<string, unknown> = {
     contents: [{ parts }],
     systemInstruction: { parts: [{ text: systemPrompt }] },
@@ -110,7 +112,7 @@ export async function completeWithGemini(options: GeminiCompleteOptions): Promis
       ...(temperature != null ? { temperature } : {}),
       maxOutputTokens: maxTokens ?? 64_000,
       ...(responseFormat === "json" ? { responseMimeType: "application/json" } : {}),
-      thinkingConfig: { thinkingBudget: 0 },
+      thinkingConfig: { thinkingBudget: effectiveThinkingBudget },
     },
   };
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -326,6 +326,14 @@ export const CompleteRequestSchema = z
         "The model must match the provider: anthropic → haiku|sonnet|opus, google → flash-lite|flash|pro.",
       example: "sonnet",
     }),
+    thinkingBudget: z.number().int().min(0).max(32000).optional().openapi({
+      description:
+        "Thinking token budget for Gemini models. When set to a value > 0, enables internal reasoning " +
+        "(chain-of-thought) before the model produces its response. Thinking tokens share the " +
+        "maxOutputTokens budget — set maxTokens high enough to accommodate both thinking and the response. " +
+        "Default: 0 (thinking disabled). Only applies to provider: \"google\"; ignored for Anthropic.",
+      example: 8000,
+    }),
     imageUrl: z.string().url().optional().openapi({
       description: "URL of an image to include in the prompt. The image is fetched server-side and sent to the model as a visual input. Supported by all models, but recommended with provider: \"google\", model: \"flash-lite\" for cost-effective vision tasks (image classification, scoring, analysis).",
       example: "https://example.com/images/hero.jpg",

--- a/tests/unit/gemini.test.ts
+++ b/tests/unit/gemini.test.ts
@@ -104,7 +104,7 @@ describe("completeWithGemini", () => {
     expect(requestBody.generationConfig.maxOutputTokens).toBe(64_000);
   });
 
-  it("disables thinking via thinkingConfig.thinkingBudget: 0", async () => {
+  it("disables thinking by default (thinkingBudget: 0)", async () => {
     fetchSpy.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
@@ -117,6 +117,21 @@ describe("completeWithGemini", () => {
 
     const requestBody = JSON.parse(fetchSpy.mock.calls[0][1].body);
     expect(requestBody.generationConfig.thinkingConfig).toEqual({ thinkingBudget: 0 });
+  });
+
+  it("uses caller-provided thinkingBudget when specified", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        candidates: [{ content: { parts: [{ text: '{}' }] }, finishReason: "STOP" }],
+        usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5 },
+      }),
+    });
+
+    await completeWithGemini({ ...baseOptions, thinkingBudget: 8000 });
+
+    const requestBody = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    expect(requestBody.generationConfig.thinkingConfig).toEqual({ thinkingBudget: 8000 });
   });
 
   it("uses client-provided maxTokens when specified", async () => {


### PR DESCRIPTION
## Summary
- New optional field `thinkingBudget` on `POST /complete` request body
- When set to a value > 0, enables Gemini's internal reasoning (chain-of-thought) before producing the response
- Default: `0` (disabled) — current behavior unchanged
- Max: `32000` tokens
- Ignored for Anthropic provider
- Thinking tokens share the `maxOutputTokens` budget, so callers should set `maxTokens` high enough to accommodate both

## Changes
- `schemas.ts`: added `thinkingBudget` field to `CompleteRequestSchema`
- `gemini.ts`: accepts `thinkingBudget`, passes to `generationConfig.thinkingConfig`
- `index.ts`: threads `thinkingBudget` from request body to Gemini client
- `openapi.json`: regenerated

## Test plan
- [x] New test: verifies caller-provided thinkingBudget is forwarded
- [x] Existing test: verifies default thinkingBudget is 0
- [x] All 380 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)