### PR TITLE
fix: model-specific LLM timeouts (Pro 15m, Flash/Sonnet 10m, Lite/Haiku 5m)

### DIFF
--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -5,6 +5,14 @@ export const MODEL = "claude-sonnet-4-6";
 export const COST_PREFIX = "anthropic-sonnet-4.6";
 const MAX_TOKENS = 64_000;
 
+/** Model-specific API timeouts in milliseconds. */
+const ANTHROPIC_TIMEOUT_MS: Record<string, number> = {
+  "claude-opus-4-6": 15 * 60_000,    // 15 min — Opus
+  "claude-sonnet-4-6": 10 * 60_000,  // 10 min — Sonnet
+  "claude-haiku-4-5": 5 * 60_000,    //  5 min — Haiku
+};
+const DEFAULT_ANTHROPIC_TIMEOUT_MS = 10 * 60_000; // 10 min fallback
+
 // ---------------------------------------------------------------------------
 // Provider + model alias → versioned API model ID + cost prefix
 // Callers specify version-free aliases (e.g. "sonnet"); the service resolves
@@ -1100,7 +1108,8 @@ export function createAnthropicClient({ apiKey, systemPrompt }: AnthropicOptions
           : {}),
       };
 
-      const response = await client.messages.create(params);
+      const timeoutMs = ANTHROPIC_TIMEOUT_MS[effectiveModel] ?? DEFAULT_ANTHROPIC_TIMEOUT_MS;
+      const response = await client.messages.create(params, { timeout: timeoutMs });
 
       if (response.stop_reason === "max_tokens") {
         console.warn(

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -11,6 +11,14 @@ export const GEMINI_MODELS: Record<string, string> = {
   "gemini-3.1-pro-preview": "google-pro-3.1",
 };
 
+/** Model-specific API timeouts in milliseconds. */
+const GEMINI_TIMEOUT_MS: Record<string, number> = {
+  "gemini-3.1-pro-preview": 15 * 60_000,       // 15 min — Pro
+  "gemini-3-flash-preview": 10 * 60_000,        // 10 min — Flash
+  "gemini-3.1-flash-lite-preview": 5 * 60_000,  //  5 min — Flash Lite
+};
+const DEFAULT_GEMINI_TIMEOUT_MS = 10 * 60_000;  // 10 min fallback
+
 /** Check if a model ID is a Gemini model. */
 export function isGeminiModel(model: string): boolean {
   return model in GEMINI_MODELS;
@@ -119,19 +127,19 @@ export async function completeWithGemini(options: GeminiCompleteOptions): Promis
 
   const url = `${GEMINI_API_BASE}/models/${encodeURIComponent(model)}:generateContent?key=${encodeURIComponent(apiKey)}`;
 
-  const GEMINI_TIMEOUT_MS = 120_000;
+  const timeoutMs = GEMINI_TIMEOUT_MS[model] ?? DEFAULT_GEMINI_TIMEOUT_MS;
   let res: Response;
   try {
     res = await fetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(GEMINI_TIMEOUT_MS),
+      signal: AbortSignal.timeout(timeoutMs),
     });
   } catch (err: unknown) {
     if (err instanceof DOMException && err.name === "TimeoutError") {
       throw new Error(
-        `[chat-service] Gemini API timed out after ${GEMINI_TIMEOUT_MS / 1000}s | model=${model}`,
+        `[chat-service] Gemini API timed out after ${timeoutMs / 1000}s | model=${model}`,
       );
     }
     throw err;

--- a/tests/unit/anthropic-timeout.test.ts
+++ b/tests/unit/anthropic-timeout.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Tests that createAnthropicClient().complete() passes model-specific
+ * timeout values to the Anthropic SDK request options.
+ */
+
+let capturedRequestOptions: Record<string, unknown> | undefined;
+
+vi.mock("@anthropic-ai/sdk", () => {
+  return {
+    default: class MockAnthropic {
+      messages = {
+        create: async (_params: Record<string, unknown>, options?: Record<string, unknown>) => {
+          capturedRequestOptions = options;
+          return {
+            content: [{ type: "text", text: "ok" }],
+            usage: { input_tokens: 10, output_tokens: 5 },
+            stop_reason: "end_turn",
+          };
+        },
+        stream: () => {
+          throw new Error("stream not implemented in mock");
+        },
+      };
+    },
+  };
+});
+
+const { createAnthropicClient } = await import("../../src/lib/anthropic.js");
+
+describe("anthropic complete() model-specific timeouts", () => {
+  beforeEach(() => {
+    capturedRequestOptions = undefined;
+  });
+
+  it("uses 15 min timeout for opus", async () => {
+    const claude = createAnthropicClient({ apiKey: "test-key", systemPrompt: "test" });
+    await claude.complete("Hello", { model: "claude-opus-4-6" });
+
+    expect(capturedRequestOptions).toBeDefined();
+    expect(capturedRequestOptions!.timeout).toBe(15 * 60_000);
+  });
+
+  it("uses 10 min timeout for sonnet (default model)", async () => {
+    const claude = createAnthropicClient({ apiKey: "test-key", systemPrompt: "test" });
+    await claude.complete("Hello");
+
+    expect(capturedRequestOptions).toBeDefined();
+    expect(capturedRequestOptions!.timeout).toBe(10 * 60_000);
+  });
+
+  it("uses 5 min timeout for haiku", async () => {
+    const claude = createAnthropicClient({ apiKey: "test-key", systemPrompt: "test" });
+    await claude.complete("Hello", { model: "claude-haiku-4-5" });
+
+    expect(capturedRequestOptions).toBeDefined();
+    expect(capturedRequestOptions!.timeout).toBe(5 * 60_000);
+  });
+
+  it("falls back to 10 min for unknown models", async () => {
+    const claude = createAnthropicClient({ apiKey: "test-key", systemPrompt: "test" });
+    await claude.complete("Hello", { model: "claude-unknown-99" });
+
+    expect(capturedRequestOptions).toBeDefined();
+    expect(capturedRequestOptions!.timeout).toBe(10 * 60_000);
+  });
+});

--- a/tests/unit/gemini.test.ts
+++ b/tests/unit/gemini.test.ts
@@ -115,13 +115,31 @@ describe("completeWithGemini", () => {
     expect(requestBody.generationConfig.thinkingConfig).toBeUndefined();
   });
 
-  it("throws a clear timeout error when Gemini API times out", async () => {
+  it("throws a clear timeout error with model-specific duration (flash = 600s)", async () => {
     const timeoutError = new DOMException("The operation was aborted due to timeout", "TimeoutError");
     fetchSpy.mockRejectedValueOnce(timeoutError);
 
     await expect(completeWithGemini(baseOptions)).rejects.toThrow(
-      /Gemini API timed out after 120s/,
+      /Gemini API timed out after 600s/,
     );
+  });
+
+  it("uses 900s timeout for pro model", async () => {
+    const timeoutError = new DOMException("The operation was aborted due to timeout", "TimeoutError");
+    fetchSpy.mockRejectedValueOnce(timeoutError);
+
+    await expect(
+      completeWithGemini({ ...baseOptions, model: "gemini-3.1-pro-preview" }),
+    ).rejects.toThrow(/Gemini API timed out after 900s/);
+  });
+
+  it("uses 300s timeout for flash-lite model", async () => {
+    const timeoutError = new DOMException("The operation was aborted due to timeout", "TimeoutError");
+    fetchSpy.mockRejectedValueOnce(timeoutError);
+
+    await expect(
+      completeWithGemini({ ...baseOptions, model: "gemini-3.1-flash-lite-preview" }),
+    ).rejects.toThrow(/Gemini API timed out after 300s/);
   });
 
   it("passes AbortSignal.timeout to the Gemini fetch call", async () => {


### PR DESCRIPTION
## Summary
- Replace hardcoded 120s Gemini timeout with model-specific values: Pro 15min, Flash 10min, Flash Lite 5min
- Add model-specific timeouts to Anthropic `complete()`: Opus 15min, Sonnet 10min, Haiku 5min
- Fixes `gemini-3.1-pro-preview` timing out on complex workflow calls

## Test plan
- [x] Updated existing Gemini timeout test to expect 600s (flash) instead of 120s
- [x] Added tests for Pro (900s) and Flash Lite (300s) Gemini timeouts
- [x] Added `anthropic-timeout.test.ts` covering Opus, Sonnet, Haiku, and unknown model fallback
- [x] All 409 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)