### PR TITLE
feat: add browse_url tool for arbitrary URL content

### DIFF
--- a/.github/workflows/neon-cleanup.yml
+++ b/.github/workflows/neon-cleanup.yml
@@ -8,9 +8,21 @@ jobs:
   delete-neon-branch:
     runs-on: ubuntu-latest
     steps:
-      - name: Delete Neon branch
-        uses: neondatabase/delete-branch-action@v3
+      - uses: actions/setup-node@v4
         with:
-          project_id: ${{ vars.NEON_PROJECT_ID }}
-          branch: pr-${{ github.event.number }}
-          api_key: ${{ secrets.NEON_API_KEY }}
+          node-version: 20
+
+      - name: Install neonctl
+        run: npm i -g neonctl@v2
+
+      - name: Delete Neon branch (if exists)
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+        run: |
+          BRANCH="pr-${{ github.event.number }}"
+          if neonctl branches get "$BRANCH" --project-id ${{ vars.NEON_PROJECT_ID }} 2>/dev/null; then
+            neonctl branches delete "$BRANCH" --project-id ${{ vars.NEON_PROJECT_ID }}
+            echo "Deleted Neon branch $BRANCH"
+          else
+            echo "Neon branch $BRANCH does not exist — skipping"
+          fi

--- a/.github/workflows/test-check.yml
+++ b/.github/workflows/test-check.yml
@@ -2,7 +2,7 @@ name: Test Coverage Check
 
 on:
   pull_request:
-    branches: [main, dev]
+    branches: [main, staging, dev]
 
 jobs:
   check-tests:

--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ The tools available in each chat session are determined by the `allowedTools` ar
 |---|---|
 | `update_campaign_fields` | Passthrough tool — returns `{ fields }` so the frontend can apply values to the campaign form |
 | `extract_brand_fields` | Extracts arbitrary fields from a brand's website via brand-service AI (cached 30 days) |
