### PR TITLE
fix: robust JSON parsing for LLM responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Response:
 ```
 
 - `content` — raw text response (always present). **Warning:** when `responseFormat: "json"`, this field may contain markdown code fences (e.g. `` ```json...``` ``). Do **not** use this field for JSON parsing.
-- `json` — parsed JSON object (present when `responseFormat: "json"`). **Always use this field** for structured data — markdown fences are already stripped and the JSON is pre-parsed. If the model returns non-parsable JSON, the endpoint returns **502** instead of silently omitting this field.
+- `json` — parsed JSON value, object or array (present when `responseFormat: "json"`). **Always use this field** for structured data — markdown fences and trailing commas are already handled and the JSON is pre-parsed. If the model returns non-parsable JSON, the endpoint returns **502** instead of silently omitting this field.
 - `tokensInput` / `tokensOutput` — token usage
 - `model` — the versioned model ID that was actually used (resolved from the provider + alias)
 

--- a/openapi.json
+++ b/openapi.json
@@ -453,11 +453,8 @@
             "example": "{\"subject\": \"Quick question\", \"emails\": [{\"body\": \"Hi...\", \"daysSinceLastStep\": 0}]}"
           },
           "json": {
-            "type": "object",
-            "additionalProperties": {
-              "nullable": true
-            },
-            "description": "Parsed JSON object — present when responseFormat is \"json\". IMPORTANT: always use this field (not `content`) when you need structured data. Markdown fences are already stripped and the JSON is pre-parsed. If the model returns non-parsable JSON, the endpoint returns 502 instead of silently omitting this field.",
+            "nullable": true,
+            "description": "Parsed JSON value (object or array) — present when responseFormat is \"json\". IMPORTANT: always use this field (not `content`) when you need structured data. Markdown fences and trailing commas are already handled and the JSON is pre-parsed. If the model returns non-parsable JSON, the endpoint returns 502 instead of silently omitting this field.",
             "example": {
               "subject": "Quick question",
               "emails": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,55 @@ const openapiPath = join(__dirname, "..", "openapi.json");
 
 import { mergeConsecutiveMessages, stripToolUseBlocks } from "./lib/merge-messages.js";
 
+// ---------------------------------------------------------------------------
+// JSON parsing for LLM responses
+// ---------------------------------------------------------------------------
+
+/** Remove trailing commas before ] and } — a common LLM output quirk. */
+function removeTrailingCommas(s: string): string {
+  return s.replace(/,\s*([\]}])/g, "$1");
+}
+
+/**
+ * Parse JSON from model output with progressive repair:
+ * 1. Try raw JSON.parse
+ * 2. Strip markdown code fences and retry
+ * 3. Remove trailing commas and retry
+ * Throws with diagnostics if all attempts fail.
+ */
+function parseModelJson(raw: string): unknown {
+  const trimmed = raw.trim();
+
+  // Attempt 1: direct parse
+  try {
+    return JSON.parse(trimmed);
+  } catch { /* continue */ }
+
+  // Attempt 2: strip markdown fences
+  const stripped = trimmed
+    .replace(/^```(?:json)?\s*\n?/i, "")
+    .replace(/\n?```\s*$/i, "")
+    .trim();
+  try {
+    return JSON.parse(stripped);
+  } catch { /* continue */ }
+
+  // Attempt 3: remove trailing commas (LLMs often produce these)
+  const repaired = removeTrailingCommas(stripped);
+  try {
+    const parsed = JSON.parse(repaired);
+    console.warn(`[chat-service] JSON required trailing-comma repair (contentLen=${raw.length})`);
+    return parsed;
+  } catch { /* continue */ }
+
+  throw new Error(
+    `Model returned non-parsable JSON despite responseFormat: "json". ` +
+    `contentLen=${raw.length}, ` +
+    `first500=${raw.slice(0, 500)}, ` +
+    `last200=${raw.slice(-200)}`
+  );
+}
+
 const app = express();
 app.use(cors());
 app.use(express.json({ limit: "10mb" }));
@@ -338,18 +387,7 @@ app.post("/complete", requireAuth, async (req, res) => {
 
     // Parse JSON if requested
     if (responseFormat === "json") {
-      const trimmed = result.content.trim();
-      try {
-        response.json = JSON.parse(trimmed);
-      } catch {
-        // LLM sometimes wraps JSON in markdown fences — strip and retry
-        const stripped = trimmed.replace(/^```(?:json)?\s*\n?/i, "").replace(/\n?```\s*$/i, "").trim();
-        try {
-          response.json = JSON.parse(stripped);
-        } catch {
-          throw new Error(`Model returned non-parsable JSON despite responseFormat: "json". Content: ${result.content.slice(0, 500)}`);
-        }
-      }
+      response.json = parseModelJson(result.content);
     }
 
     res.json(response);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -398,8 +398,8 @@ export const CompleteResponseSchema = z
       description: "Raw text response from the model. WARNING: when responseFormat is \"json\", this field may contain markdown code fences (e.g. ```json...```). Do NOT use this field for JSON parsing — use the `json` field instead.",
       example: '{"subject": "Quick question", "emails": [{"body": "Hi...", "daysSinceLastStep": 0}]}',
     }),
-    json: z.record(z.string(), z.unknown()).optional().openapi({
-      description: "Parsed JSON object — present when responseFormat is \"json\". IMPORTANT: always use this field (not `content`) when you need structured data. Markdown fences are already stripped and the JSON is pre-parsed. If the model returns non-parsable JSON, the endpoint returns 502 instead of silently omitting this field.",
+    json: z.unknown().optional().openapi({
+      description: "Parsed JSON value (object or array) — present when responseFormat is \"json\". IMPORTANT: always use this field (not `content`) when you need structured data. Markdown fences and trailing commas are already handled and the JSON is pre-parsed. If the model returns non-parsable JSON, the endpoint returns 502 instead of silently omitting this field.",
       example: { subject: "Quick question", emails: [{ body: "Hi there, I noticed...", daysSinceLastStep: 0 }] },
     }),
     tokensInput: z.number().openapi({

--- a/tests/unit/json-markdown-strip.test.ts
+++ b/tests/unit/json-markdown-strip.test.ts
@@ -1,94 +1,173 @@
 import { describe, it, expect } from "vitest";
 
+/** Remove trailing commas before ] and } — a common LLM output quirk. */
+function removeTrailingCommas(s: string): string {
+  return s.replace(/,\s*([\]}])/g, "$1");
+}
+
 /**
- * Mirrors the markdown-fence stripping logic in src/index.ts /complete handler.
- * If JSON.parse fails on raw content, strip ```json fences and retry.
+ * Mirrors the parseModelJson logic in src/index.ts /complete handler.
+ * Progressive repair: raw parse → strip fences → remove trailing commas.
  * Throws on truly unparsable content (no silent fallback).
  */
-function parseJsonWithFenceStrip(content: string): unknown {
-  const trimmed = content.trim();
+function parseModelJson(raw: string): unknown {
+  const trimmed = raw.trim();
+
+  // Attempt 1: direct parse
   try {
     return JSON.parse(trimmed);
-  } catch {
-    const stripped = trimmed.replace(/^```(?:json)?\s*\n?/i, "").replace(/\n?```\s*$/i, "").trim();
-    try {
-      return JSON.parse(stripped);
-    } catch {
-      throw new Error(`Model returned non-parsable JSON. Content: ${content.slice(0, 500)}`);
-    }
-  }
+  } catch { /* continue */ }
+
+  // Attempt 2: strip markdown fences
+  const stripped = trimmed
+    .replace(/^```(?:json)?\s*\n?/i, "")
+    .replace(/\n?```\s*$/i, "")
+    .trim();
+  try {
+    return JSON.parse(stripped);
+  } catch { /* continue */ }
+
+  // Attempt 3: remove trailing commas
+  const repaired = removeTrailingCommas(stripped);
+  try {
+    return JSON.parse(repaired);
+  } catch { /* continue */ }
+
+  throw new Error(
+    `Model returned non-parsable JSON. contentLen=${raw.length}, first500=${raw.slice(0, 500)}`
+  );
 }
 
 describe("JSON markdown fence stripping", () => {
   it("parses plain JSON without fences", () => {
-    const result = parseJsonWithFenceStrip('{"key": "value"}');
+    const result = parseModelJson('{"key": "value"}');
     expect(result).toEqual({ key: "value" });
   });
 
   it("strips ```json fences and parses", () => {
     const content = '```json\n{"key": "value"}\n```';
-    const result = parseJsonWithFenceStrip(content);
+    const result = parseModelJson(content);
     expect(result).toEqual({ key: "value" });
   });
 
   it("strips ``` fences without json tag", () => {
     const content = '```\n{"key": "value"}\n```';
-    const result = parseJsonWithFenceStrip(content);
+    const result = parseModelJson(content);
     expect(result).toEqual({ key: "value" });
   });
 
   it("strips ```JSON fences (case-insensitive)", () => {
     const content = '```JSON\n{"items": [1, 2, 3]}\n```';
-    const result = parseJsonWithFenceStrip(content);
+    const result = parseModelJson(content);
     expect(result).toEqual({ items: [1, 2, 3] });
   });
 
   it("handles array responses wrapped in fences", () => {
     const content = '```json\n[{"id": 1}, {"id": 2}]\n```';
-    const result = parseJsonWithFenceStrip(content);
+    const result = parseModelJson(content);
     expect(result).toEqual([{ id: 1 }, { id: 2 }]);
   });
 
   it("throws for truly unparsable content", () => {
-    expect(() => parseJsonWithFenceStrip("This is not JSON at all")).toThrow(
+    expect(() => parseModelJson("This is not JSON at all")).toThrow(
       "Model returned non-parsable JSON",
     );
   });
 
   it("throws for fenced non-JSON content", () => {
     const content = '```json\nnot actually json\n```';
-    expect(() => parseJsonWithFenceStrip(content)).toThrow(
+    expect(() => parseModelJson(content)).toThrow(
       "Model returned non-parsable JSON",
     );
   });
 
   it("handles fences with no trailing newline", () => {
     const content = '```json\n{"ok": true}```';
-    const result = parseJsonWithFenceStrip(content);
+    const result = parseModelJson(content);
     expect(result).toEqual({ ok: true });
   });
 
   it("handles leading/trailing whitespace around fences", () => {
     const content = '\n```json\n{"isArticle": false, "authors": [], "publishedAt": null}\n```\n';
-    const result = parseJsonWithFenceStrip(content);
+    const result = parseModelJson(content);
     expect(result).toEqual({ isArticle: false, authors: [], publishedAt: null });
   });
 
   it("handles leading/trailing whitespace around plain JSON", () => {
     const content = '  \n{"key": "value"}\n  ';
-    const result = parseJsonWithFenceStrip(content);
+    const result = parseModelJson(content);
     expect(result).toEqual({ key: "value" });
   });
 
   it("handles whitespace inside fences around JSON", () => {
     const content = '```json\n\n  {"key": "value"}\n\n```';
-    const result = parseJsonWithFenceStrip(content);
+    const result = parseModelJson(content);
     expect(result).toEqual({ key: "value" });
   });
 
   it("handles \\r\\n line endings", () => {
     const content = '```json\r\n{"key": "value"}\r\n```';
-    const result = parseJsonWithFenceStrip(content);
+    const result = parseModelJson(content);
     expect(result).toEqual({ key: "value" });
+  });
+});
+
+describe("trailing comma repair", () => {
+  it("repairs trailing comma in object", () => {
+    const content = '{"key": "value",}';
+    const result = parseModelJson(content);
+    expect(result).toEqual({ key: "value" });
+  });
+
+  it("repairs trailing comma in array", () => {
+    const content = '["url1", "url2", "url3",]';
+    const result = parseModelJson(content);
+    expect(result).toEqual(["url1", "url2", "url3"]);
+  });
+
+  it("repairs trailing comma with whitespace/newlines", () => {
+    const content = '[\n  "https://example.com/about",\n  "https://example.com/team",\n]';
+    const result = parseModelJson(content);
+    expect(result).toEqual(["https://example.com/about", "https://example.com/team"]);
+  });
+
+  it("repairs trailing comma in nested structures", () => {
+    const content = '{"items": [1, 2, 3,], "nested": {"a": 1,},}';
+    const result = parseModelJson(content);
+    expect(result).toEqual({ items: [1, 2, 3], nested: { a: 1 } });
+  });
+
+  it("repairs trailing comma inside fenced JSON", () => {
+    const content = '```json\n["url1", "url2",]\n```';
+    const result = parseModelJson(content);
+    expect(result).toEqual(["url1", "url2"]);
+  });
+
+  it("repairs real-world URL array with trailing comma", () => {
+    const content = `[
+  "https://nesarabaycity.com/about",
+  "https://nesarabaycity.com/major-changes-under-new-ownership",
+  "https://nesarabaycity.com/why-invest-in-nesara-bay",
+]`;
+    const result = parseModelJson(content);
+    expect(result).toEqual([
+      "https://nesarabaycity.com/about",
+      "https://nesarabaycity.com/major-changes-under-new-ownership",
+      "https://nesarabaycity.com/why-invest-in-nesara-bay",
+    ]);
+  });
+});
+
+describe("plain JSON arrays", () => {
+  it("parses a plain JSON array of strings", () => {
+    const content = '["a", "b", "c"]';
+    const result = parseModelJson(content);
+    expect(result).toEqual(["a", "b", "c"]);
+  });
+
+  it("parses a plain JSON array of objects", () => {
+    const content = '[{"id": 1}, {"id": 2}]';
+    const result = parseModelJson(content);
+    expect(result).toEqual([{ id: 1 }, { id: 2 }]);
   });
 });


### PR DESCRIPTION
## Summary
- **Fix**: LLM responses with trailing commas in JSON arrays/objects (e.g. `["url1", "url2",]`) now parse correctly instead of returning 502
- **Fix**: `json` response field schema changed from `Record<string, unknown>` to `unknown` to properly support JSON arrays (not just objects)
- **Improvement**: Error messages now include `contentLen` and `last200` chars for better debugging of parse failures
- Progressive repair chain: raw parse → strip markdown fences → remove trailing commas → throw with diagnostics

## Test plan
- [x] 20 unit tests covering: plain JSON, fenced JSON, trailing commas in objects/arrays/nested, real-world URL arrays
- [x] All existing tests pass (400 passed, 6 skipped DB integration)
- [x] Build succeeds, OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)