### PR TITLE
fix: handle 409 on duplicate DAG after fork redirect

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -834,26 +834,45 @@ app.post("/chat", requireAuth, async (req, res) => {
           // Redirect to the already-forked workflow if the LLM tries to
           // update the same source workflow again in this turn.
           const effectiveWorkflowId = forkedWorkflowMap.get(rawWorkflowId as string) ?? rawWorkflowId as string;
-          if (effectiveWorkflowId !== rawWorkflowId) {
+          const wasRedirected = effectiveWorkflowId !== (rawWorkflowId as string);
+          if (wasRedirected) {
             console.log(
               `[chat] Redirecting update_workflow from already-forked source "${rawWorkflowId}" → "${effectiveWorkflowId}"`,
             );
           }
-          const updateResult = await updateWorkflow(
-            effectiveWorkflowId,
-            updateBody as import("./lib/workflow-client.js").UpdateWorkflowBody,
-            wfParams,
-          );
-          if (updateResult.outcome === "forked") {
-            const forkedFrom = updateResult.workflow._forkedFromName || rawWorkflowId;
-            // Record the fork so subsequent calls target the fork, not the original
-            forkedWorkflowMap.set(rawWorkflowId as string, updateResult.workflow.id);
-            result = {
-              ...updateResult.workflow,
-              _note: `This is a NEW workflow forked from "${forkedFrom}". Tell the user: "Your customized workflow is ready: ${updateResult.workflow.name || updateResult.workflow.signatureName || updateResult.workflow.id}. Use this name for future campaigns."`,
-            };
-          } else {
-            result = updateResult.workflow;
+          try {
+            const updateResult = await updateWorkflow(
+              effectiveWorkflowId,
+              updateBody as import("./lib/workflow-client.js").UpdateWorkflowBody,
+              wfParams,
+            );
+            if (updateResult.outcome === "forked") {
+              const forkedFrom = updateResult.workflow._forkedFromName || rawWorkflowId;
+              // Record the fork so subsequent calls target the fork, not the original
+              forkedWorkflowMap.set(rawWorkflowId as string, updateResult.workflow.id);
+              result = {
+                ...updateResult.workflow,
+                _note: `This is a NEW workflow forked from "${forkedFrom}". Tell the user: "Your customized workflow is ready: ${updateResult.workflow.name || updateResult.workflow.signatureName || updateResult.workflow.id}. Use this name for future campaigns."`,
+              };
+            } else {
+              result = updateResult.workflow;
+            }
+          } catch (err: unknown) {
+            // 409 on a redirected call means the forked workflow already has
+            // the same DAG — treat as a no-op and return the current state.
+            const is409 = err instanceof Error && err.message.includes("signature already exists");
+            if (is409) {
+              console.log(
+                `[chat] update_workflow 409 on "${effectiveWorkflowId}" — workflow already has this DAG, returning current state`,
+              );
+              const current = await getWorkflow(effectiveWorkflowId, wfParams);
+              result = {
+                ...current,
+                _note: "No changes needed — this workflow already has the requested configuration.",
+              };
+            } else {
+              throw err;
+            }
           }
         } else {
           result = await validateWorkflow(
@@ -921,29 +940,51 @@ app.post("/chat", requireAuth, async (req, res) => {
             `[chat] Redirecting update_workflow_node_config from already-forked source "${rawWorkflowId}" → "${effectiveWorkflowId}"`,
           );
         }
-        const updateResult = await updateWorkflowNodeConfig(
-          effectiveWorkflowId,
-          args.nodeId as string,
-          args.configUpdates as Record<string, unknown>,
-          {
-            orgId,
-            userId,
-            runId: runId!,
-            trackingHeaders: Object.keys(trackingHeaders).length > 0 ? trackingHeaders as Record<string, string> : undefined,
-          },
-        );
 
         let result: unknown;
-        if (updateResult.outcome === "forked") {
-          const forkedFrom = updateResult.workflow._forkedFromName || "the original";
-          // Record the fork so subsequent calls target the fork
-          forkedWorkflowMap.set(rawWorkflowId, updateResult.workflow.id);
-          result = {
-            ...updateResult.workflow,
-            _note: `This is a NEW workflow forked from "${forkedFrom}". Tell the user: "Your customized workflow is ready: ${updateResult.workflow.name || updateResult.workflow.signatureName || updateResult.workflow.id}. Use this name for future campaigns."`,
-          };
-        } else {
-          result = updateResult.workflow;
+        try {
+          const updateResult = await updateWorkflowNodeConfig(
+            effectiveWorkflowId,
+            args.nodeId as string,
+            args.configUpdates as Record<string, unknown>,
+            {
+              orgId,
+              userId,
+              runId: runId!,
+              trackingHeaders: Object.keys(trackingHeaders).length > 0 ? trackingHeaders as Record<string, string> : undefined,
+            },
+          );
+
+          if (updateResult.outcome === "forked") {
+            const forkedFrom = updateResult.workflow._forkedFromName || "the original";
+            // Record the fork so subsequent calls target the fork
+            forkedWorkflowMap.set(rawWorkflowId, updateResult.workflow.id);
+            result = {
+              ...updateResult.workflow,
+              _note: `This is a NEW workflow forked from "${forkedFrom}". Tell the user: "Your customized workflow is ready: ${updateResult.workflow.name || updateResult.workflow.signatureName || updateResult.workflow.id}. Use this name for future campaigns."`,
+            };
+          } else {
+            result = updateResult.workflow;
+          }
+        } catch (err: unknown) {
+          const is409 = err instanceof Error && err.message.includes("signature already exists");
+          if (is409) {
+            console.log(
+              `[chat] update_workflow_node_config 409 on "${effectiveWorkflowId}" — workflow already has this DAG, returning current state`,
+            );
+            const current = await getWorkflow(effectiveWorkflowId, {
+              orgId,
+              userId,
+              runId: runId!,
+              trackingHeaders: Object.keys(trackingHeaders).length > 0 ? trackingHeaders as Record<string, string> : undefined,
+            });
+            result = {
+              ...current,
+              _note: "No changes needed — this workflow already has the requested configuration.",
+            };
+          } else {
+            throw err;
+          }
         }
 
         toolCalls.push({ name: call.name, args, result });

--- a/tests/unit/fork-dedup.test.ts
+++ b/tests/unit/fork-dedup.test.ts
@@ -157,4 +157,55 @@ describe("fork deduplication (forkedWorkflowMap)", () => {
     expect(originalCalls).toHaveLength(1);
     expect(forkedCalls).toHaveLength(3);
   });
+
+  it("handles 409 gracefully when redirected update has same DAG signature", async () => {
+    /**
+     * Regression: after a fork, the LLM may call update_workflow again with
+     * the same DAG. Workflow-service returns 409 "signature already exists".
+     * The handler should catch this and return the current workflow state
+     * instead of propagating the error (which causes the LLM to retry).
+     */
+    const { updateWorkflow, getWorkflow } = await loadModule();
+    const dedup = createForkDedup();
+
+    // First call: fork
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: () =>
+        Promise.resolve({
+          id: "wf-forked",
+          name: "PR Cold Email Fork",
+          _action: "forked",
+          _forkedFromName: "PR Cold Email Original",
+        }),
+    });
+
+    const params = { orgId: "org-1", userId: "user-1", runId: "run-1" };
+    const result1 = await updateWorkflow("wf-original", { dag: { nodes: [{ id: "s1", type: "http.call" }], edges: [] } }, params);
+    expect(result1.outcome).toBe("forked");
+    dedup.recordFork("wf-original", result1.workflow.id);
+
+    // Second call: redirected to fork, but 409 because same DAG
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      json: () =>
+        Promise.resolve({
+          error: "A workflow with this DAG signature already exists",
+          existingWorkflowId: undefined,
+          existingWorkflowSlug: undefined,
+        }),
+    });
+
+    const effectiveId = dedup.resolveWorkflowId("wf-original");
+    expect(effectiveId).toBe("wf-forked");
+
+    // The 409 should throw from updateWorkflow — the handler in index.ts
+    // catches it and calls getWorkflow instead. Here we verify the error
+    // message contains "signature already exists" so the handler can match it.
+    await expect(
+      updateWorkflow(effectiveId, { dag: { nodes: [{ id: "s1", type: "http.call" }], edges: [] } }, params),
+    ).rejects.toThrow(/signature already exists/);
+  });
 });


### PR DESCRIPTION
## Summary
- Follow-up to #148 (duplicate fork fix)
- After a fork, the LLM sometimes calls `update_workflow` or `update_workflow_node_config` again with the same DAG — workflow-service returns 409 "signature already exists"
- Previously this error propagated to the LLM, which retried in a loop causing repeated 409s
- Now: catch the 409, call `getWorkflow` to fetch the current state, and return it as a successful no-op with a `_note` telling the LLM no changes were needed

## Test plan
- [x] New test: verifies the 409 error message matches `signature already exists` so the handler can catch it
- [x] All 424 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)