+| `browse_url` | Fetches and returns the content of any public URL as markdown (via scraping-service/firecrawl). Read-only. |
 
 **UI tools:**
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Response:
 ```
 
 - `content` — raw text response (always present). **Warning:** when `responseFormat: "json"`, this field may contain markdown code fences (e.g. `` ```json...``` ``). Do **not** use this field for JSON parsing.
-- `json` — parsed JSON object (present when `responseFormat: "json"`). **Always use this field** for structured data — markdown fences are already stripped and the JSON is pre-parsed. If the model returns non-parsable JSON, the endpoint returns **502** instead of silently omitting this field.
+- `json` — parsed JSON object (present when `responseFormat: "json"`). **Always use this field** for structured data. The service applies a 3-stage repair pipeline: (1) direct `JSON.parse`, (2) algorithmic repair via `jsonrepair` (handles fences, trailing commas, missing quotes, truncation, etc.), (3) LLM-assisted repair — the same model that produced the output is asked to fix the JSON structure (up to 3 rounds, using parse error diagnostics). If all stages fail, the endpoint returns **502**.
 - `tokensInput` / `tokensOutput` — token usage
 - `model` — the versioned model ID that was actually used (resolved from the provider + alias)
 

--- a/openapi.json
+++ b/openapi.json
@@ -370,7 +370,7 @@
               "minLength": 1
             },
             "minItems": 1,
-            "description": "List of tool names the LLM is allowed to use in this chat mode. Only these tools will be provided to the model and executable server-side. Available tools: request_user_input, update_workflow, validate_workflow, get_workflow_details, generate_workflow, get_workflow_required_providers, list_workflows, update_workflow_node_config, get_prompt_template, update_prompt_template, list_services, list_service_endpoints, list_org_keys, get_key_source, list_key_sources, check_provider_requirements, create_feature, update_feature, list_features, get_feature, get_feature_inputs, prefill_feature, get_feature_stats, update_campaign_fields, extract_brand_fields",
+            "description": "List of tool names the LLM is allowed to use in this chat mode. Only these tools will be provided to the model and executable server-side. Available tools: request_user_input, update_workflow, validate_workflow, get_workflow_details, generate_workflow, get_workflow_required_providers, list_workflows, update_workflow_node_config, get_prompt_template, update_prompt_template, list_services, list_service_endpoints, list_org_keys, get_key_source, list_key_sources, check_provider_requirements, create_feature, update_feature, list_features, get_feature, get_feature_inputs, prefill_feature, get_feature_stats, update_campaign_fields, extract_brand_fields, browse_url",
             "example": [
               "request_user_input",
               "update_workflow",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "cors": "^2.8.5",
         "drizzle-orm": "^0.38.0",
         "express": "^4.21.0",
+        "jsonrepair": "^3.13.3",
         "postgres": "^3.4.0",
         "zod": "^4.3.6"
       },
@@ -2467,6 +2468,15 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/jsonrepair": {
+      "version": "3.13.3",
+      "resolved": "https://registry.npmjs.org/jsonrepair/-/jsonrepair-3.13.3.tgz",
+      "integrity": "sha512-BTznj0owIt2CBAH/LTo7+1I5pMvl1e1033LRl/HUowlZmJOIhzC0zbX5bxMngLkfT4WnzPP26QnW5wMr2g9tsQ==",
+      "license": "ISC",
+      "bin": {
+        "jsonrepair": "bin/cli.js"
       }
     },
     "node_modules/loupe": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "cors": "^2.8.5",
     "drizzle-orm": "^0.38.0",
     "express": "^4.21.0",
+    "jsonrepair": "^3.13.3",
     "postgres": "^3.4.0",
     "zod": "^4.3.6"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import crypto from "crypto";
 import { readFileSync, existsSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
+import { jsonrepair, JSONRepairError } from "jsonrepair";
 import { db } from "./db/index.js";
 import { sessions, messages, appConfigs, platformConfigs } from "./db/schema.js";
 import { eq, and } from "drizzle-orm";
@@ -132,19 +133,75 @@ function classifyErrorForClient(err: unknown): { message: string; code: string }
 // JSON parsing for LLM responses
 // ---------------------------------------------------------------------------
 
-/** Remove trailing commas before ] and } — a common LLM output quirk. */
-function removeTrailingCommas(s: string): string {
-  return s.replace(/,\s*([\]}])/g, "$1");
+/** Context needed to call the same model for LLM-assisted JSON repair. */
+interface JsonRepairContext {
+  apiKey: string;
+  model: string;
+  isGemini: boolean;
+}
+
+const LLM_REPAIR_MAX_ROUNDS = 3;
+
+/** Extract a ±200-char window around a character position for diagnostics. */
+function snippetAround(text: string, pos: number, radius = 200): string {
+  const start = Math.max(0, pos - radius);
+  const end = Math.min(text.length, pos + radius);
+  return (
+    (start > 0 ? "..." : "") +
+    text.slice(start, end) +
+    (end < text.length ? "..." : "")
+  );
+}
+
+/**
+ * Ask the same model that produced the broken JSON to repair it.
+ * Sends the full broken output + the parse error diagnostic and asks
+ * for a minimal structural fix. Returns the raw LLM response text.
+ */
+async function llmRepairJson(
+  broken: string,
+  errorMessage: string,
+  ctx: JsonRepairContext,
+): Promise<string> {
+  const repairPrompt =
+    `The following JSON is structurally broken. A JSON parser returned this error:\n\n` +
+    `${errorMessage}\n\n` +
+    `Here is the broken JSON:\n\`\`\`\n${broken}\n\`\`\`\n\n` +
+    `Return ONLY the corrected JSON. Make minimal structural edits to fix the syntax ` +
+    `(missing brackets, quotes, commas, truncation, etc.). Do NOT change any field names or values — ` +
+    `only fix the structure so it parses as valid JSON.`;
+
+  const systemPrompt =
+    "You are a JSON repair tool. You receive broken JSON and return ONLY the fixed JSON. " +
+    "No explanations, no markdown fences, no extra text.";
+
+  if (ctx.isGemini) {
+    const result = await completeWithGemini({
+      apiKey: ctx.apiKey,
+      model: ctx.model,
+      message: repairPrompt,
+      systemPrompt,
+      responseFormat: "json",
+    });
+    return result.content;
+  } else {
+    const claude = createAnthropicClient({ apiKey: ctx.apiKey, systemPrompt });
+    const result = await claude.complete(repairPrompt, {
+      responseFormat: "json",
+      model: ctx.model,
+    });
+    return result.content;
+  }
 }
 
 /**
  * Parse JSON from model output with progressive repair:
  * 1. Try raw JSON.parse
- * 2. Strip markdown code fences and retry
- * 3. Remove trailing commas and retry
+ * 2. Try jsonrepair (handles fences, trailing commas, missing quotes, truncation, etc.)
+ * 3. LLM-assisted repair — send broken JSON + jsonrepair diagnostics to the same model (up to 3 rounds)
  * Throws with diagnostics if all attempts fail.
  */
