### PR TITLE
feat: add POST /internal/platform-complete endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,37 @@ Unlike POST /chat, this endpoint is **stateless** (no sessions), accepts an **in
 
 Error responses: 400 (validation), 401 (auth), 402 (insufficient credits), 502 (upstream failure).
 
+## Internal Platform Completion
+
+`POST /internal/platform-complete` — platform-level LLM completion for internal service-to-service calls.
+
+**Auth:** `X-API-Key` only — no `x-org-id`, `x-user-id`, or `x-run-id` headers required.
+
+```json
+{
+  "message": "Analyze this workflow definition and suggest field mappings.",
+  "systemPrompt": "You are a workflow analysis assistant.",
+  "provider": "anthropic",
+  "model": "sonnet",
+  "responseFormat": "json",
+  "temperature": 0.3
+}
+```
+
+Same fields as `POST /complete` except **no `imageUrl` or `imageContext`** support.
+
+**Key differences from `POST /complete`:**
+- **No billing** — platform-level calls are not charged to any org
+- **No run tracking** — no run is created in runs-service
+- **No campaign context** — no `x-campaign-id` enrichment
+- **Platform key resolution** — uses `GET /keys/platform/{provider}/decrypt` directly (no org-level key lookup)
+
+Use this endpoint when a service needs an LLM call during startup or for platform-level operations that don't belong to a specific org or user (e.g. workflow upgrades, schema analysis).
+
+Response format is identical to `POST /complete`.
+
+Error responses: 400 (validation), 401 (auth), 502 (upstream failure).
+
 ## Campaign Context Enrichment
 
 When the `x-campaign-id` header is present, both `/chat` and `/complete` automatically fetch the campaign's `featureInputs` from campaign-service and inject them into the system prompt. This ensures every LLM call is informed by the user's campaign-specific inputs (editorial angle, target geography, audience type, etc.).
