### PR TITLE
feat: Gemini retry + fallback to 2.5 stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ src/
     schema.ts       # sessions + messages + app_configs + platform_configs table definitions
   lib/
     anthropic.ts       # Claude AI client (Sonnet 4.6), streaming + non-streaming, tool calling, adaptive thinking, context management (compaction), built-in tool declarations
-    gemini.ts          # Gemini REST API client (Flash 2.0) for vision tasks — lightweight, no SDK dependency
+    gemini.ts          # Gemini REST API client — retry with exponential backoff (3 retries) + fallback to stable 2.5 models on failure
     merge-messages.ts  # Ensures alternating user/assistant roles by merging orphaned consecutive same-role messages
     billing-client.ts  # Billing-service client for credit authorization before platform-key operations
     key-client.ts      # Key-service client: resolveKey (decrypt), listOrgKeys, getKeySource, listKeySources, checkProviderRequirements

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -73,6 +73,8 @@ export const SUPPORTED_MODELS: Record<string, string> = {
   "gemini-3.1-flash-lite-preview": "google-flash-lite-3.1",
   "gemini-3-flash-preview": "google-flash-3",
   "gemini-3.1-pro-preview": "google-pro-3.1",
+  "gemini-2.5-pro": "google-pro-2.5",
+  "gemini-2.5-flash": "google-flash-2.5",
 };
 
 /** Resolve the cost prefix for a given model ID (falls back to default). */

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -9,6 +9,8 @@ export const GEMINI_MODELS: Record<string, string> = {
   "gemini-3.1-flash-lite-preview": "google-flash-lite-3.1",
   "gemini-3-flash-preview": "google-flash-3",
   "gemini-3.1-pro-preview": "google-pro-3.1",
+  "gemini-2.5-pro": "google-pro-2.5",
+  "gemini-2.5-flash": "google-flash-2.5",
 };
 
 /** Model-specific API timeouts in milliseconds. */
@@ -16,8 +18,29 @@ const GEMINI_TIMEOUT_MS: Record<string, number> = {
   "gemini-3.1-pro-preview": 15 * 60_000,       // 15 min — Pro
   "gemini-3-flash-preview": 10 * 60_000,        // 10 min — Flash
   "gemini-3.1-flash-lite-preview": 5 * 60_000,  //  5 min — Flash Lite
+  "gemini-2.5-pro": 15 * 60_000,                // 15 min — 2.5 Pro
+  "gemini-2.5-flash": 10 * 60_000,              // 10 min — 2.5 Flash
 };
 const DEFAULT_GEMINI_TIMEOUT_MS = 10 * 60_000;  // 10 min fallback