-function parseModelJson(raw: string): unknown {
+async function parseModelJson(raw: string, repairCtx?: JsonRepairContext): Promise<unknown> {
   const trimmed = raw.trim();
 
   // Attempt 1: direct parse
@@ -152,22 +209,85 @@ function parseModelJson(raw: string): unknown {
     return JSON.parse(trimmed);
   } catch { /* continue */ }
 
-  // Attempt 2: strip markdown fences
-  const stripped = trimmed
-    .replace(/^```(?:json)?\s*\n?/i, "")
-    .replace(/\n?```\s*$/i, "")
-    .trim();
+  // Attempt 2: jsonrepair — handles fences, trailing commas, missing quotes,
+  // truncated JSON, single quotes, comments, and many more LLM quirks
+  let repairError: JSONRepairError | undefined;
   try {
-    return JSON.parse(stripped);
-  } catch { /* continue */ }
-
-  // Attempt 3: remove trailing commas (LLMs often produce these)
-  const repaired = removeTrailingCommas(stripped);
-  try {
+    const repaired = jsonrepair(trimmed);
     const parsed = JSON.parse(repaired);
-    console.warn(`[chat-service] JSON required trailing-comma repair (contentLen=${raw.length})`);
+    console.warn(`[chat-service] JSON required jsonrepair (contentLen=${raw.length})`);
     return parsed;
-  } catch { /* continue */ }
+  } catch (err) {
+    if (err instanceof JSONRepairError) {
+      repairError = err;
+    }
+    // continue to LLM repair
+  }
+
+  // Attempt 3: LLM-assisted repair (up to 3 rounds)
+  if (repairCtx) {
+    let current = trimmed;
+    for (let round = 1; round <= LLM_REPAIR_MAX_ROUNDS; round++) {
+      // Build diagnostic from jsonrepair error or JSON.parse error
+      let diagnostic: string;
+      try {
+        JSON.parse(current);
+        // If somehow it parses now, return it (shouldn't happen but be safe)
+        return JSON.parse(current);
+      } catch (parseErr) {
+        const parseError = parseErr as SyntaxError & { message: string };
+        // Extract position from JSON.parse error (e.g. "at position 1847")
+        const posMatch = parseError.message.match(/position\s+(\d+)/);
+        const pos = posMatch ? parseInt(posMatch[1], 10) : undefined;
+
+        diagnostic = `JSON.parse error: ${parseError.message}`;
+        if (pos != null) {
+          diagnostic += `\nContext around position ${pos}:\n${snippetAround(current, pos)}`;
+        }
+        if (repairError && round === 1) {
+          diagnostic += `\njsonrepair also failed: ${repairError.message}`;
+        }
+      }
+
+      console.warn(
+        `[chat-service] LLM JSON repair round ${round}/${LLM_REPAIR_MAX_ROUNDS} (contentLen=${current.length})`,
+      );
+
+      try {
+        const repaired = await llmRepairJson(current, diagnostic, repairCtx);
+        const repairedTrimmed = repaired.trim();
+
+        // Try direct parse first
+        try {
+          const parsed = JSON.parse(repairedTrimmed);
+          console.warn(
+            `[chat-service] LLM JSON repair succeeded on round ${round} (contentLen=${raw.length})`,
+          );
+          return parsed;
+        } catch { /* continue */ }
+
+        // Try jsonrepair on the LLM output too
+        try {
+          const doubleRepaired = jsonrepair(repairedTrimmed);
+          const parsed = JSON.parse(doubleRepaired);
+          console.warn(
+            `[chat-service] LLM JSON repair + jsonrepair succeeded on round ${round} (contentLen=${raw.length})`,
+          );
+          return parsed;
+        } catch { /* continue */ }
+
+        // Feed this round's output into the next round
+        current = repairedTrimmed;
+      } catch (llmErr) {
+        console.error(
+          `[chat-service] LLM JSON repair round ${round} call failed:`,
+          llmErr,
+        );
+        // Don't retry if the LLM call itself failed — likely a transient issue
+        break;
+      }
+    }
+  }
 
   throw new Error(
     `Model returned non-parsable JSON despite responseFormat: "json". ` +
@@ -461,7 +581,11 @@ app.post("/complete", requireAuth, async (req, res) => {
 
     // Parse JSON if requested
     if (responseFormat === "json") {
-      response.json = parseModelJson(result.content);
+      response.json = await parseModelJson(result.content, {
+        apiKey: resolvedKey.key,
+        model: effectiveModel,
+        isGemini,
+      });
     }
 
     res.json(response);
@@ -558,7 +682,11 @@ app.post("/internal/platform-complete", requireInternalAuth, async (req, res) =>
     };
 
     if (responseFormat === "json") {
-      response.json = parseModelJson(result.content);
+      response.json = await parseModelJson(result.content, {
+        apiKey,
+        model: effectiveModel,
+        isGemini,
+      });
     }
 
     res.json(response);

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ import { listServices, listServiceEndpoints } from "./lib/api-registry-client.js
 import { createRun, updateRunStatus, addRunCosts } from "./lib/runs-client.js";
 import { createFeature, updateFeature, listFeatures, getFeature, getFeatureInputs, prefillFeature, getFeatureStats } from "./lib/features-client.js";
 import { extractBrandFields } from "./lib/brand-client.js";
+import { scrapeUrl } from "./lib/scraping-client.js";
 import { formatToolError } from "./lib/tool-errors.js";
 import {
   resolveKey,
@@ -1398,6 +1399,16 @@ app.post("/chat", requireAuth, async (req, res) => {
         const args = (call.args as Record<string, unknown>) || {};
         const result = await extractBrandFields(
           args.fields as Array<{ key: string; description: string }>,
+          featureCallParams,
+        );
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
+      if (call.name === "browse_url") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const result = await scrapeUrl(
+          args.url as string,
           featureCallParams,
         );
         toolCalls.push({ name: call.name, args, result });

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -869,6 +869,22 @@ export const EXTRACT_BRAND_FIELDS_TOOL: Anthropic.Tool = {
   },
 };
 
+export const BROWSE_URL_TOOL: Anthropic.Tool = {
+  name: "browse_url",
+  description:
+    "Fetch and read the content of any public URL. Returns the page text as markdown, plus the meta description. Use this to visit competitor pages, reference articles, product pages, or any URL the user mentions. Read-only — does not modify anything.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      url: {
+        type: "string",
+        description: "The URL to visit and read (must be a valid http or https URL).",
+      },
+    },
+    required: ["url"],
+  },
+};
+
 // ---------------------------------------------------------------------------
 // Tool registry — every tool the service knows how to execute.
 // Clients choose which subset to enable via allowedTools in their config.
@@ -900,6 +916,7 @@ export const TOOL_REGISTRY: Record<string, Anthropic.Tool> = {
   get_feature_stats: GET_FEATURE_STATS_TOOL,
   update_campaign_fields: UPDATE_CAMPAIGN_FIELDS_TOOL,
   extract_brand_fields: EXTRACT_BRAND_FIELDS_TOOL,
+  browse_url: BROWSE_URL_TOOL,
 };
 
 /** All tool names available for use in allowedTools config. */

--- a/src/lib/scraping-client.ts
+++ b/src/lib/scraping-client.ts
@@ -1,0 +1,51 @@
+import { apiServiceFetch, type ApiCallParams } from "./api-client.js";
+
+export type ScrapingCallParams = ApiCallParams;
+
+// ---------------------------------------------------------------------------
+// POST /v1/scraping/scrape  (via api-service proxy to scraping-service)
+// ---------------------------------------------------------------------------
+
+export interface ScrapeResult {
+  url: string;
+  description: string | null;
+  rawMarkdown: string | null;
+}
+
+export async function scrapeUrl(
+  url: string,
+  params: ScrapingCallParams,
+): Promise<ScrapeResult> {
+  const res = await apiServiceFetch(
+    `/v1/scraping/scrape`,
+    "POST",
+    params,
+    {
+      url,
+      provider: "firecrawl",
+      options: {
+        formats: ["markdown"],
+        onlyMainContent: true,
+      },
+    },
+  );
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "unknown error");
+    throw new Error(`[scraping-client] scrape failed (${res.status}): ${text}`);
+  }
+
+  const data = (await res.json()) as {
+    result: {
+      url: string;
+      description: string | null;
+      rawMarkdown: string | null;
+    };
+  };
+
+  return {
+    url: data.result.url,
+    description: data.result.description,
+    rawMarkdown: data.result.rawMarkdown,
+  };
+}

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -121,7 +121,7 @@ export const AppConfigRequestSchema = z
         "list_org_keys, get_key_source, list_key_sources, check_provider_requirements, " +
         "create_feature, update_feature, list_features, get_feature, get_feature_inputs, " +
         "prefill_feature, get_feature_stats, " +
-        "update_campaign_fields, extract_brand_fields",
+        "update_campaign_fields, extract_brand_fields, browse_url",
       example: [
         "request_user_input",
         "update_workflow",

--- a/tests/integration/db.test.ts
+++ b/tests/integration/db.test.ts
@@ -6,7 +6,7 @@ import * as schema from "../../src/db/schema.js";
 
 const connectionString = process.env.CHAT_SERVICE_DATABASE_URL;
 
-describe("database integration", () => {
+describe("database integration", { timeout: 15000 }, () => {
   let client: ReturnType<typeof postgres>;
   let db: ReturnType<typeof drizzle<typeof schema>>;
 

--- a/tests/integration/db.test.ts
+++ b/tests/integration/db.test.ts
@@ -141,41 +141,54 @@ describe("database integration", () => {
       .where(eq(schema.sessions.id, session.id));
   });
 
-  it("should create and upsert app_configs by orgId", async () => {
+  it("should create and upsert app_configs by orgId + key", async () => {
     // Insert
     const [config] = await db
       .insert(schema.appConfigs)
       .values({
         orgId: "test-org-config",
+        key: "test-key",
         systemPrompt: "You are a test assistant.",
+        allowedTools: ["search"],
       })
       .returning();
 
     expect(config.orgId).toBe("test-org-config");
+    expect(config.key).toBe("test-key");
     expect(config.systemPrompt).toBe("You are a test assistant.");
+    expect(config.allowedTools).toEqual(["search"]);
 
-    // Upsert (update on conflict by orgId)
+    // Upsert (update on conflict by orgId + key)
     const [updated] = await db
       .insert(schema.appConfigs)
       .values({
         orgId: "test-org-config",
+        key: "test-key",
         systemPrompt: "Updated prompt.",
+        allowedTools: ["search", "browse"],
       })
       .onConflictDoUpdate({
-        target: [schema.appConfigs.orgId],
+        target: [schema.appConfigs.orgId, schema.appConfigs.key],
         set: {
           systemPrompt: "Updated prompt.",
+          allowedTools: ["search", "browse"],
           updatedAt: new Date(),
         },
       })
       .returning();
 
     expect(updated.systemPrompt).toBe("Updated prompt.");
+    expect(updated.allowedTools).toEqual(["search", "browse"]);
     expect(updated.id).toBe(config.id); // Same row
 
     // Cleanup
     await db
       .delete(schema.appConfigs)
-      .where(eq(schema.appConfigs.orgId, "test-org-config"));
+      .where(
+        and(
+          eq(schema.appConfigs.orgId, "test-org-config"),
+          eq(schema.appConfigs.key, "test-key"),
+        ),
+      );
   });
 });

--- a/tests/unit/json-markdown-strip.test.ts
+++ b/tests/unit/json-markdown-strip.test.ts
@@ -1,138 +1,333 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+import { jsonrepair, JSONRepairError } from "jsonrepair";
 
 // ---------------------------------------------------------------------------
 // Mirrors parseModelJson from src/index.ts — progressive JSON repair for LLM output
 // ---------------------------------------------------------------------------
 
-function removeTrailingCommas(s: string): string {
-  return s.replace(/,\s*([\]}])/g, "$1");
+interface JsonRepairContext {
+  apiKey: string;
+  model: string;
+  isGemini: boolean;
 }
 
-function parseModelJson(raw: string): unknown {
+const LLM_REPAIR_MAX_ROUNDS = 3;
+
+function snippetAround(text: string, pos: number, radius = 200): string {
+  const start = Math.max(0, pos - radius);
+  const end = Math.min(text.length, pos + radius);
+  return (
+    (start > 0 ? "..." : "") +
+    text.slice(start, end) +
+    (end < text.length ? "..." : "")
+  );
+}
+
+/**
+ * Minimal mock-friendly version: accepts an async llmRepairFn instead of
+ * calling the real Gemini/Anthropic clients. The production code uses the
+ * same logic but calls the real LLM; tests inject a fake.
+ */
+async function parseModelJson(
+  raw: string,
+  repairCtx?: JsonRepairContext,
+  llmRepairFn?: (broken: string, diag: string) => Promise<string>,
+): Promise<unknown> {
   const trimmed = raw.trim();
 
+  // Attempt 1: direct parse
   try {
     return JSON.parse(trimmed);
   } catch { /* continue */ }
 
-  const stripped = trimmed
-    .replace(/^```(?:json)?\s*\n?/i, "")
-    .replace(/\n?```\s*$/i, "")
-    .trim();
+  // Attempt 2: jsonrepair
+  let repairError: JSONRepairError | undefined;
   try {
-    return JSON.parse(stripped);
-  } catch { /* continue */ }
-
-  const repaired = removeTrailingCommas(stripped);
-  try {
+    const repaired = jsonrepair(trimmed);
     return JSON.parse(repaired);
-  } catch { /* continue */ }
+  } catch (err) {
+    if (err instanceof JSONRepairError) {
+      repairError = err;
+    }
+  }
+
+  // Attempt 3: LLM-assisted repair (up to 3 rounds)
+  if (repairCtx && llmRepairFn) {
+    let current = trimmed;
+    for (let round = 1; round <= LLM_REPAIR_MAX_ROUNDS; round++) {
+      let diagnostic: string;
+      try {
+        return JSON.parse(current);
+      } catch (parseErr) {
+        const parseError = parseErr as SyntaxError & { message: string };
+        const posMatch = parseError.message.match(/position\s+(\d+)/);
+        const pos = posMatch ? parseInt(posMatch[1], 10) : undefined;
+        diagnostic = `JSON.parse error: ${parseError.message}`;
+        if (pos != null) {
+          diagnostic += `\nContext around position ${pos}:\n${snippetAround(current, pos)}`;
+        }
+        if (repairError && round === 1) {
+          diagnostic += `\njsonrepair also failed: ${repairError.message}`;
+        }
+      }
+
+      try {
+        const repaired = await llmRepairFn(current, diagnostic);
+        const repairedTrimmed = repaired.trim();
+
+        try {
+          return JSON.parse(repairedTrimmed);
+        } catch { /* continue */ }
+
+        try {
+          const doubleRepaired = jsonrepair(repairedTrimmed);
+          return JSON.parse(doubleRepaired);
+        } catch { /* continue */ }
+
+        current = repairedTrimmed;
+      } catch {
+        break;
+      }
+    }
+  }
 
   throw new Error(
     `Model returned non-parsable JSON despite responseFormat: "json". ` +
     `contentLen=${raw.length}, ` +
     `first500=${raw.slice(0, 500)}, ` +
-    `last200=${raw.slice(-200)}`
+    `last200=${raw.slice(-200)}`,
   );
 }
 
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
 describe("parseModelJson — JSON parsing with progressive repair", () => {
-  // --- Direct parse ---
-  it("parses plain JSON object", () => {
-    expect(parseModelJson('{"key": "value"}')).toEqual({ key: "value" });
+  // --- Attempt 1: Direct parse ---
+  it("parses plain JSON object", async () => {
+    expect(await parseModelJson('{"key": "value"}')).toEqual({ key: "value" });
   });
 
-  it("parses plain JSON array", () => {
-    expect(parseModelJson('[1, 2, 3]')).toEqual([1, 2, 3]);
+  it("parses plain JSON array", async () => {
+    expect(await parseModelJson('[1, 2, 3]')).toEqual([1, 2, 3]);
   });
 
-  it("handles leading/trailing whitespace", () => {
-    expect(parseModelJson('  \n{"key": "value"}\n  ')).toEqual({ key: "value" });
+  it("handles leading/trailing whitespace", async () => {
+    expect(await parseModelJson('  \n{"key": "value"}\n  ')).toEqual({ key: "value" });
   });
 
-  // --- Markdown fence stripping ---
-  it("strips ```json fences and parses", () => {
+  // --- Attempt 2: jsonrepair ---
+  it("strips ```json fences and parses", async () => {
     const content = '```json\n{"key": "value"}\n```';
-    expect(parseModelJson(content)).toEqual({ key: "value" });
+    expect(await parseModelJson(content)).toEqual({ key: "value" });
   });
 
-  it("strips ``` fences without json tag", () => {
+  it("strips ``` fences without json tag", async () => {
     const content = '```\n{"key": "value"}\n```';
-    expect(parseModelJson(content)).toEqual({ key: "value" });
+    expect(await parseModelJson(content)).toEqual({ key: "value" });
   });
 
-  it("strips ```JSON fences (case-insensitive)", () => {
+  it("strips ```JSON fences (case-insensitive)", async () => {
     const content = '```JSON\n{"items": [1, 2, 3]}\n```';
-    expect(parseModelJson(content)).toEqual({ items: [1, 2, 3] });
+    expect(await parseModelJson(content)).toEqual({ items: [1, 2, 3] });
   });
 
-  it("handles array responses wrapped in fences", () => {
+  it("handles array responses wrapped in fences", async () => {
     const content = '```json\n[{"id": 1}, {"id": 2}]\n```';
-    expect(parseModelJson(content)).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(await parseModelJson(content)).toEqual([{ id: 1 }, { id: 2 }]);
   });
 
-  it("handles fences with no trailing newline", () => {
+  it("handles fences with no trailing newline", async () => {
     const content = '```json\n{"ok": true}```';
-    expect(parseModelJson(content)).toEqual({ ok: true });
+    expect(await parseModelJson(content)).toEqual({ ok: true });
   });
 
-  it("handles leading/trailing whitespace around fences", () => {
+  it("handles leading/trailing whitespace around fences", async () => {
     const content = '\n```json\n{"isArticle": false, "authors": [], "publishedAt": null}\n```\n';
-    expect(parseModelJson(content)).toEqual({ isArticle: false, authors: [], publishedAt: null });
+    expect(await parseModelJson(content)).toEqual({ isArticle: false, authors: [], publishedAt: null });
   });
 
-  it("handles whitespace inside fences around JSON", () => {
+  it("handles whitespace inside fences around JSON", async () => {
     const content = '```json\n\n  {"key": "value"}\n\n```';
-    expect(parseModelJson(content)).toEqual({ key: "value" });
+    expect(await parseModelJson(content)).toEqual({ key: "value" });
   });
 
-  it("handles \\r\\n line endings", () => {
+  it("handles \\r\\n line endings", async () => {
     const content = '```json\r\n{"key": "value"}\r\n```';
-    expect(parseModelJson(content)).toEqual({ key: "value" });
+    expect(await parseModelJson(content)).toEqual({ key: "value" });
   });
 
-  // --- Trailing comma repair ---
-  it("repairs trailing comma in object", () => {
-    expect(parseModelJson('{"a": 1, "b": 2,}')).toEqual({ a: 1, b: 2 });
+  it("repairs trailing comma in object", async () => {
+    expect(await parseModelJson('{"a": 1, "b": 2,}')).toEqual({ a: 1, b: 2 });
   });
 
-  it("repairs trailing comma in array", () => {
-    expect(parseModelJson('["url1", "url2", "url3",]')).toEqual(["url1", "url2", "url3"]);
+  it("repairs trailing comma in array", async () => {
+    expect(await parseModelJson('["url1", "url2", "url3",]')).toEqual(["url1", "url2", "url3"]);
   });
 
-  it("repairs trailing comma with whitespace", () => {
+  it("repairs trailing comma with whitespace", async () => {
     const content = '[\n  "https://example.com/a",\n  "https://example.com/b",\n]';
-    expect(parseModelJson(content)).toEqual(["https://example.com/a", "https://example.com/b"]);
+    expect(await parseModelJson(content)).toEqual(["https://example.com/a", "https://example.com/b"]);
   });
 
-  it("repairs trailing comma inside fenced JSON", () => {
+  it("repairs trailing comma inside fenced JSON", async () => {
     const content = '```json\n{"items": [1, 2, 3,],}\n```';
-    expect(parseModelJson(content)).toEqual({ items: [1, 2, 3] });
+    expect(await parseModelJson(content)).toEqual({ items: [1, 2, 3] });
   });
 
-  it("repairs nested trailing commas", () => {
+  it("repairs nested trailing commas", async () => {
     const content = '{"a": {"b": [1, 2,], "c": 3,},}';
-    expect(parseModelJson(content)).toEqual({ a: { b: [1, 2], c: 3 } });
+    expect(await parseModelJson(content)).toEqual({ a: { b: [1, 2], c: 3 } });
   });
 
-  // --- Error cases ---
-  it("throws for truly unparsable content", () => {
-    expect(() => parseModelJson("This is not JSON at all")).toThrow(
+  // --- jsonrepair-specific: things the old manual repair couldn't handle ---
+  it("repairs single quotes to double quotes", async () => {
+    expect(await parseModelJson("{'key': 'value'}")).toEqual({ key: "value" });
+  });
+
+  it("repairs unquoted keys", async () => {
+    expect(await parseModelJson("{key: \"value\"}")).toEqual({ key: "value" });
+  });
+
+  it("repairs missing closing bracket", async () => {
+    expect(await parseModelJson('{"key": "value"')).toEqual({ key: "value" });
+  });
+
+  it("strips JavaScript comments", async () => {
+    const content = '{"key": "value" /* comment */}';
+    expect(await parseModelJson(content)).toEqual({ key: "value" });
+  });
+
+  // --- Error cases (no LLM repair context) ---
+  // jsonrepair treats bare text as a valid JSON string, so we use text
+  // surrounding JSON — the kind of thing LLMs actually produce — to trigger failure.
+  const UNPARSABLE = 'Here is your JSON: {"key": "value"}. I hope this helps!';
+
+  it("throws for truly unparsable content without repairCtx", async () => {
+    await expect(parseModelJson(UNPARSABLE)).rejects.toThrow(
       "Model returned non-parsable JSON",
     );
   });
 
-  it("throws for fenced non-JSON content", () => {
-    const content = '```json\nnot actually json\n```';
-    expect(() => parseModelJson(content)).toThrow(
-      "Model returned non-parsable JSON",
-    );
+  it("includes contentLen and preview in error", async () => {
+    await expect(parseModelJson(UNPARSABLE)).rejects.toThrow(/contentLen=\d+/);
+    await expect(parseModelJson(UNPARSABLE)).rejects.toThrow(/first500=/);
+    await expect(parseModelJson(UNPARSABLE)).rejects.toThrow(/last200=/);
+  });
+});
+
+describe("parseModelJson — LLM-assisted repair", () => {
+  const ctx: JsonRepairContext = { apiKey: "test-key", model: "test-model", isGemini: true };
+  // Inputs that defeat both JSON.parse AND jsonrepair (text wrapping JSON)
+  const BROKEN = 'Here is your JSON: {"key": "value"}. I hope this helps!';
+  const BROKEN2 = 'Sure! Here is the result: {"a": 1}. Let me know if you need more.';
+  const BROKEN3 = 'The output is: {"x": true}. Please review it carefully.';
+
+  it("calls LLM when jsonrepair fails, succeeds on first round", async () => {
+    const llmRepairFn = vi.fn().mockResolvedValueOnce('{"key": "value"}');
+
+    const result = await parseModelJson(BROKEN, ctx, llmRepairFn);
+    expect(result).toEqual({ key: "value" });
+    expect(llmRepairFn).toHaveBeenCalledTimes(1);
+    // Verify diagnostic is passed
+    expect(llmRepairFn.mock.calls[0][1]).toContain("JSON.parse error:");
   });
 
-  it("includes contentLen and preview in error", () => {
-    const content = "broken json content here";
-    expect(() => parseModelJson(content)).toThrow(/contentLen=\d+/);
-    expect(() => parseModelJson(content)).toThrow(/first500=/);
-    expect(() => parseModelJson(content)).toThrow(/last200=/);
+  it("retries when first LLM round still returns broken JSON", async () => {
+    const llmRepairFn = vi
+      .fn()
+      .mockResolvedValueOnce(BROKEN2)
+      .mockResolvedValueOnce('{"fixed": true}');
+
+    const result = await parseModelJson(BROKEN, ctx, llmRepairFn);
+    expect(result).toEqual({ fixed: true });
+    expect(llmRepairFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("succeeds on third round", async () => {
+    const llmRepairFn = vi
+      .fn()
+      .mockResolvedValueOnce(BROKEN2)
+      .mockResolvedValueOnce(BROKEN3)
+      .mockResolvedValueOnce('{"ok": true}');
+
+    const result = await parseModelJson(BROKEN, ctx, llmRepairFn);
+    expect(result).toEqual({ ok: true });
+    expect(llmRepairFn).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws after 3 failed LLM rounds", async () => {
+    const llmRepairFn = vi
+      .fn()
+      .mockResolvedValueOnce(BROKEN)
+      .mockResolvedValueOnce(BROKEN2)
+      .mockResolvedValueOnce(BROKEN3);
+
+    await expect(parseModelJson(BROKEN, ctx, llmRepairFn)).rejects.toThrow(
+      "Model returned non-parsable JSON",
+    );
+    expect(llmRepairFn).toHaveBeenCalledTimes(3);
+  });
+
+  it("stops retrying if LLM call itself throws", async () => {
+    const llmRepairFn = vi.fn().mockRejectedValueOnce(new Error("API error"));
+
+    await expect(parseModelJson(BROKEN, ctx, llmRepairFn)).rejects.toThrow(
+      "Model returned non-parsable JSON",
+    );
+    expect(llmRepairFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies jsonrepair to LLM output as fallback", async () => {
+    // LLM returns something with trailing commas — jsonrepair can fix it
+    const llmRepairFn = vi.fn().mockResolvedValueOnce('{"a": 1, "b": 2,}');
+
+    const result = await parseModelJson(BROKEN, ctx, llmRepairFn);
+    expect(result).toEqual({ a: 1, b: 2 });
+    expect(llmRepairFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call LLM when repairCtx is not provided", async () => {
+    await expect(parseModelJson(BROKEN)).rejects.toThrow("Model returned non-parsable JSON");
+  });
+
+  it("includes jsonrepair error in diagnostic on first round", async () => {
+    const llmRepairFn = vi.fn().mockResolvedValueOnce('{"ok": true}');
+
+    await parseModelJson(BROKEN, ctx, llmRepairFn);
+    const diagnostic = llmRepairFn.mock.calls[0][1] as string;
+    expect(diagnostic).toContain("jsonrepair also failed:");
+  });
+});
+
+describe("snippetAround", () => {
+  it("returns full text if shorter than 2*radius", () => {
+    const text = '{"short": "text"}';
+    const result = snippetAround(text, 5, 200);
+    expect(result).toBe(text);
+  });
+
+  it("adds ellipsis for text exceeding radius", () => {
+    const text = "A".repeat(600);
+    const result = snippetAround(text, 300, 50);
+    expect(result.startsWith("...")).toBe(true);
+    expect(result.endsWith("...")).toBe(true);
+    // 100 chars from the text + 6 chars for "..." on each side
+    expect(result.length).toBe(106);
+  });
+
+  it("no leading ellipsis when position is near start", () => {
+    const text = "A".repeat(600);
+    const result = snippetAround(text, 10, 50);
+    expect(result.startsWith("...")).toBe(false);
+    expect(result.endsWith("...")).toBe(true);
+  });
+
+  it("no trailing ellipsis when position is near end", () => {
+    const text = "A".repeat(600);
+    const result = snippetAround(text, 590, 50);
+    expect(result.startsWith("...")).toBe(true);
+    expect(result.endsWith("...")).toBe(false);
   });
 });

--- a/tests/unit/scraping-client.test.ts
+++ b/tests/unit/scraping-client.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  process.env.ADMIN_DISTRIBUTE_API_KEY = "test-api-svc-key";
+  process.env.API_SERVICE_URL = "https://api.test.local";
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.restoreAllMocks();
+});
+
+async function loadModule() {
+  vi.resetModules();
+  return import("../../src/lib/scraping-client.js");
+}
+
+const baseParams = {
+  orgId: "org-1",
+  userId: "user-1",
+  runId: "run-1",
+};
+
+describe("scrapeUrl", () => {
+  it("calls POST /v1/scraping/scrape with firecrawl provider and onlyMainContent", async () => {
+    const mockResponse = {
+      cached: false,
+      provider: "firecrawl",
+      result: {
+        url: "https://example.com",
+        description: "Example page",
+        rawMarkdown: "# Hello World\nSome content here.",
+      },
+    };
+
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    });
+
+    const { scrapeUrl } = await loadModule();
+    const result = await scrapeUrl("https://example.com", baseParams);
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.test.local/v1/scraping/scrape",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "x-org-id": "org-1",
+          "x-user-id": "user-1",
+          "x-run-id": "run-1",
+        }),
+        body: JSON.stringify({
+          url: "https://example.com",
+          provider: "firecrawl",
+          options: {
+            formats: ["markdown"],
+            onlyMainContent: true,
+          },
+        }),
+      }),
+    );
+
+    expect(result).toEqual({
+      url: "https://example.com",
+      description: "Example page",
+      rawMarkdown: "# Hello World\nSome content here.",
+    });
+  });
+
+  it("returns only url, description, and rawMarkdown from the response", async () => {
+    const mockResponse = {
+      cached: true,
+      provider: "firecrawl",
+      requestId: "req-123",
+      result: {
+        id: "scrape-id-1",
+        url: "https://example.com/page",
+        companyName: "Example Corp",
+        description: "A test page",
+        industry: "Tech",
+        rawMarkdown: "# Page Content",
+        createdAt: "2026-01-01T00:00:00Z",
+      },
+    };
+
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    });
+
+    const { scrapeUrl } = await loadModule();
+    const result = await scrapeUrl("https://example.com/page", baseParams);
+
+    // Should only include the three fields we care about
+    expect(Object.keys(result)).toEqual(["url", "description", "rawMarkdown"]);
+    expect(result.url).toBe("https://example.com/page");
+    expect(result.description).toBe("A test page");
+    expect(result.rawMarkdown).toBe("# Page Content");
+  });
+
+  it("throws on non-OK response", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("Internal error"),
+    });
+
+    const { scrapeUrl } = await loadModule();
+
+    await expect(
+      scrapeUrl("https://example.com", baseParams),
+    ).rejects.toThrow("[scraping-client] scrape failed (500)");
+  });
+
+  it("forwards tracking headers", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        result: { url: "https://example.com", description: null, rawMarkdown: null },
+      }),
+    });
+
+    const { scrapeUrl } = await loadModule();
+    await scrapeUrl("https://example.com", {
+      ...baseParams,
+      trackingHeaders: { "x-campaign-id": "camp-1", "x-brand-id": "b-1" },
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-campaign-id": "camp-1",
+          "x-brand-id": "b-1",
+        }),
+      }),
+    );
+  });
+});

--- a/tests/unit/tool-registry.test.ts
+++ b/tests/unit/tool-registry.test.ts
@@ -9,6 +9,7 @@ describe("TOOL_REGISTRY", () => {
     expect(AVAILABLE_TOOL_NAMES).toContain("list_services");
     expect(AVAILABLE_TOOL_NAMES).toContain("update_campaign_fields");
     expect(AVAILABLE_TOOL_NAMES).toContain("extract_brand_fields");
+    expect(AVAILABLE_TOOL_NAMES).toContain("browse_url");
     expect(AVAILABLE_TOOL_NAMES).not.toContain("extract_brand_text");
   });
 


### PR DESCRIPTION
## Summary
- Adds a new `browse_url` tool that fetches and returns the content of any public URL as markdown
- Uses the existing `POST /v1/scraping/scrape` endpoint (firecrawl provider, `onlyMainContent: true`)
- Returns a trimmed response (`url`, `description`, `rawMarkdown`) to keep LLM context lean
- Read-only — no mutations

## Files changed
- `src/lib/scraping-client.ts` — new client wrapping api-service scraping proxy
- `src/lib/anthropic.ts` — `BROWSE_URL_TOOL` definition + registry entry
- `src/index.ts` — execution handler in the tool dispatch chain
- `src/schemas.ts` — updated allowedTools docs to include `browse_url`
- `openapi.json` — regenerated
- `README.md` — added `browse_url` to the campaign-prefill tools table
- `tests/unit/scraping-client.test.ts` — new test file (4 tests)
- `tests/unit/tool-registry.test.ts` — added `browse_url` to registry assertions

## Next steps (dashboard)
Add `browse_url` to `allowedTools` in the campaign-prefill config on the dashboard side.

## Test plan
- [x] `npm run test:unit` — all new tests pass
- [x] `npm run build` — clean TypeScript compilation
- [ ] Deploy to staging and test via campaign-prefill chat with a URL request

🤖 Generated with [Claude Code](https://claude.com/claude-code)