### PR TITLE
fix: increase integration test timeout for Neon cold starts

### DIFF
--- a/tests/integration/db.test.ts
+++ b/tests/integration/db.test.ts
@@ -6,7 +6,7 @@ import * as schema from "../../src/db/schema.js";
 
 const connectionString = process.env.CHAT_SERVICE_DATABASE_URL;
 
-describe("database integration", () => {
+describe("database integration", { timeout: 15000 }, () => {
   let client: ReturnType<typeof postgres>;
   let db: ReturnType<typeof drizzle<typeof schema>>;
 


### PR DESCRIPTION
## Summary
- The `should create, read, and delete a session` integration test was timing out at the default 5000ms due to Neon database cold start latency
- Increased the `db.test.ts` suite timeout to 15s to accommodate cold starts

## Test plan
- [x] CI integration tests should pass consistently
- [x] No functional changes — only test timeout adjustment

🤖 Generated with [Claude Code](https://claude.com/claude-code)