+
+/** Fallback from preview 3.x models to stable 2.5 models. */
+const GEMINI_FALLBACK_MODEL: Record<string, string> = {
+  "gemini-3.1-pro-preview": "gemini-2.5-pro",
+  "gemini-3-flash-preview": "gemini-2.5-flash",
+  "gemini-3.1-flash-lite-preview": "gemini-2.5-flash",
+};
+
+/** HTTP status codes that warrant a retry. */
+const RETRYABLE_STATUS_CODES = new Set([429, 500, 503, 504]);
+
+/** Max retries before falling back to the stable model. */
+const MAX_RETRIES = 3;
+
+/** Base delay for exponential backoff in ms. */
+const RETRY_BASE_DELAY_MS = 1_000;
+
+/** Max delay cap for exponential backoff in ms. */
+const RETRY_MAX_DELAY_MS = 30_000;
 
 /** Check if a model ID is a Gemini model. */
 export function isGeminiModel(model: string): boolean {
@@ -78,9 +101,115 @@ async function fetchImageAsBase64(url: string): Promise<{ data: string; mimeType
   return { data, mimeType: contentType.split(";")[0].trim() };
 }
 
+/** Error thrown when the Gemini API returns a retryable HTTP status. */
+class GeminiRetryableError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "GeminiRetryableError";
+  }
+}
+
+/**
+ * Single attempt to call the Gemini API. Throws GeminiRetryableError for
+ * retryable status codes so the caller can decide whether to retry.
+ */
+async function callGeminiOnce(
+  model: string,
+  apiKey: string,
+  body: Record<string, unknown>,
+  responseFormat: string | undefined,
+): Promise<GeminiCompleteResult> {
+  const url = `${GEMINI_API_BASE}/models/${encodeURIComponent(model)}:generateContent?key=${encodeURIComponent(apiKey)}`;
+  const timeoutMs = GEMINI_TIMEOUT_MS[model] ?? DEFAULT_GEMINI_TIMEOUT_MS;
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (err: unknown) {
+    if (err instanceof DOMException && err.name === "TimeoutError") {
+      throw new GeminiRetryableError(
+        504,
+        `[chat-service] Gemini API timed out after ${timeoutMs / 1000}s | model=${model}`,
+      );
+    }
+    throw err;
+  }
+
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => "unknown error");
+    if (RETRYABLE_STATUS_CODES.has(res.status)) {
+      throw new GeminiRetryableError(res.status, `[gemini] API error ${res.status}: ${errorText}`);
+    }
+    throw new Error(`[gemini] API error ${res.status}: ${errorText}`);
+  }
+
+  const data = (await res.json()) as {
+    candidates?: Array<{
+      content?: { parts?: Array<{ text?: string }> };
+      finishReason?: string;
+    }>;
+    usageMetadata?: {
+      promptTokenCount?: number;
+      candidatesTokenCount?: number;
+    };
+  };
+
+  const finishReason = data.candidates?.[0]?.finishReason;
+  const tokensIn = data.usageMetadata?.promptTokenCount ?? 0;
+  const tokensOut = data.usageMetadata?.candidatesTokenCount ?? 0;
+  if (finishReason === "MAX_TOKENS") {
+    console.warn(
+      `[gemini] MAX_TOKENS hit | model=${model}` +
+      ` | tokensInput=${tokensIn}` +
+      ` | tokensOutput=${tokensOut}` +
+      ` | responseFormat=${responseFormat ?? "text"}` +
+      ` — returning partial content`,
+    );
+  }
+
+  const content =
+    data.candidates?.[0]?.content?.parts
+      ?.map((p) => p.text ?? "")
+      .join("") ?? "";
+
+  return {
+    content,
+    tokensInput: data.usageMetadata?.promptTokenCount ?? 0,
+    tokensOutput: data.usageMetadata?.candidatesTokenCount ?? 0,
+    model,
+  };
+}
+
+/** Sleep for a given number of milliseconds. */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Compute delay for exponential backoff with jitter.
+ * delay = min(base * 2^attempt, max) + random jitter [0, 500ms]
+ */
+function retryDelay(attempt: number): number {
+  const exponential = Math.min(RETRY_BASE_DELAY_MS * 2 ** attempt, RETRY_MAX_DELAY_MS);
+  const jitter = Math.random() * 500;
+  return exponential + jitter;
+}
+
 /**
  * Non-streaming completion via the Gemini REST API.
  * Supports multimodal (text + image) input.
+ *
+ * Retry strategy: up to 3 retries with exponential backoff on retryable errors
+ * (429, 500, 503, 504, timeout). If all retries fail, falls back to the stable
+ * Gemini 2.5 equivalent model for one final attempt.
  */
 export async function completeWithGemini(options: GeminiCompleteOptions): Promise<GeminiCompleteResult> {
   const {
@@ -125,64 +254,36 @@ export async function completeWithGemini(options: GeminiCompleteOptions): Promis
     },
   };
 
