### PR TITLE
fix: cleanup Neon branches after integration tests

### DIFF
--- a/.github/workflows/test-check.yml
+++ b/.github/workflows/test-check.yml
@@ -78,3 +78,11 @@ jobs:
         run: npm run test:integration
         env:
           CHAT_SERVICE_DATABASE_URL: ${{ steps.neon.outputs.db_url_pooled }}
+
+      - name: Delete Neon branch
+        if: always()
+        uses: neondatabase/delete-branch-action@v3
+        with:
+          project_id: ${{ vars.NEON_PROJECT_ID }}
+          branch: pr-${{ github.event.number }}
+          api_key: ${{ secrets.NEON_API_KEY }}


### PR DESCRIPTION
## Summary
- Adds a `Delete Neon branch` step with `if: always()` at the end of the `test-integration` job, so the PR branch is cleaned up after every CI run regardless of test outcome
- Previously, cleanup only happened via `neon-cleanup.yml` on PR close, which left orphaned branches when it failed or was skipped
- Manually deleted 15 stale `pr-*` branches from the chat-service Neon project

## Test plan
- [ ] Verify the cleanup step runs after integration tests (check a PR's CI logs)
- [ ] Confirm no new orphaned Neon branches appear after merged PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)