### PR TITLE
feat: support thinkingBudget for Anthropic extended thinking

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Request body:
 - `responseFormat` (optional) — set to `"json"` to instruct the model to return valid JSON. The parsed result appears in the `json` field.
 - `temperature` (optional) — sampling temperature, 0–2 (default: model default)
 - `maxTokens` (optional) — max output tokens, 1–64000 (default: 64000)
+- `thinkingBudget` (optional) — thinking token budget, 0–32000 (default: 0 = disabled). Enables internal chain-of-thought reasoning before the model responds. Thinking tokens share the `maxTokens` budget, so set `maxTokens` high enough for both. **Google:** maps to `thinkingConfig.thinkingBudget`. **Anthropic:** maps to `thinking.budget_tokens` (minimum 1024; temperature is forced to 1 when enabled).
 - `imageUrl` (optional) — URL of an image to include as visual input. The image is fetched server-side. Supported by all models, but recommended with `google` + `flash-lite` for cost-effective vision tasks.
 - `imageContext` (optional) — metadata about the image to help the model classify it: `{ alt?: string, title?: string, sourceUrl?: string }`. Injected into the prompt alongside the image. Only meaningful when `imageUrl` is provided.
 

--- a/openapi.json
+++ b/openapi.json
@@ -577,7 +577,7 @@
             "type": "integer",
             "minimum": 0,
             "maximum": 32000,