-  const url = `${GEMINI_API_BASE}/models/${encodeURIComponent(model)}:generateContent?key=${encodeURIComponent(apiKey)}`;
-
-  const timeoutMs = GEMINI_TIMEOUT_MS[model] ?? DEFAULT_GEMINI_TIMEOUT_MS;
-  let res: Response;
-  try {
-    res = await fetch(url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-      signal: AbortSignal.timeout(timeoutMs),
-    });
-  } catch (err: unknown) {
-    if (err instanceof DOMException && err.name === "TimeoutError") {
-      throw new Error(
-        `[chat-service] Gemini API timed out after ${timeoutMs / 1000}s | model=${model}`,
+  // --- Retry loop on the primary model ---
+  let lastError: Error | undefined;
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    if (attempt > 0) {
+      const delay = retryDelay(attempt - 1);
+      console.warn(
+        `[chat-service] Gemini retry ${attempt}/${MAX_RETRIES} after ${Math.round(delay)}ms | model=${model}`,
       );
+      await sleep(delay);
     }
-    throw err;
+    try {
+      return await callGeminiOnce(model, apiKey, body, responseFormat);
+    } catch (err: unknown) {
+      if (err instanceof GeminiRetryableError) {
+        lastError = err;
+        continue;
+      }
+      throw err;
+    }
   }
 
-  if (!res.ok) {
-    const errorText = await res.text().catch(() => "unknown error");
-    throw new Error(`[gemini] API error ${res.status}: ${errorText}`);
-  }
-
-  const data = (await res.json()) as {
-    candidates?: Array<{
-      content?: { parts?: Array<{ text?: string }> };
-      finishReason?: string;
-    }>;
-    usageMetadata?: {
-      promptTokenCount?: number;
-      candidatesTokenCount?: number;
-    };
-  };
-
-  const finishReason = data.candidates?.[0]?.finishReason;
-  const tokensIn = data.usageMetadata?.promptTokenCount ?? 0;
-  const tokensOut = data.usageMetadata?.candidatesTokenCount ?? 0;
-  if (finishReason === "MAX_TOKENS") {
+  // --- All retries exhausted — try fallback model ---
+  const fallbackModel = GEMINI_FALLBACK_MODEL[model];
+  if (fallbackModel) {
     console.warn(
-      `[gemini] MAX_TOKENS hit | model=${model}` +
-      ` | tokensInput=${tokensIn}` +
-      ` | tokensOutput=${tokensOut}` +
-      ` | responseFormat=${responseFormat ?? "text"}` +
-      ` — returning partial content`,
+      `[chat-service] All ${MAX_RETRIES} retries failed for ${model}, falling back to ${fallbackModel} | lastError=${lastError?.message}`,
     );
+    return await callGeminiOnce(fallbackModel, apiKey, body, responseFormat);
   }
 
-  const content =
-    data.candidates?.[0]?.content?.parts
-      ?.map((p) => p.text ?? "")
-      .join("") ?? "";
-
-  return {
-    content,
-    tokensInput: data.usageMetadata?.promptTokenCount ?? 0,
-    tokensOutput: data.usageMetadata?.candidatesTokenCount ?? 0,
-    model,
-  };
+  // No fallback available — re-throw the last error
+  throw lastError;
 }

--- a/tests/unit/gemini.test.ts
+++ b/tests/unit/gemini.test.ts
@@ -7,10 +7,14 @@ describe("completeWithGemini", () => {
   beforeEach(() => {
     fetchSpy.mockReset();
     vi.stubGlobal("fetch", fetchSpy);
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   const baseOptions = {
@@ -20,6 +24,29 @@ describe("completeWithGemini", () => {
     systemPrompt: "You are helpful.",
     responseFormat: "json" as const,
   };
+
+  const okResponse = (text = '["https://example.com"]', tokensIn = 100, tokensOut = 50) => ({
+    ok: true,
+    json: async () => ({
+      candidates: [{ content: { parts: [{ text }] }, finishReason: "STOP" }],
+      usageMetadata: { promptTokenCount: tokensIn, candidatesTokenCount: tokensOut },
+    }),
+  });
+
+  const errorResponse = (status: number, body = "overloaded") => ({
+    ok: false,
+    status,
+    text: async () => body,
+  });
+
+  /** Run completeWithGemini and advance fake timers until it resolves. */
+  async function runWithTimers(opts: Parameters<typeof completeWithGemini>[0]) {
+    const promise = completeWithGemini(opts);
+    // Prevent unhandled rejection warnings — caller will handle via .rejects
+    promise.catch(() => {});
+    await vi.runAllTimersAsync();
+    return promise;
+  }
 
   it("returns partial content when finishReason is MAX_TOKENS in JSON mode (no throw)", async () => {
     fetchSpy.mockResolvedValueOnce({
@@ -35,7 +62,7 @@ describe("completeWithGemini", () => {
       }),
     });
 
-    const result = await completeWithGemini(baseOptions);
+    const result = await runWithTimers(baseOptions);
     expect(result.content).toBe('["https://example.com", "https://truncat');
     expect(result.tokensInput).toBe(100);
     expect(result.tokensOutput).toBe(500);
@@ -55,112 +82,219 @@ describe("completeWithGemini", () => {
       }),
     });
 
-    const result = await completeWithGemini({
-      ...baseOptions,
-      responseFormat: undefined,
-    });
-
+    const result = await runWithTimers({ ...baseOptions, responseFormat: undefined });
     expect(result.content).toBe("Here are the top outlets for your campaign: 1. TechCrun");
     expect(result.tokensInput).toBe(200);
     expect(result.tokensOutput).toBe(1000);
   });
 
   it("returns content when finishReason is STOP (normal completion)", async () => {
-    fetchSpy.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        candidates: [
-          {
-            content: { parts: [{ text: '["https://example.com"]' }] },
-            finishReason: "STOP",
-          },
-        ],
-        usageMetadata: { promptTokenCount: 100, candidatesTokenCount: 50 },
-      }),
-    });
+    fetchSpy.mockResolvedValueOnce(okResponse());
 
-    const result = await completeWithGemini(baseOptions);
+    const result = await runWithTimers(baseOptions);
     expect(result.content).toBe('["https://example.com"]');
     expect(result.tokensInput).toBe(100);
     expect(result.tokensOutput).toBe(50);
   });
 
   it("does not send maxOutputTokens (API manages its own limits)", async () => {
-    fetchSpy.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        candidates: [{ content: { parts: [{ text: '{}' }] }, finishReason: "STOP" }],
-        usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5 },
-      }),
-    });
-
-    await completeWithGemini(baseOptions);
-
+    fetchSpy.mockResolvedValueOnce(okResponse("{}"));
+    await runWithTimers(baseOptions);
     const requestBody = JSON.parse(fetchSpy.mock.calls[0][1].body);
     expect(requestBody.generationConfig.maxOutputTokens).toBeUndefined();
   });
 
   it("does not send thinkingConfig (thinking removed from API)", async () => {
-    fetchSpy.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        candidates: [{ content: { parts: [{ text: '{}' }] }, finishReason: "STOP" }],
-        usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5 },
-      }),
-    });
-
-    await completeWithGemini(baseOptions);
-
+    fetchSpy.mockResolvedValueOnce(okResponse("{}"));
+    await runWithTimers(baseOptions);
     const requestBody = JSON.parse(fetchSpy.mock.calls[0][1].body);
     expect(requestBody.generationConfig.thinkingConfig).toBeUndefined();
   });
 