@@ -476,7 +507,7 @@ Node 20 defaults `requestTimeout` to 300s (5 min), which would kill long-running
 
 ```
 src/
-  index.ts          # Express server, /chat, /complete, /config, /platform-config, /health, /openapi.json
+  index.ts          # Express server, /chat, /complete, /internal/platform-complete, /config, /platform-config, /health, /openapi.json
   types.ts          # SSE event TypeScript interfaces
   schemas.ts        # Zod schemas, OpenAPI registry, and request/response types
   middleware/

--- a/openapi.json
+++ b/openapi.json
@@ -601,6 +601,65 @@
           "model"
         ]
       },
+      "InternalPlatformCompleteRequest": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The prompt to send to the LLM",
+            "example": "Analyze this workflow definition and suggest field mappings."
+          },
+          "systemPrompt": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Inline system prompt",
+            "example": "You are a workflow analysis assistant."
+          },
+          "responseFormat": {
+            "type": "string",
+            "enum": [
+              "json"
+            ],
+            "description": "Set to \"json\" to instruct the model to return valid JSON."
+          },
+          "temperature": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 2,
+            "description": "Sampling temperature (0–2). Lower = more deterministic.",
+            "example": 0.3
+          },
+          "provider": {
+            "type": "string",
+            "enum": [
+              "anthropic",
+              "google"
+            ],
+            "description": "LLM provider to use.",
+            "example": "anthropic"
+          },
+          "model": {
+            "type": "string",
+            "enum": [
+              "haiku",
+              "sonnet",
+              "opus",
+              "flash-lite",
+              "flash",
+              "pro"
+            ],
+            "description": "Model alias (version-free).",
+            "example": "sonnet"
+          }
+        },
+        "required": [
+          "message",
+          "systemPrompt",
+          "provider",
+          "model"
+        ]
+      },
       "ChatRequest": {
         "type": "object",
         "properties": {
@@ -1042,6 +1101,78 @@
           },
           "502": {
             "description": "Upstream service unavailable (key-service, billing-service, runs-service, or LLM provider)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/internal/platform-complete": {
+      "post": {
+        "tags": [
+          "Internal"
+        ],
+        "summary": "Platform-level LLM completion (no billing, no run tracking)",
+        "description": "Internal endpoint for platform-level LLM calls that do not belong to a specific org or user.\n\n**Auth:** Requires only `x-api-key` (no `x-org-id`, `x-user-id`, or `x-run-id`).\n\n**Key resolution:** Uses the platform key directly via `GET /keys/platform/{provider}/decrypt` — no org-level key lookup.\n\n**No billing, no run tracking.** This endpoint is for internal service-to-service calls (e.g. workflow upgrades at startup) where there is no org to bill and no user-initiated run to track.\n\nDoes not support `imageUrl` or `imageContext` — use `POST /complete` for vision tasks.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Service-to-service API key"
+            },
+            "required": true,
+            "description": "Service-to-service API key",
+            "name": "x-api-key",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InternalPlatformCompleteRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "LLM completion result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompleteResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid request fields",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid x-api-key header",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream service unavailable (key-service or LLM provider)",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,15 +36,16 @@ import { extractBrandFields, extractBrandText } from "./lib/brand-client.js";
 import { formatToolError } from "./lib/tool-errors.js";
 import {
   resolveKey,
+  resolvePlatformKey,
   type ResolvedKey,
   listOrgKeys,
   getKeySource,
   listKeySources,
   checkProviderRequirements,
 } from "./lib/key-client.js";
-import { authorizeCredits } from "./lib/billing-client.js";
+import { authorizeCredits, BillingError } from "./lib/billing-client.js";
 import { getCampaignFeatureInputs } from "./lib/campaign-client.js";
-import { ChatRequestSchema, CompleteRequestSchema, AppConfigRequestSchema, PlatformConfigRequestSchema } from "./schemas.js";
+import { ChatRequestSchema, CompleteRequestSchema, InternalPlatformCompleteRequestSchema, AppConfigRequestSchema, PlatformConfigRequestSchema } from "./schemas.js";
 import { requireAuth, requireInternalAuth, type AuthLocals } from "./middleware/auth.js";
 import type { ButtonRecord, ToolCallRecord } from "./db/schema.js";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
@@ -299,6 +300,11 @@ app.post("/complete", requireAuth, async (req, res) => {
       }
     } catch (billingErr) {
       console.error(`[complete] billing authorization failed for org="${orgId}":`, billingErr);
+      if (billingErr instanceof BillingError && billingErr.isClientError) {
+        return res.status(billingErr.statusCode).json({
+          error: `Billing authorization rejected: ${billingErr.upstreamBody}`,
+        });
+      }
       return res.status(502).json({
         error: "Billing service unavailable. Please try again.",
       });
@@ -412,6 +418,83 @@ app.post("/complete", requireAuth, async (req, res) => {
         addRunCosts(runId, costItems, runIdentity, trackingHeaders),
       ]).catch(() => {});
     }
+  }
+});
+
+// --- Internal Platform Complete (no billing, no run tracking) ---
+
+app.post("/internal/platform-complete", requireInternalAuth, async (req, res) => {
+  const parsed = InternalPlatformCompleteRequestSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res
+      .status(400)
+      .json({ error: "Invalid request", details: parsed.error.flatten() });
+  }
+
+  const { message, systemPrompt, responseFormat, temperature, provider: requestedProvider, model: requestedModel } = parsed.data;
+
+  const resolved = resolveModel(requestedProvider as Provider, requestedModel as ModelAlias);
+  const effectiveModel = resolved.apiModelId;
+  const isGemini = resolved.provider === "google";
+  const provider = resolved.provider;
+
+  let apiKey: string;
+  try {
+    const platformKey = await resolvePlatformKey(provider, {
+      method: "POST",
+      path: "/internal/platform-complete",
+    });
+    apiKey = platformKey.key;
+  } catch (err) {
+    console.error(`[internal/platform-complete] Failed to resolve platform ${provider} key:`, err);
+    return res.status(502).json({
+      error: `Failed to resolve platform ${provider} API key.`,
+    });
+  }
+
+  try {
+    let effectiveSystemPrompt = systemPrompt;
+    if (responseFormat === "json") {
+      effectiveSystemPrompt += `\n\nIMPORTANT: You MUST respond with valid JSON only. No markdown, no code fences, no extra text — just a single JSON object or array.`;
+    }
+
+    let result: { content: string; tokensInput: number; tokensOutput: number; model: string };
+
+    if (isGemini) {
+      result = await completeWithGemini({
+        apiKey,
+        model: effectiveModel,
+        message,
+        systemPrompt: effectiveSystemPrompt,
+        responseFormat,
+        temperature,
+      });
+    } else {
+      const claude = createAnthropicClient({ apiKey, systemPrompt: effectiveSystemPrompt });
+      result = await claude.complete(message, {
+        responseFormat,
+        temperature,
+        model: effectiveModel,
+      });
+    }
+
+    const response: Record<string, unknown> = {
+      content: result.content,
+      tokensInput: result.tokensInput,
+      tokensOutput: result.tokensOutput,
+      model: result.model,
+    };
+
+    if (responseFormat === "json") {
+      response.json = parseModelJson(result.content);
+    }
+
+    res.json(response);
+  } catch (err) {
+    console.error(`[internal/platform-complete] LLM call failed:`, err);
+    res.status(502).json({
+      error: "LLM call failed. Please try again.",
+    });
   }
 });
 

--- a/src/lib/billing-client.ts
+++ b/src/lib/billing-client.ts
@@ -2,6 +2,22 @@ const BILLING_SERVICE_URL =
   process.env.BILLING_SERVICE_URL || "https://billing.mcpfactory.org";
 const BILLING_SERVICE_API_KEY = process.env.BILLING_SERVICE_API_KEY;
 
+export class BillingError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
+    public readonly upstreamBody: string,
+  ) {
+    super(message);
+    this.name = "BillingError";
+  }
+
+  /** True when billing-service explicitly rejected the request (4xx) */
+  get isClientError(): boolean {
+    return this.statusCode >= 400 && this.statusCode < 500;
+  }
+}
+
 export interface CreditItem {
   costName: string;
   quantity: number;
@@ -60,8 +76,10 @@ export async function authorizeCredits(
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
-    throw new Error(
+    throw new BillingError(
       `[billing-client] POST /v1/credits/authorize returned ${res.status}: ${text}`,
+      res.status,
+      text,
     );
   }
 

--- a/src/lib/key-client.ts
+++ b/src/lib/key-client.ts
@@ -80,6 +80,47 @@ export async function resolveKey(
 }
 
 // ---------------------------------------------------------------------------
+// resolvePlatformKey — direct platform-key lookup (no org/user context needed)
+// ---------------------------------------------------------------------------
+
+export interface PlatformResolvedKey {
+  provider: string;
+  key: string;
+}
+
+export async function resolvePlatformKey(
+  provider: string,
+  caller: CallerInfo,
+): Promise<PlatformResolvedKey> {
+  if (!KEY_SERVICE_API_KEY) {
+    throw new Error(
+      "[key-client] KEY_SERVICE_API_KEY is required to resolve keys",
+    );
+  }
+
+  const url = `${KEY_SERVICE_URL}/keys/platform/${encodeURIComponent(provider)}/decrypt`;
+
+  const res = await fetch(url, {
+    method: "GET",
+    headers: {
+      "x-api-key": KEY_SERVICE_API_KEY,
+      "X-Caller-Service": CALLER_SERVICE,
+      "X-Caller-Method": caller.method,
+      "X-Caller-Path": caller.path,
+    },
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `[key-client] GET /keys/platform/${provider}/decrypt returned ${res.status}: ${text}`,
+    );
+  }
+
+  return (await res.json()) as PlatformResolvedKey;
+}
+
+// ---------------------------------------------------------------------------
 // Read-only key tools (exposed to LLM) — routed via api-service
 // ---------------------------------------------------------------------------
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -466,6 +466,86 @@ All Google models require a Google API key configured in key-service (provider: 
   },
 });
 
+// --- Internal Platform Complete ---
+
+export const InternalPlatformCompleteRequestSchema = z
+  .object({
+    message: z.string().min(1, "message is required").openapi({
+      description: "The prompt to send to the LLM",
+      example: "Analyze this workflow definition and suggest field mappings.",
+    }),
+    systemPrompt: z.string().min(1).openapi({
+      description: "Inline system prompt",
+      example: "You are a workflow analysis assistant.",
+    }),
+    responseFormat: z.literal("json").optional().openapi({
+      description: 'Set to "json" to instruct the model to return valid JSON.',
+    }),
+    temperature: z.number().min(0).max(2).optional().openapi({
+      description: "Sampling temperature (0–2). Lower = more deterministic.",
+      example: 0.3,
+    }),
+    provider: z.enum(["anthropic", "google"]).openapi({
+      description: "LLM provider to use.",
+      example: "anthropic",
+    }),
+    model: z.enum(["haiku", "sonnet", "opus", "flash-lite", "flash", "pro"]).openapi({
+      description: "Model alias (version-free).",
+      example: "sonnet",
+    }),
+  })
+  .openapi("InternalPlatformCompleteRequest");
+
+export type InternalPlatformCompleteRequest = z.infer<typeof InternalPlatformCompleteRequestSchema>;
+
+registry.registerPath({
+  method: "post",
+  path: "/internal/platform-complete",
+  tags: ["Internal"],
+  summary: "Platform-level LLM completion (no billing, no run tracking)",
+  description: `Internal endpoint for platform-level LLM calls that do not belong to a specific org or user.
+
+**Auth:** Requires only \`x-api-key\` (no \`x-org-id\`, \`x-user-id\`, or \`x-run-id\`).
+
+**Key resolution:** Uses the platform key directly via \`GET /keys/platform/{provider}/decrypt\` — no org-level key lookup.
+
+**No billing, no run tracking.** This endpoint is for internal service-to-service calls (e.g. workflow upgrades at startup) where there is no org to bill and no user-initiated run to track.
+
+Does not support \`imageUrl\` or \`imageContext\` — use \`POST /complete\` for vision tasks.`,
+  request: {
+    headers: z.object({
+      "x-api-key": z.string().openapi({
+        description: "Service-to-service API key",
+      }),
+    }),
+    body: {
+      content: { "application/json": { schema: InternalPlatformCompleteRequestSchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "LLM completion result",
+      content: {
+        "application/json": { schema: CompleteResponseSchema },
+      },
+    },
+    400: {
+      description: "Missing or invalid request fields",
+      content: {
+        "application/json": { schema: ValidationErrorResponseSchema },
+      },
+    },
+    401: {
+      description: "Missing or invalid x-api-key header",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    502: {
+      description: "Upstream service unavailable (key-service or LLM provider)",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
 // --- Chat ---
 
 export const ChatRequestSchema = z

--- a/tests/unit/billing-client.test.ts
+++ b/tests/unit/billing-client.test.ts
@@ -110,23 +110,53 @@ describe("authorizeCredits", () => {
     expect(headers["x-workflow-slug"]).toBe("wf-3");
   });
 
-  it("throws on HTTP error from billing-service", async () => {
+  it("throws BillingError with statusCode on HTTP error from billing-service", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: false,
       status: 500,
       text: () => Promise.resolve("Internal Server Error"),
     });
 
-    const { authorizeCredits } = await loadModule();
-    await expect(
-      authorizeCredits({
+    const { authorizeCredits, BillingError } = await loadModule();
+    try {
+      await authorizeCredits({
         items: [{ costName: "claude-sonnet-4-6-tokens-input", quantity: 500 }],
         description: "chat — claude-sonnet-4-6",
         orgId: "org-123",
         userId: "user-456",
         runId: "run-789",
-      }),
-    ).rejects.toThrow(/returned 500/);
+      });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(BillingError);
+      expect((err as InstanceType<typeof BillingError>).statusCode).toBe(500);
+      expect((err as InstanceType<typeof BillingError>).isClientError).toBe(false);
+    }
+  });
+
+  it("throws BillingError with isClientError=true on 400 from billing-service", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: () => Promise.resolve('{"error":"x-org-id must be a valid UUID"}'),
+    });
+
+    const { authorizeCredits, BillingError } = await loadModule();
+    try {
+      await authorizeCredits({
+        items: [{ costName: "claude-sonnet-4-6-tokens-input", quantity: 500 }],
+        description: "chat — claude-sonnet-4-6",
+        orgId: "platform",
+        userId: "user-456",
+        runId: "run-789",
+      });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(BillingError);
+      expect((err as InstanceType<typeof BillingError>).statusCode).toBe(400);
+      expect((err as InstanceType<typeof BillingError>).isClientError).toBe(true);
+      expect((err as InstanceType<typeof BillingError>).upstreamBody).toContain("x-org-id must be a valid UUID");
+    }
   });
 
   it("throws on network error", async () => {

--- a/tests/unit/internal-platform-complete.test.ts
+++ b/tests/unit/internal-platform-complete.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { InternalPlatformCompleteRequestSchema } from "../../src/schemas.js";
+
+describe("InternalPlatformCompleteRequestSchema", () => {
+  it("accepts valid request with provider and model", () => {
+    const result = InternalPlatformCompleteRequestSchema.safeParse({
+      message: "Analyze this workflow definition",
+      systemPrompt: "You are a workflow analysis assistant.",
+      provider: "anthropic",
+      model: "sonnet",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts optional responseFormat and temperature", () => {
+    const result = InternalPlatformCompleteRequestSchema.safeParse({
+      message: "Analyze this",
+      systemPrompt: "You are helpful.",
+      provider: "google",
+      model: "flash",
+      responseFormat: "json",
+      temperature: 0.5,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.responseFormat).toBe("json");
+      expect(result.data.temperature).toBe(0.5);
+    }
+  });
+
+  it("rejects missing message", () => {
+    const result = InternalPlatformCompleteRequestSchema.safeParse({
+      systemPrompt: "You are helpful.",
+      provider: "anthropic",
+      model: "sonnet",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty message", () => {
+    const result = InternalPlatformCompleteRequestSchema.safeParse({
+      message: "",
+      systemPrompt: "You are helpful.",
+      provider: "anthropic",
+      model: "sonnet",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing systemPrompt", () => {
+    const result = InternalPlatformCompleteRequestSchema.safeParse({
+      message: "Hello",
+      provider: "anthropic",
+      model: "sonnet",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing provider", () => {
+    const result = InternalPlatformCompleteRequestSchema.safeParse({
+      message: "Hello",
+      systemPrompt: "You are helpful.",
+      model: "sonnet",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing model", () => {
+    const result = InternalPlatformCompleteRequestSchema.safeParse({
+      message: "Hello",
+      systemPrompt: "You are helpful.",
+      provider: "anthropic",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid provider", () => {
+    const result = InternalPlatformCompleteRequestSchema.safeParse({
+      message: "Hello",
+      systemPrompt: "You are helpful.",
+      provider: "openai",
+      model: "sonnet",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid model", () => {
+    const result = InternalPlatformCompleteRequestSchema.safeParse({
+      message: "Hello",
+      systemPrompt: "You are helpful.",
+      provider: "anthropic",
+      model: "gpt-4",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("does NOT accept imageUrl (not supported on internal endpoint)", () => {
+    const result = InternalPlatformCompleteRequestSchema.safeParse({
+      message: "Hello",
+      systemPrompt: "You are helpful.",
+      provider: "anthropic",
+      model: "sonnet",
+      imageUrl: "https://example.com/image.png",
+    });
+    // imageUrl should be stripped (not in schema) — parse still succeeds but field is absent
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect((result.data as Record<string, unknown>).imageUrl).toBeUndefined();
+    }
+  });
+});

--- a/tests/unit/key-client.test.ts
+++ b/tests/unit/key-client.test.ts
@@ -212,6 +212,84 @@ describe("resolveKey", () => {
 });
 
 // ---------------------------------------------------------------------------
+// resolvePlatformKey — direct platform-key lookup
+// ---------------------------------------------------------------------------
+
+describe("resolvePlatformKey", () => {
+  it("sends GET to /keys/platform/{provider}/decrypt with caller headers only", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({ provider: "anthropic", key: "platform-key-123" }),
+    });
+
+    const { resolvePlatformKey } = await loadModule();
+    const result = await resolvePlatformKey("anthropic", {
+      method: "POST",
+      path: "/internal/platform-complete",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://key.test.local/keys/platform/anthropic/decrypt",
+      expect.objectContaining({
+        method: "GET",
+        headers: {
+          "x-api-key": "test-key-svc-key",
+          "X-Caller-Service": "chat",
+          "X-Caller-Method": "POST",
+          "X-Caller-Path": "/internal/platform-complete",
+        },
+      }),
+    );
+    expect(result).toEqual({ provider: "anthropic", key: "platform-key-123" });
+  });
+
+  it("does NOT send x-org-id, x-user-id, or x-run-id headers", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({ provider: "google", key: "google-platform-key" }),
+    });
+
+    const { resolvePlatformKey } = await loadModule();
+    await resolvePlatformKey("google", {
+      method: "POST",
+      path: "/internal/platform-complete",
+    });
+
+    const callArgs = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const headers = callArgs[1].headers;
+    expect(headers).not.toHaveProperty("x-org-id");
+    expect(headers).not.toHaveProperty("x-user-id");
+    expect(headers).not.toHaveProperty("x-run-id");
+  });
+
+  it("throws on HTTP error", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve("Platform key not found"),
+    });
+
+    const { resolvePlatformKey } = await loadModule();
+    await expect(
+      resolvePlatformKey("anthropic", { method: "POST", path: "/internal/platform-complete" }),
+    ).rejects.toThrow(/returned 404/);
+  });
+
+  it("throws when KEY_SERVICE_API_KEY is not set", async () => {
+    delete process.env.KEY_SERVICE_API_KEY;
+
+    const { resolvePlatformKey } = await loadModule();
+    await expect(
+      resolvePlatformKey("anthropic", { method: "POST", path: "/internal/platform-complete" }),
+    ).rejects.toThrow(/KEY_SERVICE_API_KEY is required/);
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Read-only key tools — now routed via api-service
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **New endpoint `POST /internal/platform-complete`** — platform-level LLM completion for internal service-to-service calls (e.g. workflow-service startup upgrades). Uses `requireInternalAuth` (x-api-key only), no billing, no run tracking, no campaign context enrichment.
- **Root cause:** workflow-service was calling `POST /complete` with `x-org-id: "platform"` (not a UUID), causing billing-service to reject with 400. Chat-service masked this as 502 "Billing service unavailable", making it look like billing was down.
- **Better error surfacing:** billing 4xx errors now propagate as their actual status code instead of being masked as 502.
- **New `resolvePlatformKey()`** in key-client — calls `GET /keys/platform/{provider}/decrypt` directly without org/user context.

## Test plan

- [x] `InternalPlatformCompleteRequestSchema` validation tests (10 tests)
- [x] `resolvePlatformKey` unit tests (4 tests) — correct headers, no org/user leakage, error handling
- [x] `BillingError` typed error tests (2 tests) — statusCode, isClientError for 400 vs 500
- [x] All 400 existing tests still pass (35 files, 400 tests)
- [ ] Verify workflow-service can switch to `/internal/platform-complete` for startup upgrades

🤖 Generated with [Claude Code](https://claude.com/claude-code)