### PR TITLE
feat: retry Anthropic streaming on transient errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@ src/
     index.ts        # Drizzle client init
     schema.ts       # sessions + messages + app_configs + platform_configs table definitions
   lib/
-    anthropic.ts       # Claude AI client (Sonnet 4.6), streaming + non-streaming, tool calling, adaptive thinking, context management (compaction), built-in tool declarations
+    anthropic.ts       # Claude AI client (Sonnet 4.6), streaming + non-streaming, tool calling, adaptive thinking, context management (compaction), built-in tool declarations. Streaming retries transient errors (overloaded, 429, 5xx) up to 2× with exponential backoff when no tokens have been emitted yet
     gemini.ts          # Gemini REST API client — retry with exponential backoff (3 retries) + fallback to stable 2.5 models on failure
     merge-messages.ts  # Ensures alternating user/assistant roles by merging orphaned consecutive same-role messages
     billing-client.ts  # Billing-service client for credit authorization before platform-key operations

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,31 @@ const openapiPath = join(__dirname, "..", "openapi.json");
 import { mergeConsecutiveMessages, stripToolUseBlocks } from "./lib/merge-messages.js";
 
 // ---------------------------------------------------------------------------
+// Anthropic stream retry
+// ---------------------------------------------------------------------------
+
+/** Max retries for Anthropic streaming on transient errors. */
+const ANTHROPIC_STREAM_MAX_RETRIES = 2;
+
+/** Base delay for Anthropic stream retry backoff in ms. */
+const ANTHROPIC_STREAM_RETRY_BASE_MS = 2_000;
+
+/**
+ * Check if an Anthropic error is retryable (overloaded, rate-limited, or server error).
+ * Only safe to retry if no tokens have been emitted to the client yet.
+ */
+function isRetryableAnthropicError(err: unknown): boolean {
+  if (!(err instanceof Anthropic.APIError)) return false;
+  // During streaming, the SDK throws `new APIError(undefined, parsedBody, ...)` directly.
+  // The `error` property is the raw SSE payload: { type: "error", error: { type: "overloaded_error", ... } }
+  const errorBody = err.error as { type?: string; error?: { type?: string } } | undefined;
+  if (errorBody?.error?.type === "overloaded_error") return true;
+  // Standard retryable HTTP statuses (non-streaming or future SDK changes)
+  if (typeof err.status === "number" && [429, 500, 503, 529].includes(err.status)) return true;
+  return false;
+}
+
+// ---------------------------------------------------------------------------
 // JSON parsing for LLM responses
 // ---------------------------------------------------------------------------
 
