### PR TITLE
fix: don't send thinkingBudget: 0 to Gemini thinking-only models

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Request body:
 - `responseFormat` (optional) — set to `"json"` to instruct the model to return valid JSON. The parsed result appears in the `json` field.
 - `temperature` (optional) — sampling temperature, 0–2 (default: model default)
 - `maxTokens` (optional) — max output tokens, 1–64000 (default: 64000)
-- `thinkingBudget` (optional) — thinking token budget, 0–32000 (default: 0 = disabled). Enables internal chain-of-thought reasoning before the model responds. Thinking tokens share the `maxTokens` budget, so set `maxTokens` high enough for both. **Google:** maps to `thinkingConfig.thinkingBudget`. **Anthropic:** maps to `thinking.budget_tokens` (minimum 1024; temperature is forced to 1 when enabled).
+- `thinkingBudget` (optional) — thinking token budget, 0–32000. Enables internal chain-of-thought reasoning before the model responds. Thinking tokens share the `maxTokens` budget, so set `maxTokens` high enough for both. **Google:** maps to `thinkingConfig.thinkingBudget`; when omitted or 0, `thinkingConfig` is not sent (thinking-only models use their default budget). **Anthropic:** maps to `thinking.budget_tokens` (minimum 1024; temperature is forced to 1 when enabled).
 - `imageUrl` (optional) — URL of an image to include as visual input. The image is fetched server-side. Supported by all models, but recommended with `google` + `flash-lite` for cost-effective vision tasks.
 - `imageContext` (optional) — metadata about the image to help the model classify it: `{ alt?: string, title?: string, sourceUrl?: string }`. Injected into the prompt alongside the image. Only meaningful when `imageUrl` is provided.
 

--- a/openapi.json
+++ b/openapi.json
@@ -574,7 +574,7 @@
             "type": "integer",
             "minimum": 0,
             "maximum": 32000,
-            "description": "Thinking token budget — enables internal reasoning (chain-of-thought) before the model produces its response. Thinking tokens share the maxTokens budget, so set maxTokens high enough to accommodate both.\n\n**Google:** maps to `thinkingConfig.thinkingBudget`. Default: 0 (disabled).\n**Anthropic:** maps to `thinking.budget_tokens`. Minimum: 1024. When enabled, temperature is forced to 1 (Anthropic API requirement).\n\nDefault: 0 (thinking disabled for both providers).",
+            "description": "Thinking token budget — enables internal reasoning (chain-of-thought) before the model produces its response. Thinking tokens share the maxTokens budget, so set maxTokens high enough to accommodate both.\n\n**Google:** maps to `thinkingConfig.thinkingBudget`. When omitted or 0, thinkingConfig is not sent (lets thinking-only models use their default budget).\n**Anthropic:** maps to `thinking.budget_tokens`. Minimum: 1024. When enabled, temperature is forced to 1 (Anthropic API requirement).\n\nDefault: omitted (thinking not explicitly configured).",
             "example": 8000
           },
           "imageUrl": {

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -101,19 +101,22 @@ export async function completeWithGemini(options: GeminiCompleteOptions): Promis
   }
 
   // Build request body
