### PR TITLE
revert: restore Flash to gemini-3-flash-preview

### DIFF
--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -39,7 +39,7 @@ const MODEL_MAP: Record<string, Record<string, ResolvedModel>> = {
   },
   google: {
     "flash-lite": { apiModelId: "gemini-3.1-flash-lite-preview", costPrefix: "google-flash-lite-3.1", provider: "google" },
-    "flash": { apiModelId: "gemini-3.1-flash-preview", costPrefix: "google-flash-3.1", provider: "google" },
+    "flash": { apiModelId: "gemini-3-flash-preview", costPrefix: "google-flash-3", provider: "google" },
     "pro": { apiModelId: "gemini-3.1-pro-preview", costPrefix: "google-pro-3.1", provider: "google" },
   },
 };
@@ -71,7 +71,7 @@ export const SUPPORTED_MODELS: Record<string, string> = {
   "claude-haiku-4-5": "anthropic-haiku-4.5",
   "claude-opus-4-6": "anthropic-opus-4.6",
   "gemini-3.1-flash-lite-preview": "google-flash-lite-3.1",
-  "gemini-3.1-flash-preview": "google-flash-3.1",
+  "gemini-3-flash-preview": "google-flash-3",
   "gemini-3.1-pro-preview": "google-pro-3.1",
   "gemini-2.5-pro": "google-pro-2.5",
   "gemini-2.5-flash": "google-flash-2.5",

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -7,7 +7,7 @@ const GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta";
 
 export const GEMINI_MODELS: Record<string, string> = {
   "gemini-3.1-flash-lite-preview": "google-flash-lite-3.1",
-  "gemini-3.1-flash-preview": "google-flash-3.1",
+  "gemini-3-flash-preview": "google-flash-3",
   "gemini-3.1-pro-preview": "google-pro-3.1",
   "gemini-2.5-pro": "google-pro-2.5",
   "gemini-2.5-flash": "google-flash-2.5",
@@ -16,7 +16,7 @@ export const GEMINI_MODELS: Record<string, string> = {
 /** Model-specific API timeouts in milliseconds. */
 const GEMINI_TIMEOUT_MS: Record<string, number> = {
   "gemini-3.1-pro-preview": 15 * 60_000,       // 15 min — Pro
-  "gemini-3.1-flash-preview": 10 * 60_000,       // 10 min — Flash
+  "gemini-3-flash-preview": 10 * 60_000,        // 10 min — Flash
   "gemini-3.1-flash-lite-preview": 5 * 60_000,  //  5 min — Flash Lite
   "gemini-2.5-pro": 15 * 60_000,                // 15 min — 2.5 Pro
   "gemini-2.5-flash": 10 * 60_000,              // 10 min — 2.5 Flash
@@ -26,7 +26,7 @@ const DEFAULT_GEMINI_TIMEOUT_MS = 10 * 60_000;  // 10 min fallback
 /** Fallback from preview 3.x models to stable 2.5 models. */
 const GEMINI_FALLBACK_MODEL: Record<string, string> = {
   "gemini-3.1-pro-preview": "gemini-2.5-pro",
-  "gemini-3.1-flash-preview": "gemini-2.5-flash",
+  "gemini-3-flash-preview": "gemini-2.5-flash",
   "gemini-3.1-flash-lite-preview": "gemini-2.5-flash",
 };
 

--- a/tests/unit/complete.test.ts
+++ b/tests/unit/complete.test.ts
@@ -418,10 +418,10 @@ describe("resolveModel", () => {
     expect(resolved.provider).toBe("google");
   });
 
-  it("resolves google + flash to gemini-3.1-flash-preview", () => {
+  it("resolves google + flash to gemini-3-flash-preview", () => {
     const resolved = resolveModel("google", "flash");
-    expect(resolved.apiModelId).toBe("gemini-3.1-flash-preview");
-    expect(resolved.costPrefix).toBe("google-flash-3.1");
+    expect(resolved.apiModelId).toBe("gemini-3-flash-preview");
+    expect(resolved.costPrefix).toBe("google-flash-3");
     expect(resolved.provider).toBe("google");
   });
 
@@ -448,8 +448,8 @@ describe("isGeminiModel", () => {
     expect(isGeminiModel("gemini-3.1-flash-lite-preview")).toBe(true);
   });
 
-  it("returns true for gemini-3.1-flash-preview", () => {
-    expect(isGeminiModel("gemini-3.1-flash-preview")).toBe(true);
+  it("returns true for gemini-3-flash-preview", () => {
+    expect(isGeminiModel("gemini-3-flash-preview")).toBe(true);
   });
 
   it("returns true for gemini-3.1-pro-preview", () => {
@@ -471,8 +471,8 @@ describe("geminiCostPrefix", () => {
     expect(geminiCostPrefix("gemini-3.1-flash-lite-preview")).toBe("google-flash-lite-3.1");
   });
 
-  it("returns correct prefix for gemini-3.1-flash-preview", () => {
-    expect(geminiCostPrefix("gemini-3.1-flash-preview")).toBe("google-flash-3.1");
+  it("returns correct prefix for gemini-3-flash-preview", () => {
+    expect(geminiCostPrefix("gemini-3-flash-preview")).toBe("google-flash-3");
   });
 
   it("returns correct prefix for gemini-3.1-pro-preview", () => {
@@ -492,7 +492,7 @@ describe("costPrefixForModel", () => {
   });
 
   it("returns correct prefix for all gemini models", () => {
-    expect(costPrefixForModel("gemini-3.1-flash-preview")).toBe("google-flash-3.1");
+    expect(costPrefixForModel("gemini-3-flash-preview")).toBe("google-flash-3");
     expect(costPrefixForModel("gemini-3.1-pro-preview")).toBe("google-pro-3.1");
   });
 });

--- a/tests/unit/gemini.test.ts
+++ b/tests/unit/gemini.test.ts
@@ -19,7 +19,7 @@ describe("completeWithGemini", () => {
 
   const baseOptions = {
     apiKey: "test-key",
-    model: "gemini-3.1-flash-preview",
+    model: "gemini-3-flash-preview",
     message: "Return URLs as JSON",
     systemPrompt: "You are helpful.",
     responseFormat: "json" as const,
@@ -139,7 +139,7 @@ describe("completeWithGemini", () => {
 
     const result = await runWithTimers(baseOptions);
     expect(result.content).toBe("ok");
-    expect(result.model).toBe("gemini-3.1-flash-preview");
+    expect(result.model).toBe("gemini-3-flash-preview");
     expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 


### PR DESCRIPTION
## Summary
- PR #150 incorrectly changed `"flash"` to `gemini-3.1-flash-preview`, which **does not exist** in Google's API
- Reverts to `gemini-3-flash-preview` (cost prefix `google-flash-3`) — the correct and only Flash standard model

## Test plan
- [x] All unit tests pass
- [x] Build + OpenAPI regen successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)