@@ -1243,38 +1268,66 @@ app.post("/chat", requireAuth, async (req, res) => {
       }
 
       let currentBlockType: string | null = null;
-      const stream = claude.createStream(turnMessages, allTools, abortController.signal);
+      let stream: ReturnType<typeof claude.createStream> | undefined;
+      let tokensEmitted = false;
 
-      try {
-        for await (const event of stream) {
-          if (event.type === "content_block_start") {
-            currentBlockType = event.content_block.type;
-            if (currentBlockType === "thinking") {
-              sendSSE(res, { type: "thinking_start" });
+      // Retry loop for transient Anthropic errors (overloaded, 429, 5xx).
+      // Only retries when no tokens have been sent to the client yet.
+      for (let attempt = 0; attempt <= ANTHROPIC_STREAM_MAX_RETRIES; attempt++) {
+        tokensEmitted = false;
+        currentBlockType = null;
+        stream = claude.createStream(turnMessages, allTools, abortController.signal);
+
+        try {
+          for await (const event of stream) {
+            if (event.type === "content_block_start") {
+              currentBlockType = event.content_block.type;
+              if (currentBlockType === "thinking") {
+                sendSSE(res, { type: "thinking_start" });
+                tokensEmitted = true;
+              }
+            } else if (event.type === "content_block_delta") {
+              if (event.delta.type === "thinking_delta") {
+                sendSSE(res, { type: "thinking_delta", thinking: event.delta.thinking });
+                tokensEmitted = true;
+              } else if (event.delta.type === "text_delta") {
+                bufferToken(event.delta.text);
+                tokensEmitted = true;
+              }
+            } else if (event.type === "content_block_stop") {
+              if (currentBlockType === "thinking") {
+                sendSSE(res, { type: "thinking_stop" });
+              }
+              currentBlockType = null;
             }
-          } else if (event.type === "content_block_delta") {
-            if (event.delta.type === "thinking_delta") {
-              sendSSE(res, { type: "thinking_delta", thinking: event.delta.thinking });
-            } else if (event.delta.type === "text_delta") {
-              bufferToken(event.delta.text);
-            }
-          } else if (event.type === "content_block_stop") {
-            if (currentBlockType === "thinking") {
-              sendSSE(res, { type: "thinking_stop" });
-            }
-            currentBlockType = null;
           }
+          break; // Stream completed successfully — exit retry loop
+        } catch (streamErr) {
+          // If aborted due to client disconnect, exit cleanly
+          if (abortController.signal.aborted) {
+            console.log(`[chat] session="${currentSessionId}" stream aborted (client disconnect)`);
+            return;
+          }
+          // Only retry if: (a) retryable error, (b) no tokens emitted yet, (c) retries left
+          if (
+            !tokensEmitted &&
+            isRetryableAnthropicError(streamErr) &&
+            attempt < ANTHROPIC_STREAM_MAX_RETRIES
+          ) {
+            const delay = ANTHROPIC_STREAM_RETRY_BASE_MS * 2 ** attempt + Math.random() * 500;
+            console.warn(
+              `[chat] Anthropic stream retry ${attempt + 1}/${ANTHROPIC_STREAM_MAX_RETRIES} ` +
+                `after ${Math.round(delay)}ms | session="${currentSessionId}" org="${orgId}" | ` +
+                `error=${streamErr instanceof Error ? streamErr.message : String(streamErr)}`,
+            );
+            await new Promise((resolve) => setTimeout(resolve, delay));
+            continue;
+          }
+          throw streamErr; // Non-retryable or tokens already emitted — propagate
         }
-      } catch (streamErr) {
-        // If aborted due to client disconnect, exit cleanly
-        if (abortController.signal.aborted) {
-          console.log(`[chat] session="${currentSessionId}" stream aborted (client disconnect)`);
-          return;
-        }
-        throw streamErr; // Re-throw to outer catch for error SSE
       }
 
-      const finalMessage = await stream.finalMessage();
+      const finalMessage = await stream!.finalMessage();
       totalPromptTokens += finalMessage.usage.input_tokens;
       totalOutputTokens += finalMessage.usage.output_tokens;
       lastContentBlocks = finalMessage.content;

--- a/tests/unit/anthropic-stream-retry.test.ts
+++ b/tests/unit/anthropic-stream-retry.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import Anthropic from "@anthropic-ai/sdk";
+
+/**
+ * Inline the isRetryableAnthropicError logic from src/index.ts for unit testing.
+ * Mirrors the actual implementation.
+ */
+function isRetryableAnthropicError(err: unknown): boolean {
+  if (!(err instanceof Anthropic.APIError)) return false;
+  const errorBody = err.error as { type?: string; error?: { type?: string } } | undefined;
+  if (errorBody?.error?.type === "overloaded_error") return true;
+  if (typeof err.status === "number" && [429, 500, 503, 529].includes(err.status)) return true;
+  return false;
+}
+
+describe("isRetryableAnthropicError", () => {
+  it("returns true for overloaded_error with undefined status (streaming SSE error)", () => {
+    // During streaming, the SDK calls `new APIError(undefined, parsedBody, undefined, headers)` directly.
+    // This is the exact shape from the production logs.
+    const err = new Anthropic.APIError(
+      undefined,
+      {
+        type: "error",
+        error: { details: null, type: "overloaded_error", message: "Overloaded" },
+      },
+      undefined,
+      new Headers(),
+    );
+    expect(err.status).toBeUndefined();
+    expect(isRetryableAnthropicError(err)).toBe(true);
+  });
+
+  it("returns true for 429 rate limit error", () => {
+    const err = Anthropic.APIError.generate(
+      429,
+      { type: "error", error: { type: "rate_limit_error", message: "Rate limited" } },
+      "Rate limited",
+      new Headers(),
+    );
+    expect(isRetryableAnthropicError(err)).toBe(true);
+  });
+
+  it("returns true for 500 internal server error", () => {
+    const err = Anthropic.APIError.generate(
+      500,
+      { type: "error", error: { type: "api_error", message: "Internal error" } },
+      "Internal error",
+      new Headers(),
+    );
+    expect(isRetryableAnthropicError(err)).toBe(true);
+  });
+
+  it("returns true for 503 service unavailable", () => {
+    const err = Anthropic.APIError.generate(
+      503,
+      { type: "error", error: { type: "api_error", message: "Unavailable" } },
+      "Unavailable",
+      new Headers(),
+    );
+    expect(isRetryableAnthropicError(err)).toBe(true);
+  });
+
+  it("returns true for 529 overloaded", () => {
+    const err = Anthropic.APIError.generate(
+      529,
+      { type: "error", error: { type: "overloaded_error", message: "Overloaded" } },
+      "Overloaded",
+      new Headers(),
+    );
+    expect(isRetryableAnthropicError(err)).toBe(true);
+  });
+
+  it("returns false for 400 bad request", () => {
+    const err = Anthropic.APIError.generate(
+      400,
+      { type: "error", error: { type: "invalid_request_error", message: "Bad request" } },
+      "Bad request",
+      new Headers(),
+    );
+    expect(isRetryableAnthropicError(err)).toBe(false);
+  });
+
+  it("returns false for 401 authentication error", () => {
+    const err = Anthropic.APIError.generate(
+      401,
+      { type: "error", error: { type: "authentication_error", message: "Invalid key" } },
+      "Invalid key",
+      new Headers(),
+    );
+    expect(isRetryableAnthropicError(err)).toBe(false);
+  });
+
+  it("returns false for non-Anthropic errors", () => {
+    expect(isRetryableAnthropicError(new Error("random error"))).toBe(false);
+    expect(isRetryableAnthropicError("string error")).toBe(false);
+    expect(isRetryableAnthropicError(null)).toBe(false);
+    expect(isRetryableAnthropicError(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds retry logic (up to 2 retries with exponential backoff) for Anthropic streaming when the API returns `overloaded_error`, 429, or 5xx errors
- Only retries when no tokens have been emitted to the client yet — safe since the client hasn't received any partial response
- Mirrors the existing Gemini retry strategy but adapted for streaming (shorter retry count, no model fallback)

## Test plan
- [x] Unit tests for `isRetryableAnthropicError` covering overloaded, 429, 500, 503, 529, and non-retryable errors (400, 401, generic errors)
- [x] All 433 existing tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)