-  // Thinking (internal reasoning) is disabled by default (thinkingBudget: 0)
-  // because thinking tokens share the maxOutputTokens budget and can consume
-  // it entirely.  Callers can opt in via the thinkingBudget option.
-  const effectiveThinkingBudget = thinkingBudget ?? 0;
+  // Only include thinkingConfig when the caller explicitly opts in with a
+  // positive budget.  Some Gemini models ("thinking-only") reject
+  // thinkingBudget: 0 with a 400.  Omitting thinkingConfig entirely lets
+  // each model use its own default behaviour.
+  const generationConfig: Record<string, unknown> = {
+    ...(temperature != null ? { temperature } : {}),
+    maxOutputTokens: maxTokens ?? 64_000,
+    ...(responseFormat === "json" ? { responseMimeType: "application/json" } : {}),
+    ...(thinkingBudget != null && thinkingBudget > 0
+      ? { thinkingConfig: { thinkingBudget } }
+      : {}),
+  };
   const body: Record<string, unknown> = {
     contents: [{ parts }],
     systemInstruction: { parts: [{ text: systemPrompt }] },
-    generationConfig: {
-      ...(temperature != null ? { temperature } : {}),
-      maxOutputTokens: maxTokens ?? 64_000,
-      ...(responseFormat === "json" ? { responseMimeType: "application/json" } : {}),
-      thinkingConfig: { thinkingBudget: effectiveThinkingBudget },
-    },
+    generationConfig,
   };
 
   const url = `${GEMINI_API_BASE}/models/${encodeURIComponent(model)}:generateContent?key=${encodeURIComponent(apiKey)}`;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -331,10 +331,11 @@ export const CompleteRequestSchema = z
         "Thinking token budget — enables internal reasoning (chain-of-thought) before the model " +
         "produces its response. Thinking tokens share the maxTokens budget, so set maxTokens high " +
         "enough to accommodate both.\n\n" +
-        "**Google:** maps to `thinkingConfig.thinkingBudget`. Default: 0 (disabled).\n" +
+        "**Google:** maps to `thinkingConfig.thinkingBudget`. When omitted or 0, thinkingConfig is not sent " +
+        "(lets thinking-only models use their default budget).\n" +
         "**Anthropic:** maps to `thinking.budget_tokens`. Minimum: 1024. " +
         "When enabled, temperature is forced to 1 (Anthropic API requirement).\n\n" +
-        "Default: 0 (thinking disabled for both providers).",
+        "Default: omitted (thinking not explicitly configured).",
       example: 8000,
     }),
     imageUrl: z.string().url().optional().openapi({

--- a/tests/unit/gemini.test.ts
+++ b/tests/unit/gemini.test.ts
@@ -104,7 +104,7 @@ describe("completeWithGemini", () => {
     expect(requestBody.generationConfig.maxOutputTokens).toBe(64_000);
   });
 
-  it("disables thinking by default (thinkingBudget: 0)", async () => {
+  it("omits thinkingConfig by default so thinking-only models use their defaults", async () => {
     fetchSpy.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
@@ -116,7 +116,22 @@ describe("completeWithGemini", () => {
     await completeWithGemini(baseOptions);
 
     const requestBody = JSON.parse(fetchSpy.mock.calls[0][1].body);
-    expect(requestBody.generationConfig.thinkingConfig).toEqual({ thinkingBudget: 0 });
+    expect(requestBody.generationConfig.thinkingConfig).toBeUndefined();
+  });
+
+  it("omits thinkingConfig when thinkingBudget is explicitly 0", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        candidates: [{ content: { parts: [{ text: '{}' }] }, finishReason: "STOP" }],
+        usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5 },
+      }),
+    });
+
+    await completeWithGemini({ ...baseOptions, thinkingBudget: 0 });
+
+    const requestBody = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    expect(requestBody.generationConfig.thinkingConfig).toBeUndefined();
   });
 
   it("uses caller-provided thinkingBudget when specified", async () => {


### PR DESCRIPTION
## Summary
- Some Gemini models (e.g. pro) reject `thinkingBudget: 0` with HTTP 400: *"Budget 0 is invalid. This model only works in thinking mode."*
- Instead of always sending `thinkingConfig: { thinkingBudget: 0 }`, we now omit `thinkingConfig` entirely when `thinkingBudget` is not provided or is 0
- Thinking-only models use their default budget; callers can still explicitly control the budget with a positive value

## Test plan
- [x] Updated existing test: verifies `thinkingConfig` is omitted by default
- [x] Added new test: verifies `thinkingConfig` is omitted when `thinkingBudget: 0` is explicitly passed
- [x] Existing test: verifies `thinkingConfig` is sent when `thinkingBudget > 0`
- [x] All 400 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)