### PR TITLE
fix: restore robust JSON parsing for LLM responses

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,55 @@ const openapiPath = join(__dirname, "..", "openapi.json");
 
 import { mergeConsecutiveMessages, stripToolUseBlocks } from "./lib/merge-messages.js";
 
+// ---------------------------------------------------------------------------
+// JSON parsing for LLM responses
+// ---------------------------------------------------------------------------
+
+/** Remove trailing commas before ] and } — a common LLM output quirk. */
+function removeTrailingCommas(s: string): string {
+  return s.replace(/,\s*([\]}])/g, "$1");
+}
+
+/**
+ * Parse JSON from model output with progressive repair:
+ * 1. Try raw JSON.parse
+ * 2. Strip markdown code fences and retry
+ * 3. Remove trailing commas and retry
+ * Throws with diagnostics if all attempts fail.
+ */
+function parseModelJson(raw: string): unknown {
+  const trimmed = raw.trim();
+
+  // Attempt 1: direct parse
+  try {
+    return JSON.parse(trimmed);
+  } catch { /* continue */ }
+
+  // Attempt 2: strip markdown fences
+  const stripped = trimmed
+    .replace(/^```(?:json)?\s*\n?/i, "")
+    .replace(/\n?```\s*$/i, "")
+    .trim();
+  try {
+    return JSON.parse(stripped);
+  } catch { /* continue */ }
+
+  // Attempt 3: remove trailing commas (LLMs often produce these)
+  const repaired = removeTrailingCommas(stripped);
+  try {
+    const parsed = JSON.parse(repaired);
+    console.warn(`[chat-service] JSON required trailing-comma repair (contentLen=${raw.length})`);
+    return parsed;
+  } catch { /* continue */ }
+
+  throw new Error(
+    `Model returned non-parsable JSON despite responseFormat: "json". ` +
+    `contentLen=${raw.length}, ` +
+    `first500=${raw.slice(0, 500)}, ` +
+    `last200=${raw.slice(-200)}`
+  );
+}
+
 const app = express();
 app.use(cors());
 app.use(express.json({ limit: "10mb" }));