-            "description": "Thinking token budget for Gemini models. When set to a value > 0, enables internal reasoning (chain-of-thought) before the model produces its response. Thinking tokens share the maxOutputTokens budget — set maxTokens high enough to accommodate both thinking and the response. Default: 0 (thinking disabled). Only applies to provider: \"google\"; ignored for Anthropic.",
+            "description": "Thinking token budget — enables internal reasoning (chain-of-thought) before the model produces its response. Thinking tokens share the maxTokens budget, so set maxTokens high enough to accommodate both.\n\n**Google:** maps to `thinkingConfig.thinkingBudget`. Default: 0 (disabled).\n**Anthropic:** maps to `thinking.budget_tokens`. Minimum: 1024. When enabled, temperature is forced to 1 (Anthropic API requirement).\n\nDefault: 0 (thinking disabled for both providers).",
             "example": 8000
           },
           "imageUrl": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -321,6 +321,7 @@ app.post("/complete", requireAuth, async (req, res) => {
         maxTokens,
         model: effectiveModel,
         imageUrl,
+        thinkingBudget,
       });
     }
 

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -1057,6 +1057,7 @@ export function createAnthropicClient({ apiKey, systemPrompt }: AnthropicOptions
         maxTokens?: number;
         model?: string;
         imageUrl?: string;
+        thinkingBudget?: number;
       },
     ): Promise<{
       content: string;
@@ -1080,12 +1081,20 @@ export function createAnthropicClient({ apiKey, systemPrompt }: AnthropicOptions
         userContent = message;
       }
 
+      const thinkingEnabled = (options?.thinkingBudget ?? 0) > 0;
+
       const params: Anthropic.MessageCreateParamsNonStreaming = {
         model: effectiveModel,
         max_tokens: options?.maxTokens ?? MAX_TOKENS,
         system: systemPrompt,
         messages: [{ role: "user", content: userContent }],
-        ...(options?.temperature != null ? { temperature: options.temperature } : {}),
+        // When thinking is enabled, Anthropic forces temperature to 1
+        ...(thinkingEnabled
+          ? {}
+          : options?.temperature != null ? { temperature: options.temperature } : {}),
+        ...(thinkingEnabled
+          ? { thinking: { type: "enabled" as const, budget_tokens: options!.thinkingBudget! } }
+          : {}),
         ...(options?.responseFormat === "json"
           ? {
               output_config: {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -328,10 +328,13 @@ export const CompleteRequestSchema = z
     }),
     thinkingBudget: z.number().int().min(0).max(32000).optional().openapi({
       description:
-        "Thinking token budget for Gemini models. When set to a value > 0, enables internal reasoning " +
-        "(chain-of-thought) before the model produces its response. Thinking tokens share the " +
-        "maxOutputTokens budget — set maxTokens high enough to accommodate both thinking and the response. " +
-        "Default: 0 (thinking disabled). Only applies to provider: \"google\"; ignored for Anthropic.",
+        "Thinking token budget — enables internal reasoning (chain-of-thought) before the model " +
+        "produces its response. Thinking tokens share the maxTokens budget, so set maxTokens high " +
+        "enough to accommodate both.\n\n" +
+        "**Google:** maps to `thinkingConfig.thinkingBudget`. Default: 0 (disabled).\n" +
+        "**Anthropic:** maps to `thinking.budget_tokens`. Minimum: 1024. " +
+        "When enabled, temperature is forced to 1 (Anthropic API requirement).\n\n" +
+        "Default: 0 (thinking disabled for both providers).",
       example: 8000,
     }),
     imageUrl: z.string().url().optional().openapi({
@@ -367,6 +370,24 @@ export const CompleteRequestSchema = z
         message: `Model "${data.model}" is not valid for provider "${data.provider}". Valid models: ${allowed.join(", ")}`,
         path: ["model"],
       });
+    }
+    // Anthropic thinking requires budget_tokens >= 1024 and budget_tokens < max_tokens
+    if (data.provider === "anthropic" && data.thinkingBudget != null && data.thinkingBudget > 0) {
+      if (data.thinkingBudget < 1024) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Anthropic requires thinkingBudget >= 1024 (got ${data.thinkingBudget})`,
+          path: ["thinkingBudget"],
+        });
+      }
+      const effectiveMax = data.maxTokens ?? 64000;
+      if (data.thinkingBudget >= effectiveMax) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `thinkingBudget (${data.thinkingBudget}) must be less than maxTokens (${effectiveMax}) — thinking tokens share the output budget`,
+          path: ["thinkingBudget"],
+        });
+      }
     }
   })
   .openapi("CompleteRequest");

--- a/tests/unit/anthropic-thinking.test.ts
+++ b/tests/unit/anthropic-thinking.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from "vitest";
+
+let lastCreateParams: Record<string, unknown>;
+let mockCreateResponse: Record<string, unknown>;
+
+vi.mock("@anthropic-ai/sdk", () => {
+  return {
+    default: class MockAnthropic {
+      messages = {
+        create: async (params: Record<string, unknown>) => {
+          lastCreateParams = params;
+          return mockCreateResponse;
+        },
+        stream: () => {
+          throw new Error("stream not implemented in mock");
+        },
+      };
+    },
+  };
+});
+
+const { createAnthropicClient } = await import("../../src/lib/anthropic.js");
+
+describe("anthropic complete() thinking support", () => {
+  const claude = createAnthropicClient({ apiKey: "test-key", systemPrompt: "You are helpful." });
+
+  it("sends thinking config when thinkingBudget > 0", async () => {
+    mockCreateResponse = {
+      stop_reason: "end_turn",
+      content: [
+        { type: "thinking", thinking: "Let me reason about this..." },
+        { type: "text", text: '{"answer": 42}' },
+      ],
+      usage: { input_tokens: 50, output_tokens: 200 },
+    };
+
+    const result = await claude.complete("Think about this", {
+      thinkingBudget: 8000,
+      maxTokens: 16000,
+    });
+
+    expect(lastCreateParams.thinking).toEqual({ type: "enabled", budget_tokens: 8000 });
+    // Thinking blocks should be excluded from content
+    expect(result.content).toBe('{"answer": 42}');
+    expect(result.tokensOutput).toBe(200);
+  });
+
+  it("does NOT send thinking config when thinkingBudget is 0", async () => {
+    mockCreateResponse = {
+      stop_reason: "end_turn",
+      content: [{ type: "text", text: "no thinking" }],
+      usage: { input_tokens: 10, output_tokens: 5 },
+    };
+
+    await claude.complete("Simple task", { thinkingBudget: 0 });
+
+    expect(lastCreateParams.thinking).toBeUndefined();
+  });
+
+  it("does NOT send thinking config when thinkingBudget is omitted", async () => {
+    mockCreateResponse = {
+      stop_reason: "end_turn",
+      content: [{ type: "text", text: "no thinking" }],
+      usage: { input_tokens: 10, output_tokens: 5 },
+    };
+
+    await claude.complete("Simple task");
+
+    expect(lastCreateParams.thinking).toBeUndefined();
+  });
+
+  it("omits caller temperature when thinking is enabled (Anthropic forces temp=1)", async () => {
+    mockCreateResponse = {
+      stop_reason: "end_turn",
+      content: [{ type: "text", text: "result" }],
+      usage: { input_tokens: 10, output_tokens: 5 },
+    };
+
+    await claude.complete("Think about this", {
+      thinkingBudget: 2000,
+      maxTokens: 16000,
+      temperature: 0.3,
+    });
+
+    expect(lastCreateParams.temperature).toBeUndefined();
+    expect(lastCreateParams.thinking).toEqual({ type: "enabled", budget_tokens: 2000 });
+  });
+
+  it("preserves caller temperature when thinking is NOT enabled", async () => {
+    mockCreateResponse = {
+      stop_reason: "end_turn",
+      content: [{ type: "text", text: "result" }],
+      usage: { input_tokens: 10, output_tokens: 5 },
+    };
+
+    await claude.complete("Simple task", { temperature: 0.3 });
+
+    expect(lastCreateParams.temperature).toBe(0.3);
+    expect(lastCreateParams.thinking).toBeUndefined();
+  });
+});

--- a/tests/unit/thinking-validation.test.ts
+++ b/tests/unit/thinking-validation.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { CompleteRequestSchema } from "../../src/schemas.js";
+
+describe("CompleteRequestSchema thinkingBudget validation", () => {
+  const base = {
+    message: "test",
+    systemPrompt: "You are helpful.",
+    provider: "anthropic" as const,
+    model: "sonnet" as const,
+  };
+
+  it("accepts thinkingBudget: 0 for Anthropic (disabled)", () => {
+    const result = CompleteRequestSchema.safeParse({ ...base, thinkingBudget: 0 });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts thinkingBudget >= 1024 for Anthropic", () => {
+    const result = CompleteRequestSchema.safeParse({ ...base, thinkingBudget: 1024, maxTokens: 16000 });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects thinkingBudget < 1024 for Anthropic (when > 0)", () => {
+    const result = CompleteRequestSchema.safeParse({ ...base, thinkingBudget: 500 });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toMatch(/thinkingBudget >= 1024/);
+    }
+  });
+
+  it("rejects thinkingBudget >= maxTokens for Anthropic", () => {
+    const result = CompleteRequestSchema.safeParse({ ...base, thinkingBudget: 2000, maxTokens: 2000 });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toMatch(/must be less than maxTokens/);
+    }
+  });
+
+  it("rejects thinkingBudget >= default maxTokens (64000) for Anthropic", () => {
+    const result = CompleteRequestSchema.safeParse({ ...base, thinkingBudget: 64000 });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts any thinkingBudget > 0 for Google (no min constraint)", () => {
+    const result = CompleteRequestSchema.safeParse({
+      ...base,
+      provider: "google",
+      model: "flash",
+      thinkingBudget: 100,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts omitted thinkingBudget", () => {
+    const result = CompleteRequestSchema.safeParse(base);
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- `thinkingBudget` on `POST /complete` now works for **both** providers (was Google-only)
- **Google:** maps to `thinkingConfig.thinkingBudget` (any value >= 0)
- **Anthropic:** maps to `thinking.budget_tokens` (min 1024, must be < maxTokens). Temperature is forced to 1 when thinking is enabled (Anthropic API requirement — caller's temperature value is silently ignored)
- Schema validation catches Anthropic-specific constraints at request time with clear 400 errors
- Thinking content blocks are filtered out of the response — callers only see the final text output

## Test plan
- [x] `anthropic-thinking.test.ts`: 5 tests — thinking params, temperature override, thinking block filtering
- [x] `thinking-validation.test.ts`: 7 tests — schema validation for Anthropic constraints (min 1024, budget < maxTokens)
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)