-  it("throws a clear timeout error with model-specific duration (flash = 600s)", async () => {
-    const timeoutError = new DOMException("The operation was aborted due to timeout", "TimeoutError");
-    fetchSpy.mockRejectedValueOnce(timeoutError);
-
-    await expect(completeWithGemini(baseOptions)).rejects.toThrow(
-      /Gemini API timed out after 600s/,
-    );
-  });
-
-  it("uses 900s timeout for pro model", async () => {
-    const timeoutError = new DOMException("The operation was aborted due to timeout", "TimeoutError");
-    fetchSpy.mockRejectedValueOnce(timeoutError);
-
-    await expect(
-      completeWithGemini({ ...baseOptions, model: "gemini-3.1-pro-preview" }),
-    ).rejects.toThrow(/Gemini API timed out after 900s/);
-  });
-
-  it("uses 300s timeout for flash-lite model", async () => {
-    const timeoutError = new DOMException("The operation was aborted due to timeout", "TimeoutError");
-    fetchSpy.mockRejectedValueOnce(timeoutError);
-
-    await expect(
-      completeWithGemini({ ...baseOptions, model: "gemini-3.1-flash-lite-preview" }),
-    ).rejects.toThrow(/Gemini API timed out after 300s/);
-  });
-
   it("passes AbortSignal.timeout to the Gemini fetch call", async () => {
-    fetchSpy.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        candidates: [{ content: { parts: [{ text: "{}" }] }, finishReason: "STOP" }],
-        usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5 },
-      }),
-    });
-
-    await completeWithGemini(baseOptions);
-
+    fetchSpy.mockResolvedValueOnce(okResponse("{}"));
+    await runWithTimers(baseOptions);
     const fetchOptions = fetchSpy.mock.calls[0][1];
     expect(fetchOptions.signal).toBeInstanceOf(AbortSignal);
   });
 
