### PR TITLE
fix: call api-registry directly instead of proxying through api-service

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -849,7 +849,7 @@ app.post("/chat", requireAuth, async (req, res) => {
 
       // API Registry progressive disclosure tools
       if (call.name === "list_services") {
-        const result = await listServices({ orgId, userId, runId: runId! });
+        const result = await listServices();
         toolCalls.push({ name: call.name, args: {}, result });
         return { name: call.name, result };
       }
@@ -858,7 +858,6 @@ app.post("/chat", requireAuth, async (req, res) => {
         const args = (call.args as Record<string, unknown>) || {};
         const result = await listServiceEndpoints(
           args.service as string,
-          { orgId, userId, runId: runId! },
         );
         toolCalls.push({ name: call.name, args, result });
         return { name: call.name, result };

--- a/src/lib/api-registry-client.ts
+++ b/src/lib/api-registry-client.ts
@@ -1,17 +1,28 @@
-import { apiServiceFetch, type ApiCallParams } from "./api-client.js";
-
-export type ApiRegistryCallParams = ApiCallParams;
+const API_REGISTRY_URL =
+  process.env.API_REGISTRY_SERVICE_URL || "https://api-registry.distribute.you";
+const API_REGISTRY_API_KEY = process.env.API_REGISTRY_SERVICE_API_KEY;
 
 // ---------------------------------------------------------------------------
-// Progressive disclosure: list_services → list_service_endpoints → call_api
-// All routed through api-service gateway.
+// Progressive disclosure: list_services → list_service_endpoints
+// Called directly against api-registry (no api-service proxy).
 // ---------------------------------------------------------------------------
+
+function registryFetch(path: string): Promise<Response> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (API_REGISTRY_API_KEY) {
+    headers["X-API-Key"] = API_REGISTRY_API_KEY;
+  }
+  return fetch(`${API_REGISTRY_URL}${path}`, { method: "GET", headers });
+}
 
 /** Step 1: Lightweight overview — service names, descriptions, endpoint counts. */
 export interface ServiceOverview {
   service: string;
   title?: string;
   description?: string;
+  error?: string;
   endpointCount: number;
 }
 
@@ -22,14 +33,12 @@ export interface ListServicesResponse {
   services: ServiceOverview[];
 }
 
-export async function listServices(
-  params: ApiRegistryCallParams,
-): Promise<ListServicesResponse> {
-  const res = await apiServiceFetch("/v1/platform/llm-context", "GET", params);
+export async function listServices(): Promise<ListServicesResponse> {
+  const res = await registryFetch("/llm-context");
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `[api-registry-client] GET /v1/platform/llm-context returned ${res.status}: ${text}`,
+      `[api-registry-client] GET /llm-context returned ${res.status}: ${text}`,
     );
   }
   return (await res.json()) as ListServicesResponse;
@@ -46,57 +55,29 @@ export interface ListServiceEndpointsResponse {
   service: string;
   title?: string;
   description?: string;
-  endpointCount: number;
-  endpoints: EndpointSummary[];
+  endpointCount?: number;
+  endpoints?: EndpointSummary[];
+  /** Present when the service has 30+ endpoints and results are grouped. */
+  totalEndpoints?: number;
+  groupCount?: number;
+  groups?: {
+    group: string;
+    endpointCount: number;
+    endpoints: EndpointSummary[];
+  }[];
 }
 
 export async function listServiceEndpoints(
   service: string,
-  params: ApiRegistryCallParams,
 ): Promise<ListServiceEndpointsResponse> {
-  const res = await apiServiceFetch(
-    `/v1/platform/services/${encodeURIComponent(service)}`,
-    "GET",
-    params,
+  const res = await registryFetch(
+    `/llm-context/${encodeURIComponent(service)}`,
   );
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `[api-registry-client] GET /v1/platform/services/${service} returned ${res.status}: ${text}`,
+      `[api-registry-client] GET /llm-context/${service} returned ${res.status}: ${text}`,
     );
   }
   return (await res.json()) as ListServiceEndpointsResponse;
-}
-
-/** Step 3: Call an api-service endpoint directly. */
-export interface CallApiParams {
-  service: string;
-  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
-  path: string;
-  body?: Record<string, unknown>;
-}
-
-export interface CallApiResponse {
-  status: number;
-  ok: boolean;
-  data: unknown;
-}
-
-export async function callApi(
-  callParams: CallApiParams,
-  identityParams: ApiRegistryCallParams,
-): Promise<CallApiResponse> {
-  const res = await apiServiceFetch(
-    callParams.path,
-    callParams.method,
-    identityParams,
-    callParams.body,
-  );
-
-  const data = await res.json().catch(() => null);
-  return {
-    status: res.status,
-    ok: res.ok,
-    data,
-  };
 }

--- a/tests/unit/api-registry-client.test.ts
+++ b/tests/unit/api-registry-client.test.ts
@@ -3,8 +3,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 const originalEnv = { ...process.env };
 
 beforeEach(() => {
-  process.env.ADMIN_DISTRIBUTE_API_KEY = "test-api-svc-key";
-  process.env.API_SERVICE_URL = "https://api.test.local";
+  process.env.API_REGISTRY_SERVICE_URL = "https://api-registry.test.local";
+  process.env.API_REGISTRY_SERVICE_API_KEY = "test-registry-key";
   vi.stubGlobal("fetch", vi.fn());
 });
 
@@ -19,10 +19,10 @@ async function loadModule() {
 }
 
 describe("listServices", () => {
-  it("calls GET /v1/platform/llm-context via api-service", async () => {
+  it("calls GET /llm-context on api-registry directly", async () => {
     const mockResponse = {
       _description: "API registry",
-      _workflow: "list_services → list_service_endpoints → call_api",
+      _workflow: "list_services → list_service_endpoints",
       serviceCount: 2,
       services: [
         { service: "brand", title: "Brand Service", endpointCount: 5 },
@@ -36,25 +36,34 @@ describe("listServices", () => {
     });
 
     const { listServices } = await loadModule();
-    const result = await listServices({
-      orgId: "org-1",
-      userId: "user-1",
-      runId: "run-1",
-    });
+    const result = await listServices();
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://api.test.local/v1/platform/llm-context",
+      "https://api-registry.test.local/llm-context",
       expect.objectContaining({
+        method: "GET",
         headers: expect.objectContaining({
-          "X-API-Key": "test-api-svc-key",
-          "x-org-id": "org-1",
-          "x-user-id": "user-1",
-          "x-run-id": "run-1",
+          "X-API-Key": "test-registry-key",
         }),
       }),
     );
     expect(result.serviceCount).toBe(2);
     expect(result.services).toHaveLength(2);
+  });
+
+  it("omits X-API-Key header when no key is configured", async () => {
+    delete process.env.API_REGISTRY_SERVICE_API_KEY;
+
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ serviceCount: 0, services: [] }),
+    });
+
+    const { listServices } = await loadModule();
+    await listServices();
+
+    const headers = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].headers;
+    expect(headers).not.toHaveProperty("X-API-Key");
   });
 
   it("throws on HTTP error", async () => {
@@ -65,23 +74,12 @@ describe("listServices", () => {
     });
 
     const { listServices } = await loadModule();
-    await expect(
-      listServices({ orgId: "o", userId: "u", runId: "r" }),
-    ).rejects.toThrow(/returned 401/);
-  });
-
-  it("throws when API key is missing", async () => {
-    delete process.env.ADMIN_DISTRIBUTE_API_KEY;
-
-    const { listServices } = await loadModule();
-    await expect(
-      listServices({ orgId: "o", userId: "u", runId: "r" }),
-    ).rejects.toThrow(/ADMIN_DISTRIBUTE_API_KEY is required/);
+    await expect(listServices()).rejects.toThrow(/returned 401/);
   });
 });
 
 describe("listServiceEndpoints", () => {
-  it("calls GET /v1/platform/services/{service} via api-service", async () => {
+  it("calls GET /llm-context/{service} on api-registry directly", async () => {
     const mockResponse = {
       service: "brand",
       title: "Brand Service",
@@ -98,18 +96,41 @@ describe("listServiceEndpoints", () => {
     });
 
     const { listServiceEndpoints } = await loadModule();
-    const result = await listServiceEndpoints("brand", {
-      orgId: "org-1",
-      userId: "user-1",
-      runId: "run-1",
-    });
+    const result = await listServiceEndpoints("brand");
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://api.test.local/v1/platform/services/brand",
+      "https://api-registry.test.local/llm-context/brand",
       expect.anything(),
     );
     expect(result.service).toBe("brand");
     expect(result.endpoints).toHaveLength(2);
+  });
+
+  it("handles grouped response for large services", async () => {
+    const mockResponse = {
+      service: "workflow",
+      totalEndpoints: 45,
+      groupCount: 3,
+      groups: [
+        {
+          group: "workflows",
+          endpointCount: 20,
+          endpoints: [{ method: "GET", path: "/v1/workflows", summary: "List workflows" }],
+        },
+      ],
+    };
+
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    });
+
+    const { listServiceEndpoints } = await loadModule();
+    const result = await listServiceEndpoints("workflow");
+
+    expect(result.totalEndpoints).toBe(45);
+    expect(result.groupCount).toBe(3);
+    expect(result.groups).toHaveLength(1);
   });
 
   it("throws on 404 (service not found)", async () => {
@@ -121,88 +142,24 @@ describe("listServiceEndpoints", () => {
 
     const { listServiceEndpoints } = await loadModule();
     await expect(
-      listServiceEndpoints("nonexistent", { orgId: "o", userId: "u", runId: "r" }),
+      listServiceEndpoints("nonexistent"),
     ).rejects.toThrow(/returned 404/);
   });
-});
 
-describe("callApi", () => {
-  it("makes a direct GET request via api-service", async () => {
+  it("uses default URL when env var is not set", async () => {
+    delete process.env.API_REGISTRY_SERVICE_URL;
+
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
-      status: 200,
-      json: () =>
-        Promise.resolve({ keys: [{ provider: "anthropic", maskedKey: "sk-...abc" }] }),
+      json: () => Promise.resolve({ service: "test", endpoints: [] }),
     });
 
-    const { callApi } = await loadModule();
-    const result = await callApi(
-      { service: "key", method: "GET", path: "/v1/keys" },
-      { orgId: "org-1", userId: "user-1", runId: "run-1" },
-    );
+    const { listServiceEndpoints } = await loadModule();
+    await listServiceEndpoints("test");
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://api.test.local/v1/keys",
-      expect.objectContaining({
-        method: "GET",
-        headers: expect.objectContaining({
-          "X-API-Key": "test-api-svc-key",
-        }),
-      }),
+      "https://api-registry.distribute.you/llm-context/test",
+      expect.anything(),
     );
-
-    expect(result.ok).toBe(true);
-    expect(result.status).toBe(200);
-  });
-
-  it("makes a direct POST request with body via api-service", async () => {
-    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: () =>
-        Promise.resolve({ providers: ["anthropic"] }),
-    });
-
-    const { callApi } = await loadModule();
-    await callApi(
-      {
-        service: "key",
-        method: "POST",
-        path: "/v1/keys/provider-requirements",
-        body: { endpoints: [{ service: "chat", method: "POST", path: "/complete" }] },
-      },
-      { orgId: "org-1", userId: "user-1", runId: "run-1" },
-    );
-
-    expect(fetch).toHaveBeenCalledWith(
-      "https://api.test.local/v1/keys/provider-requirements",
-      expect.objectContaining({
-        method: "POST",
-      }),
-    );
-
-    const callBody = JSON.parse(
-      (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body,
-    );
-    expect(callBody).toEqual({
-      endpoints: [{ service: "chat", method: "POST", path: "/complete" }],
-    });
-  });
-
-  it("returns error status for failed requests", async () => {
-    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ok: false,
-      status: 502,
-      json: () => Promise.resolve({ error: "Downstream unavailable" }),
-    });
-
-    const { callApi } = await loadModule();
-    const result = await callApi(
-      { service: "brand", method: "GET", path: "/v1/brands" },
-      { orgId: "o", userId: "u", runId: "r" },
-    );
-
-    expect(result.ok).toBe(false);
-    expect(result.status).toBe(502);
   });
 });


### PR DESCRIPTION
## Summary
- Chat service was calling api-service at `/v1/platform/llm-context` and `/v1/platform/services/{service}` to proxy api-registry — unnecessary indirection that also returned mismatched response formats
- Now calls api-registry directly at `GET /llm-context` (lightweight service list) and `GET /llm-context/{service}` (structured endpoint list), which match the progressive disclosure pattern exactly
- Removes unused `callApi` function (tool was already removed)
- New env vars: `API_REGISTRY_SERVICE_URL` (defaults to `https://api-registry.distribute.you`), optional `API_REGISTRY_SERVICE_API_KEY`

## Test plan
- [x] Unit tests updated and passing (7 tests)
- [x] Full test suite green (376 passed)
- [ ] Verify `API_REGISTRY_SERVICE_URL` is set in Railway env (or confirm default URL works)
- [ ] Test `list_services` and `list_service_endpoints` tools in a chat session

🤖 Generated with [Claude Code](https://claude.com/claude-code)