@@ -334,18 +383,7 @@ app.post("/complete", requireAuth, async (req, res) => {
 
     // Parse JSON if requested
     if (responseFormat === "json") {
-      const trimmed = result.content.trim();
-      try {
-        response.json = JSON.parse(trimmed);
-      } catch {
-        // LLM sometimes wraps JSON in markdown fences — strip and retry
-        const stripped = trimmed.replace(/^```(?:json)?\s*\n?/i, "").replace(/\n?```\s*$/i, "").trim();
-        try {
-          response.json = JSON.parse(stripped);
-        } catch {
-          throw new Error(`Model returned non-parsable JSON despite responseFormat: "json". Content: ${result.content.slice(0, 500)}`);
-        }
-      }
+      response.json = parseModelJson(result.content);
     }
 
     res.json(response);

--- a/tests/unit/json-markdown-strip.test.ts
+++ b/tests/unit/json-markdown-strip.test.ts
@@ -1,94 +1,138 @@
 import { describe, it, expect } from "vitest";
 
-/**
- * Mirrors the markdown-fence stripping logic in src/index.ts /complete handler.
- * If JSON.parse fails on raw content, strip ```json fences and retry.
- * Throws on truly unparsable content (no silent fallback).
- */
-function parseJsonWithFenceStrip(content: string): unknown {
-  const trimmed = content.trim();
-  try {
-    return JSON.parse(trimmed);
-  } catch {
-    const stripped = trimmed.replace(/^```(?:json)?\s*\n?/i, "").replace(/\n?```\s*$/i, "").trim();
-    try {
-      return JSON.parse(stripped);
-    } catch {
-      throw new Error(`Model returned non-parsable JSON. Content: ${content.slice(0, 500)}`);
-    }
-  }
+// ---------------------------------------------------------------------------
+// Mirrors parseModelJson from src/index.ts — progressive JSON repair for LLM output
+// ---------------------------------------------------------------------------
+
+function removeTrailingCommas(s: string): string {
+  return s.replace(/,\s*([\]}])/g, "$1");
 }
 
-describe("JSON markdown fence stripping", () => {
-  it("parses plain JSON without fences", () => {
-    const result = parseJsonWithFenceStrip('{"key": "value"}');
-    expect(result).toEqual({ key: "value" });
+function parseModelJson(raw: string): unknown {
+  const trimmed = raw.trim();
+
+  try {
+    return JSON.parse(trimmed);
+  } catch { /* continue */ }
+
+  const stripped = trimmed
+    .replace(/^```(?:json)?\s*\n?/i, "")
+    .replace(/\n?```\s*$/i, "")
+    .trim();
+  try {
+    return JSON.parse(stripped);
+  } catch { /* continue */ }
+
+  const repaired = removeTrailingCommas(stripped);
+  try {
+    return JSON.parse(repaired);
+  } catch { /* continue */ }
+
+  throw new Error(
+    `Model returned non-parsable JSON despite responseFormat: "json". ` +
+    `contentLen=${raw.length}, ` +
+    `first500=${raw.slice(0, 500)}, ` +
+    `last200=${raw.slice(-200)}`
+  );
+}
+
+describe("parseModelJson — JSON parsing with progressive repair", () => {
+  // --- Direct parse ---
+  it("parses plain JSON object", () => {
+    expect(parseModelJson('{"key": "value"}')).toEqual({ key: "value" });
   });
 
+  it("parses plain JSON array", () => {
+    expect(parseModelJson('[1, 2, 3]')).toEqual([1, 2, 3]);
+  });
+
+  it("handles leading/trailing whitespace", () => {
+    expect(parseModelJson('  \n{"key": "value"}\n  ')).toEqual({ key: "value" });
+  });
+
+  // --- Markdown fence stripping ---
   it("strips ```json fences and parses", () => {
     const content = '```json\n{"key": "value"}\n```';
-    const result = parseJsonWithFenceStrip(content);
-    expect(result).toEqual({ key: "value" });
+    expect(parseModelJson(content)).toEqual({ key: "value" });
   });
 
   it("strips ``` fences without json tag", () => {
     const content = '```\n{"key": "value"}\n```';
-    const result = parseJsonWithFenceStrip(content);
-    expect(result).toEqual({ key: "value" });
+    expect(parseModelJson(content)).toEqual({ key: "value" });
   });
 
   it("strips ```JSON fences (case-insensitive)", () => {
     const content = '```JSON\n{"items": [1, 2, 3]}\n```';
-    const result = parseJsonWithFenceStrip(content);
-    expect(result).toEqual({ items: [1, 2, 3] });
+    expect(parseModelJson(content)).toEqual({ items: [1, 2, 3] });
   });
 
   it("handles array responses wrapped in fences", () => {
     const content = '```json\n[{"id": 1}, {"id": 2}]\n```';
-    const result = parseJsonWithFenceStrip(content);
-    expect(result).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(parseModelJson(content)).toEqual([{ id: 1 }, { id: 2 }]);
   });
 
+  it("handles fences with no trailing newline", () => {
+    const content = '```json\n{"ok": true}```';
+    expect(parseModelJson(content)).toEqual({ ok: true });
+  });
+
+  it("handles leading/trailing whitespace around fences", () => {
+    const content = '\n```json\n{"isArticle": false, "authors": [], "publishedAt": null}\n```\n';
+    expect(parseModelJson(content)).toEqual({ isArticle: false, authors: [], publishedAt: null });
+  });
+
+  it("handles whitespace inside fences around JSON", () => {
+    const content = '```json\n\n  {"key": "value"}\n\n```';
+    expect(parseModelJson(content)).toEqual({ key: "value" });
+  });
+
+  it("handles \\r\\n line endings", () => {
+    const content = '```json\r\n{"key": "value"}\r\n```';
+    expect(parseModelJson(content)).toEqual({ key: "value" });
+  });
+
+  // --- Trailing comma repair ---
+  it("repairs trailing comma in object", () => {
+    expect(parseModelJson('{"a": 1, "b": 2,}')).toEqual({ a: 1, b: 2 });
+  });
+
+  it("repairs trailing comma in array", () => {
+    expect(parseModelJson('["url1", "url2", "url3",]')).toEqual(["url1", "url2", "url3"]);
+  });
+
+  it("repairs trailing comma with whitespace", () => {
+    const content = '[\n  "https://example.com/a",\n  "https://example.com/b",\n]';
+    expect(parseModelJson(content)).toEqual(["https://example.com/a", "https://example.com/b"]);
+  });
+
+  it("repairs trailing comma inside fenced JSON", () => {
+    const content = '```json\n{"items": [1, 2, 3,],}\n```';
+    expect(parseModelJson(content)).toEqual({ items: [1, 2, 3] });
+  });
+
+  it("repairs nested trailing commas", () => {
+    const content = '{"a": {"b": [1, 2,], "c": 3,},}';
+    expect(parseModelJson(content)).toEqual({ a: { b: [1, 2], c: 3 } });
+  });
+
+  // --- Error cases ---
   it("throws for truly unparsable content", () => {
-    expect(() => parseJsonWithFenceStrip("This is not JSON at all")).toThrow(
+    expect(() => parseModelJson("This is not JSON at all")).toThrow(
       "Model returned non-parsable JSON",
     );
   });
 
   it("throws for fenced non-JSON content", () => {
     const content = '```json\nnot actually json\n```';
-    expect(() => parseJsonWithFenceStrip(content)).toThrow(
+    expect(() => parseModelJson(content)).toThrow(
       "Model returned non-parsable JSON",
     );
   });
 
-  it("handles fences with no trailing newline", () => {
-    const content = '```json\n{"ok": true}```';
-    const result = parseJsonWithFenceStrip(content);
-    expect(result).toEqual({ ok: true });
-  });
-
-  it("handles leading/trailing whitespace around fences", () => {
-    const content = '\n```json\n{"isArticle": false, "authors": [], "publishedAt": null}\n```\n';
-    const result = parseJsonWithFenceStrip(content);
-    expect(result).toEqual({ isArticle: false, authors: [], publishedAt: null });
-  });
-
-  it("handles leading/trailing whitespace around plain JSON", () => {
-    const content = '  \n{"key": "value"}\n  ';
-    const result = parseJsonWithFenceStrip(content);
-    expect(result).toEqual({ key: "value" });
-  });
-
-  it("handles whitespace inside fences around JSON", () => {
-    const content = '```json\n\n  {"key": "value"}\n\n```';
-    const result = parseJsonWithFenceStrip(content);
-    expect(result).toEqual({ key: "value" });
-  });
-
-  it("handles \\r\\n line endings", () => {
-    const content = '```json\r\n{"key": "value"}\r\n```';
-    const result = parseJsonWithFenceStrip(content);
-    expect(result).toEqual({ key: "value" });
+  it("includes contentLen and preview in error", () => {
+    const content = "broken json content here";
+    expect(() => parseModelJson(content)).toThrow(/contentLen=\d+/);
+    expect(() => parseModelJson(content)).toThrow(/first500=/);
+    expect(() => parseModelJson(content)).toThrow(/last200=/);
   });
 });


### PR DESCRIPTION
## Summary
- Re-adds `parseModelJson` with progressive repair: direct parse → markdown fence strip → trailing comma removal
- The revert in #139 removed trailing-comma repair, causing `/complete` to 502 when models return JSON arrays with trailing commas (a common LLM quirk, seen in prod for brand field extraction / URL selection)
- Error messages now include `contentLen`, `first500`, and `last200` for better diagnostics

## Test plan
- [x] All 385 unit tests pass (including updated `json-markdown-strip.test.ts` with trailing comma cases)
- [x] Build succeeds
- [ ] Verify in prod that `/complete` with `responseFormat: "json"` no longer 502s on trailing-comma responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)