-  it("re-throws non-timeout fetch errors as-is", async () => {
+  it("re-throws non-retryable fetch errors as-is", async () => {
     const networkError = new TypeError("fetch failed");
     fetchSpy.mockRejectedValueOnce(networkError);
+    await expect(runWithTimers(baseOptions)).rejects.toThrow("fetch failed");
+  });
 
-    await expect(completeWithGemini(baseOptions)).rejects.toThrow("fetch failed");
+  it("re-throws non-retryable HTTP errors (e.g. 400) without retrying", async () => {
+    fetchSpy.mockResolvedValueOnce(errorResponse(400, "bad request"));
+    await expect(runWithTimers(baseOptions)).rejects.toThrow("[gemini] API error 400: bad request");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // --- Retry behavior ---
+
+  it("retries on 503 and succeeds on second attempt", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockResolvedValueOnce(okResponse("ok"));
+
+    const result = await runWithTimers(baseOptions);
+    expect(result.content).toBe("ok");
+    expect(result.model).toBe("gemini-3-flash-preview");
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries on 429 and succeeds on third attempt", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(errorResponse(429))
+      .mockResolvedValueOnce(errorResponse(429))
+      .mockResolvedValueOnce(okResponse("ok"));
+
+    const result = await runWithTimers(baseOptions);
+    expect(result.content).toBe("ok");
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it("retries on 500 and succeeds", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(errorResponse(500))
+      .mockResolvedValueOnce(okResponse("recovered"));
+
+    const result = await runWithTimers(baseOptions);
+    expect(result.content).toBe("recovered");
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries on timeout (DOMException TimeoutError) and succeeds", async () => {
+    const timeoutError = new DOMException("The operation was aborted due to timeout", "TimeoutError");
+    fetchSpy
+      .mockRejectedValueOnce(timeoutError)
+      .mockResolvedValueOnce(okResponse("recovered"));
+
+    const result = await runWithTimers(baseOptions);
+    expect(result.content).toBe("recovered");
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  // --- Fallback behavior ---
+
+  it("falls back to gemini-2.5-flash after all retries fail for flash-preview", async () => {
+    // 1 initial + 3 retries = 4 calls on primary model, all 503
+    fetchSpy
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockResolvedValueOnce(errorResponse(503))
+      // fallback call succeeds
+      .mockResolvedValueOnce(okResponse("fallback-ok"));
+
+    const result = await runWithTimers(baseOptions);
+    expect(result.content).toBe("fallback-ok");
+    expect(result.model).toBe("gemini-2.5-flash");
+    expect(fetchSpy).toHaveBeenCalledTimes(5);
+    const fallbackUrl = fetchSpy.mock.calls[4][0] as string;
+    expect(fallbackUrl).toContain("gemini-2.5-flash");
+  });
+
+  it("falls back to gemini-2.5-pro after all retries fail for pro-preview", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(errorResponse(504))
+      .mockResolvedValueOnce(errorResponse(504))
+      .mockResolvedValueOnce(errorResponse(504))
+      .mockResolvedValueOnce(errorResponse(504))
+      .mockResolvedValueOnce(okResponse("pro-fallback"));
+
+    const result = await runWithTimers({ ...baseOptions, model: "gemini-3.1-pro-preview" });
+    expect(result.content).toBe("pro-fallback");
+    expect(result.model).toBe("gemini-2.5-pro");
+    const fallbackUrl = fetchSpy.mock.calls[4][0] as string;
+    expect(fallbackUrl).toContain("gemini-2.5-pro");
+  });
+
+  it("falls back to gemini-2.5-flash after all retries fail for flash-lite-preview", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockResolvedValueOnce(okResponse("lite-fallback"));
+
+    const result = await runWithTimers({ ...baseOptions, model: "gemini-3.1-flash-lite-preview" });
+    expect(result.content).toBe("lite-fallback");
+    expect(result.model).toBe("gemini-2.5-flash");
+  });
+
+  it("throws when fallback also fails", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockResolvedValueOnce(errorResponse(503, "fallback also down"));
+
+    await expect(runWithTimers(baseOptions)).rejects.toThrow(
+      "[gemini] API error 503: fallback also down",
+    );
+  });
+
+  it("throws when all retries fail and there is no fallback model", async () => {
+    const unknownModel = "gemini-99-turbo-preview";
+    fetchSpy
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockResolvedValueOnce(errorResponse(503));
+
+    await expect(
+      runWithTimers({ ...baseOptions, model: unknownModel }),
+    ).rejects.toThrow("[gemini] API error 503");
+    expect(fetchSpy).toHaveBeenCalledTimes(4);
+  });
+
+  it("retries on timeout then falls back after all retries exhausted", async () => {
+    const timeoutError = new DOMException("The operation was aborted due to timeout", "TimeoutError");
+    fetchSpy
+      .mockRejectedValueOnce(timeoutError)
+      .mockRejectedValueOnce(timeoutError)
+      .mockRejectedValueOnce(timeoutError)
+      .mockRejectedValueOnce(timeoutError)
+      .mockResolvedValueOnce(okResponse("timeout-fallback"));
+
+    const result = await runWithTimers(baseOptions);
+    expect(result.content).toBe("timeout-fallback");
+    expect(result.model).toBe("gemini-2.5-flash");
+    expect(fetchSpy).toHaveBeenCalledTimes(5);
+  });
+
+  it("logs a warning for each retry attempt", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockResolvedValueOnce(okResponse("ok"));
+
+    await runWithTimers(baseOptions);
+
+    const warnCalls = (console.warn as ReturnType<typeof vi.fn>).mock.calls
+      .map((c) => c[0] as string)
+      .filter((msg) => msg.includes("Gemini retry"));
+    expect(warnCalls).toHaveLength(2);
+    expect(warnCalls[0]).toMatch(/retry 1\/3/);
+    expect(warnCalls[1]).toMatch(/retry 2\/3/);
+  });
+
+  it("logs a warning when falling back to stable model", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockResolvedValueOnce(okResponse("fallback"));
+
+    await runWithTimers(baseOptions);
+
+    const warnCalls = (console.warn as ReturnType<typeof vi.fn>).mock.calls
+      .map((c) => c[0] as string);
+    const fallbackWarn = warnCalls.find((msg) => msg.includes("falling back to"));
+    expect(fallbackWarn).toBeDefined();
+    expect(fallbackWarn).toContain("gemini-2.5-flash");
   });
 });


### PR DESCRIPTION
## Summary
- Adds 3 retries with exponential backoff + jitter on retryable Gemini API errors (429, 500, 503, 504, timeout)
- Falls back to stable Gemini 2.5 equivalents when all retries fail (pro→2.5-pro, flash→2.5-flash, flash-lite→2.5-flash)
- Adds cost prefix mappings for Gemini 2.5 models in SUPPORTED_MODELS

## Test plan
- [x] 20 unit tests covering retry logic, fallback behavior, timeout handling, and logging
- [x] Full test suite passes (420 tests)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)