### PR TITLE
fix: clear Gemini timeout error messages

### DIFF
--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -49,9 +49,20 @@ interface GeminiCompleteResult {
  * Fetch an image from a URL and return base64-encoded data + MIME type.
  */
 async function fetchImageAsBase64(url: string): Promise<{ data: string; mimeType: string }> {
-  const res = await fetch(url);
+  const IMAGE_FETCH_TIMEOUT_MS = 30_000;
+  let res: Response;
+  try {
+    res = await fetch(url, { signal: AbortSignal.timeout(IMAGE_FETCH_TIMEOUT_MS) });
+  } catch (err: unknown) {
+    if (err instanceof DOMException && err.name === "TimeoutError") {
+      throw new Error(
+        `[chat-service] Image fetch timed out after ${IMAGE_FETCH_TIMEOUT_MS / 1000}s | url=${url}`,
+      );
+    }
+    throw err;
+  }
   if (!res.ok) {
-    throw new Error(`[gemini] Failed to fetch image from ${url}: ${res.status} ${res.statusText}`);
+    throw new Error(`[chat-service] Failed to fetch image from ${url}: ${res.status} ${res.statusText}`);
   }
   const contentType = res.headers.get("content-type") ?? "image/jpeg";
   const buffer = await res.arrayBuffer();
@@ -108,11 +119,23 @@ export async function completeWithGemini(options: GeminiCompleteOptions): Promis
 
   const url = `${GEMINI_API_BASE}/models/${encodeURIComponent(model)}:generateContent?key=${encodeURIComponent(apiKey)}`;
 
-  const res = await fetch(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
+  const GEMINI_TIMEOUT_MS = 120_000;
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(GEMINI_TIMEOUT_MS),
+    });
+  } catch (err: unknown) {
+    if (err instanceof DOMException && err.name === "TimeoutError") {
+      throw new Error(
+        `[chat-service] Gemini API timed out after ${GEMINI_TIMEOUT_MS / 1000}s | model=${model}`,
+      );
+    }
+    throw err;
+  }
 
   if (!res.ok) {
     const errorText = await res.text().catch(() => "unknown error");

--- a/tests/unit/gemini.test.ts
+++ b/tests/unit/gemini.test.ts
@@ -114,4 +114,35 @@ describe("completeWithGemini", () => {
     const requestBody = JSON.parse(fetchSpy.mock.calls[0][1].body);
     expect(requestBody.generationConfig.thinkingConfig).toBeUndefined();
   });
+
+  it("throws a clear timeout error when Gemini API times out", async () => {
+    const timeoutError = new DOMException("The operation was aborted due to timeout", "TimeoutError");
+    fetchSpy.mockRejectedValueOnce(timeoutError);
+
+    await expect(completeWithGemini(baseOptions)).rejects.toThrow(
+      /Gemini API timed out after 120s/,
+    );
+  });
+
+  it("passes AbortSignal.timeout to the Gemini fetch call", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        candidates: [{ content: { parts: [{ text: "{}" }] }, finishReason: "STOP" }],
+        usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5 },
+      }),
+    });
+
+    await completeWithGemini(baseOptions);
+
+    const fetchOptions = fetchSpy.mock.calls[0][1];
+    expect(fetchOptions.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("re-throws non-timeout fetch errors as-is", async () => {
+    const networkError = new TypeError("fetch failed");
+    fetchSpy.mockRejectedValueOnce(networkError);
+
+    await expect(completeWithGemini(baseOptions)).rejects.toThrow("fetch failed");
+  });
 });


### PR DESCRIPTION
## Summary
- Adds explicit 120s timeout to Gemini API fetch calls via `AbortSignal.timeout`
- Adds 30s timeout to image fetch calls
- Replaces cryptic `HeadersTimeoutError` with clear `[chat-service] Gemini API timed out after 120s` log messages
- Regression tests for timeout, signal passing, and non-timeout error re-throw

## Test plan
- [x] Unit tests pass (403/403)
- [x] Build passes
- [ ] Verify in prod logs: next Gemini timeout should show `[chat-service] Gemini API timed out after 120s` instead of `HeadersTimeoutError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)