### PR TITLE
feat: SSE error codes + retry-after support

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,11 +406,19 @@ If the org has insufficient credits, the endpoint returns a **402 JSON response*
 If billing-service is unreachable, a **502 JSON response** is returned instead.
 
 ### 7. Error (optional)
-Sent when the AI model returns an empty response (context overflow, safety filter) or an unexpected error occurs:
+Sent when the AI model returns an empty response, is overloaded, or an unexpected error occurs:
 ```
-data: {"type":"error","message":"The AI model returned an empty response. This may happen when the conversation is too long or the message content triggers a safety filter."}
+data: {"type":"error","code":"model_overloaded","message":"Claude is temporarily overloaded. Please try again in a moment."}
 ```
-The frontend should display the `message` to the user. An `error` event is always followed by `[DONE]`.
+
+| `code` | Meaning | Suggested UX |
+|--------|---------|-------------|
+| `model_overloaded` | Claude is temporarily at capacity (retries exhausted) | Show message + "Retry" button |
+| `rate_limited` | Too many requests | Show message + auto-retry after delay |
+| `model_error` | Transient upstream error (empty response, 5xx) | Show message + "Retry" button |
+| `internal_error` | Unexpected server error | Show message |
+
+The frontend should display the `message` to the user and use `code` to decide whether to offer a retry action. An `error` event is always followed by `[DONE]`.
 
 ### 8. Done
 ```

--- a/openapi.json
+++ b/openapi.json
@@ -249,14 +249,26 @@
               "error"
             ]
           },
+          "code": {
+            "type": "string",
+            "enum": [
+              "model_overloaded",
+              "rate_limited",
+              "model_error",
+              "internal_error"
+            ],
+            "description": "Machine-readable error code. `model_overloaded` — Claude is temporarily at capacity (retry after a moment). `rate_limited` — too many requests (respect retry-after). `model_error` — transient upstream error. `internal_error` — unexpected server error.",
+            "example": "model_overloaded"
+          },
           "message": {
             "type": "string",
             "description": "Human-readable error message explaining what went wrong",
-            "example": "The AI model returned an empty response. This may happen when the conversation is too long or the message content triggers a safety filter."
+            "example": "Claude is temporarily overloaded. Please try again in a moment."
           }
         },
         "required": [
           "type",
+          "code",
           "message"
         ]
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,53 @@ function isRetryableAnthropicError(err: unknown): boolean {
   return false;
 }
 
+/**
+ * Extract retry-after delay from an Anthropic error's response headers.
+ * Returns the delay in ms, or null if the header is missing.
+ */
+function getRetryAfterMs(err: unknown): number | null {
+  if (!(err instanceof Anthropic.APIError)) return null;
+  const headers = err.headers as Headers | undefined;
+  if (!headers) return null;
+  const retryAfter = headers.get("retry-after");
+  if (!retryAfter) return null;
+  const seconds = Number(retryAfter);
+  return Number.isFinite(seconds) && seconds > 0 ? seconds * 1000 : null;
+}
+
+/**
+ * Classify an error for the SSE error event sent to the client.
+ * Returns a user-facing message and an error code the frontend can act on.
+ */
+function classifyErrorForClient(err: unknown): { message: string; code: string } {
+  if (err instanceof Anthropic.APIError) {
+    const errorBody = err.error as { type?: string; error?: { type?: string } } | undefined;
+    const errorType = errorBody?.error?.type;
+    if (errorType === "overloaded_error" || err.status === 529) {
+      return {
+        code: "model_overloaded",
+        message: "Claude is temporarily overloaded. Please try again in a moment.",
+      };
+    }
+    if (err.status === 429) {
+      return {
+        code: "rate_limited",
+        message: "Too many requests. Please wait a moment and try again.",
+      };
+    }
+    if (typeof err.status === "number" && err.status >= 500) {
+      return {
+        code: "model_error",
+        message: "Claude encountered a temporary error. Please try again.",
+      };
+    }
+  }
+  return {
+    code: "internal_error",
+    message: "An unexpected error occurred. Please try again.",
+  };
+}
+
 // ---------------------------------------------------------------------------
 // JSON parsing for LLM responses
 // ---------------------------------------------------------------------------
@@ -688,6 +735,7 @@ app.post("/chat", requireAuth, async (req, res) => {
       console.error(`[chat] session="${currentSessionId}" run creation failed:`, runErr);
       sendSSE(res, {
         type: "error",
+        code: "internal_error",
         message: "Service temporarily unavailable (run tracking). Please try again.",
       });
       sendSSE(res, "[DONE]");
@@ -1314,7 +1362,8 @@ app.post("/chat", requireAuth, async (req, res) => {
             isRetryableAnthropicError(streamErr) &&
             attempt < ANTHROPIC_STREAM_MAX_RETRIES
           ) {
-            const delay = ANTHROPIC_STREAM_RETRY_BASE_MS * 2 ** attempt + Math.random() * 500;
+            const retryAfter = getRetryAfterMs(streamErr);
+            const delay = retryAfter ?? (ANTHROPIC_STREAM_RETRY_BASE_MS * 2 ** attempt + Math.random() * 500);
             console.warn(
               `[chat] Anthropic stream retry ${attempt + 1}/${ANTHROPIC_STREAM_MAX_RETRIES} ` +
                 `after ${Math.round(delay)}ms | session="${currentSessionId}" org="${orgId}" | ` +
@@ -1440,6 +1489,7 @@ app.post("/chat", requireAuth, async (req, res) => {
       );
       sendSSE(res, {
         type: "error",
+        code: "model_error",
         message:
           "The AI model returned an empty response. This may happen when the conversation " +
           "is too long or the message content triggers a safety filter. Please try shortening " +
@@ -1475,10 +1525,12 @@ app.post("/chat", requireAuth, async (req, res) => {
     sendSSE(res, "[DONE]");
   } catch (err) {
     chatFailed = true;
-    console.error(`[chat] org="${orgId}" unhandled error:`, err);
+    const { message: errorMessage, code: errorCode } = classifyErrorForClient(err);
+    console.error(`[chat] org="${orgId}" error code="${errorCode}":`, err);
     sendSSE(res, {
       type: "error",
-      message: "An unexpected error occurred. Please try again.",
+      code: errorCode,
+      message: errorMessage,
     });
     sendSSE(res, "[DONE]");
   } finally {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -713,11 +713,21 @@ const SSEButtonsEventSchema = z
 const SSEErrorEventSchema = z
   .object({
     type: z.literal("error"),
+    code: z
+      .enum(["model_overloaded", "rate_limited", "model_error", "internal_error"])
+      .openapi({
+        description:
+          "Machine-readable error code. `model_overloaded` — Claude is temporarily at capacity (retry after a moment). " +
+          "`rate_limited` — too many requests (respect retry-after). " +
+          "`model_error` — transient upstream error. " +
+          "`internal_error` — unexpected server error.",
+        example: "model_overloaded",
+      }),
     message: z.string().openapi({
       description:
         "Human-readable error message explaining what went wrong",
       example:
-        "The AI model returned an empty response. This may happen when the conversation is too long or the message content triggers a safety filter.",
+        "Claude is temporarily overloaded. Please try again in a moment.",
     }),
   })
   .openapi("SSEErrorEvent");

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,7 @@ export interface SSEInputRequestEvent {
 
 export interface SSEErrorEvent {
   type: "error";
+  code: string;
   message: string;
 }
 

--- a/tests/unit/anthropic-stream-retry.test.ts
+++ b/tests/unit/anthropic-stream-retry.test.ts
@@ -13,10 +13,53 @@ function isRetryableAnthropicError(err: unknown): boolean {
   return false;
 }
 
+/**
+ * Inline getRetryAfterMs from src/index.ts.
+ */
+function getRetryAfterMs(err: unknown): number | null {
+  if (!(err instanceof Anthropic.APIError)) return null;
+  const headers = err.headers as Headers | undefined;
+  if (!headers) return null;
+  const retryAfter = headers.get("retry-after");
+  if (!retryAfter) return null;
+  const seconds = Number(retryAfter);
+  return Number.isFinite(seconds) && seconds > 0 ? seconds * 1000 : null;
+}
+
+/**
+ * Inline classifyErrorForClient from src/index.ts.
+ */
+function classifyErrorForClient(err: unknown): { message: string; code: string } {
+  if (err instanceof Anthropic.APIError) {
+    const errorBody = err.error as { type?: string; error?: { type?: string } } | undefined;
+    const errorType = errorBody?.error?.type;
+    if (errorType === "overloaded_error" || err.status === 529) {
+      return {
+        code: "model_overloaded",
+        message: "Claude is temporarily overloaded. Please try again in a moment.",
+      };
+    }
+    if (err.status === 429) {
+      return {
+        code: "rate_limited",
+        message: "Too many requests. Please wait a moment and try again.",
+      };
+    }
+    if (typeof err.status === "number" && err.status >= 500) {
+      return {
+        code: "model_error",
+        message: "Claude encountered a temporary error. Please try again.",
+      };
+    }
+  }
+  return {
+    code: "internal_error",
+    message: "An unexpected error occurred. Please try again.",
+  };
+}
+
 describe("isRetryableAnthropicError", () => {
   it("returns true for overloaded_error with undefined status (streaming SSE error)", () => {
-    // During streaming, the SDK calls `new APIError(undefined, parsedBody, undefined, headers)` directly.
-    // This is the exact shape from the production logs.
     const err = new Anthropic.APIError(
       undefined,
       {
@@ -95,5 +138,110 @@ describe("isRetryableAnthropicError", () => {
     expect(isRetryableAnthropicError("string error")).toBe(false);
     expect(isRetryableAnthropicError(null)).toBe(false);
     expect(isRetryableAnthropicError(undefined)).toBe(false);
+  });
+});
+
+describe("getRetryAfterMs", () => {
+  it("parses retry-after header in seconds and converts to ms", () => {
+    const headers = new Headers({ "retry-after": "5" });
+    const err = new Anthropic.APIError(429, {}, "Rate limited", headers);
+    expect(getRetryAfterMs(err)).toBe(5000);
+  });
+
+  it("returns null when header is missing", () => {
+    const err = new Anthropic.APIError(429, {}, "Rate limited", new Headers());
+    expect(getRetryAfterMs(err)).toBeNull();
+  });
+
+  it("returns null for non-numeric header value", () => {
+    const headers = new Headers({ "retry-after": "not-a-number" });
+    const err = new Anthropic.APIError(429, {}, "Rate limited", headers);
+    expect(getRetryAfterMs(err)).toBeNull();
+  });
+
+  it("returns null for zero or negative values", () => {
+    const headers = new Headers({ "retry-after": "0" });
+    const err = new Anthropic.APIError(429, {}, "Rate limited", headers);
+    expect(getRetryAfterMs(err)).toBeNull();
+
+    const headers2 = new Headers({ "retry-after": "-1" });
+    const err2 = new Anthropic.APIError(429, {}, "Rate limited", headers2);
+    expect(getRetryAfterMs(err2)).toBeNull();
+  });
+
+  it("returns null for non-Anthropic errors", () => {
+    expect(getRetryAfterMs(new Error("random"))).toBeNull();
+  });
+
+  it("returns null when error has no headers", () => {
+    // Streaming errors: new APIError(undefined, body, undefined, headers)
+    // but headers could theoretically be undefined
+    const err = new Anthropic.APIError(undefined, {}, undefined, undefined as unknown as Headers);
+    expect(getRetryAfterMs(err)).toBeNull();
+  });
+});
+
+describe("classifyErrorForClient", () => {
+  it("returns model_overloaded for streaming overloaded_error", () => {
+    const err = new Anthropic.APIError(
+      undefined,
+      { type: "error", error: { type: "overloaded_error", message: "Overloaded" } },
+      undefined,
+      new Headers(),
+    );
+    const result = classifyErrorForClient(err);
+    expect(result.code).toBe("model_overloaded");
+    expect(result.message).toContain("overloaded");
+  });
+
+  it("returns model_overloaded for HTTP 529", () => {
+    const err = Anthropic.APIError.generate(
+      529,
+      { type: "error", error: { type: "overloaded_error", message: "Overloaded" } },
+      "Overloaded",
+      new Headers(),
+    );
+    const result = classifyErrorForClient(err);
+    expect(result.code).toBe("model_overloaded");
+  });
+
+  it("returns rate_limited for 429", () => {
+    const err = Anthropic.APIError.generate(
+      429,
+      { type: "error", error: { type: "rate_limit_error", message: "Rate limited" } },
+      "Rate limited",
+      new Headers(),
+    );
+    const result = classifyErrorForClient(err);
+    expect(result.code).toBe("rate_limited");
+    expect(result.message).toContain("Too many requests");
+  });
+
+  it("returns model_error for 500", () => {
+    const err = Anthropic.APIError.generate(
+      500,
+      { type: "error", error: { type: "api_error", message: "Internal" } },
+      "Internal",
+      new Headers(),
+    );
+    const result = classifyErrorForClient(err);
+    expect(result.code).toBe("model_error");
+  });
+
+  it("returns internal_error for non-Anthropic errors", () => {
+    const result = classifyErrorForClient(new Error("something broke"));
+    expect(result.code).toBe("internal_error");
+    expect(result.message).toContain("unexpected");
+  });
+
+  it("returns internal_error for 400 bad request (not retryable)", () => {
+    const err = Anthropic.APIError.generate(
+      400,
+      { type: "error", error: { type: "invalid_request_error", message: "Bad" } },
+      "Bad",
+      new Headers(),
+    );
+    const result = classifyErrorForClient(err);
+    expect(result.code).toBe("internal_error");
   });
 });


### PR DESCRIPTION
## Summary
- SSE error events now include a `code` field (`model_overloaded`, `rate_limited`, `model_error`, `internal_error`) so the frontend can show contextual UX (retry button, specific messages)
- Retry logic now respects the Anthropic `retry-after` header when present, instead of always using fixed exponential backoff
- User-facing error messages are specific: "Claude is temporarily overloaded" instead of generic "An unexpected error occurred"
- Updated OpenAPI schema, types, and README SSE protocol docs

## Test plan
- [x] 12 new unit tests for `classifyErrorForClient` and `getRetryAfterMs`
- [x] All 445 existing tests pass
- [x] Build + OpenAPI generation succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)