### PR TITLE
fix: instruct LLM to return plain JSON object, never array-wrapped

### DIFF
--- a/.github/workflows/neon-cleanup.yml
+++ b/.github/workflows/neon-cleanup.yml
@@ -8,9 +8,21 @@ jobs:
   delete-neon-branch:
     runs-on: ubuntu-latest
     steps:
-      - name: Delete Neon branch
-        uses: neondatabase/delete-branch-action@v3
+      - uses: actions/setup-node@v4
         with:
-          project_id: ${{ vars.NEON_PROJECT_ID }}
-          branch: pr-${{ github.event.number }}
-          api_key: ${{ secrets.NEON_API_KEY }}
+          node-version: 20
+
+      - name: Install neonctl
+        run: npm i -g neonctl@v2
+
+      - name: Delete Neon branch (if exists)
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+        run: |
+          BRANCH="pr-${{ github.event.number }}"
+          if neonctl branches get "$BRANCH" --project-id ${{ vars.NEON_PROJECT_ID }} 2>/dev/null; then
+            neonctl branches delete "$BRANCH" --project-id ${{ vars.NEON_PROJECT_ID }}
+            echo "Deleted Neon branch $BRANCH"
+          else
+            echo "Neon branch $BRANCH does not exist — skipping"
+          fi

--- a/.github/workflows/test-check.yml
+++ b/.github/workflows/test-check.yml
@@ -2,7 +2,7 @@ name: Test Coverage Check
 
 on:
   pull_request:
-    branches: [main, dev]
+    branches: [main, staging, dev]
 
 jobs:
   check-tests:

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Response:
 ```
 
 - `content` — raw text response (always present). **Warning:** when `responseFormat: "json"`, this field may contain markdown code fences (e.g. `` ```json...``` ``). Do **not** use this field for JSON parsing.
-- `json` — parsed JSON object (present when `responseFormat: "json"`). **Always use this field** for structured data — markdown fences are already stripped and the JSON is pre-parsed. If the model returns non-parsable JSON, the endpoint returns **502** instead of silently omitting this field.
+- `json` — parsed JSON object (present when `responseFormat: "json"`). **Always use this field** for structured data. The service applies a 3-stage repair pipeline: (1) direct `JSON.parse`, (2) algorithmic repair via `jsonrepair` (handles fences, trailing commas, missing quotes, truncation, etc.), (3) LLM-assisted repair — the same model that produced the output is asked to fix the JSON structure (up to 3 rounds, using parse error diagnostics). If all stages fail, the endpoint returns **502**.
 - `tokensInput` / `tokensOutput` — token usage
 - `model` — the versioned model ID that was actually used (resolved from the provider + alias)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "cors": "^2.8.5",
         "drizzle-orm": "^0.38.0",
         "express": "^4.21.0",
+        "jsonrepair": "^3.13.3",
         "postgres": "^3.4.0",
         "zod": "^4.3.6"
       },
@@ -2467,6 +2468,15 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/jsonrepair": {
+      "version": "3.13.3",
+      "resolved": "https://registry.npmjs.org/jsonrepair/-/jsonrepair-3.13.3.tgz",
+      "integrity": "sha512-BTznj0owIt2CBAH/LTo7+1I5pMvl1e1033LRl/HUowlZmJOIhzC0zbX5bxMngLkfT4WnzPP26QnW5wMr2g9tsQ==",
+      "license": "ISC",
+      "bin": {
+        "jsonrepair": "bin/cli.js"
       }
     },
     "node_modules/loupe": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "cors": "^2.8.5",
     "drizzle-orm": "^0.38.0",
     "express": "^4.21.0",
+    "jsonrepair": "^3.13.3",
     "postgres": "^3.4.0",
     "zod": "^4.3.6"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import crypto from "crypto";
 import { readFileSync, existsSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
+import { jsonrepair, JSONRepairError } from "jsonrepair";
 import { db } from "./db/index.js";
 import { sessions, messages, appConfigs, platformConfigs } from "./db/schema.js";
 import { eq, and } from "drizzle-orm";
@@ -132,19 +133,75 @@ function classifyErrorForClient(err: unknown): { message: string; code: string }
 // JSON parsing for LLM responses
 // ---------------------------------------------------------------------------
 
-/** Remove trailing commas before ] and } — a common LLM output quirk. */
-function removeTrailingCommas(s: string): string {
-  return s.replace(/,\s*([\]}])/g, "$1");
+/** Context needed to call the same model for LLM-assisted JSON repair. */
+interface JsonRepairContext {
+  apiKey: string;
+  model: string;
+  isGemini: boolean;
+}
+
+const LLM_REPAIR_MAX_ROUNDS = 3;
+
+/** Extract a ±200-char window around a character position for diagnostics. */
+function snippetAround(text: string, pos: number, radius = 200): string {
+  const start = Math.max(0, pos - radius);
+  const end = Math.min(text.length, pos + radius);
+  return (
+    (start > 0 ? "..." : "") +
+    text.slice(start, end) +
+    (end < text.length ? "..." : "")
+  );
+}
+
+/**
+ * Ask the same model that produced the broken JSON to repair it.
+ * Sends the full broken output + the parse error diagnostic and asks
+ * for a minimal structural fix. Returns the raw LLM response text.
+ */
+async function llmRepairJson(
+  broken: string,
+  errorMessage: string,
+  ctx: JsonRepairContext,
+): Promise<string> {
+  const repairPrompt =
+    `The following JSON is structurally broken. A JSON parser returned this error:\n\n` +
+    `${errorMessage}\n\n` +
+    `Here is the broken JSON:\n\`\`\`\n${broken}\n\`\`\`\n\n` +
+    `Return ONLY the corrected JSON. Make minimal structural edits to fix the syntax ` +
+    `(missing brackets, quotes, commas, truncation, etc.). Do NOT change any field names or values — ` +
+    `only fix the structure so it parses as valid JSON.`;
+
+  const systemPrompt =
+    "You are a JSON repair tool. You receive broken JSON and return ONLY the fixed JSON. " +
+    "No explanations, no markdown fences, no extra text.";
+
+  if (ctx.isGemini) {
+    const result = await completeWithGemini({
+      apiKey: ctx.apiKey,
+      model: ctx.model,
+      message: repairPrompt,
+      systemPrompt,
+      responseFormat: "json",
+    });
+    return result.content;
+  } else {
+    const claude = createAnthropicClient({ apiKey: ctx.apiKey, systemPrompt });
+    const result = await claude.complete(repairPrompt, {
+      responseFormat: "json",
+      model: ctx.model,
+    });
+    return result.content;
+  }
 }
 
 /**
  * Parse JSON from model output with progressive repair:
  * 1. Try raw JSON.parse
- * 2. Strip markdown code fences and retry
- * 3. Remove trailing commas and retry
+ * 2. Try jsonrepair (handles fences, trailing commas, missing quotes, truncation, etc.)
+ * 3. LLM-assisted repair — send broken JSON + jsonrepair diagnostics to the same model (up to 3 rounds)
  * Throws with diagnostics if all attempts fail.
  */
-function parseModelJson(raw: string): unknown {
+async function parseModelJson(raw: string, repairCtx?: JsonRepairContext): Promise<unknown> {
   const trimmed = raw.trim();
 
   // Attempt 1: direct parse
@@ -152,22 +209,85 @@ function parseModelJson(raw: string): unknown {
     return JSON.parse(trimmed);
   } catch { /* continue */ }
 
-  // Attempt 2: strip markdown fences
-  const stripped = trimmed
-    .replace(/^```(?:json)?\s*\n?/i, "")
-    .replace(/\n?```\s*$/i, "")
-    .trim();
+  // Attempt 2: jsonrepair — handles fences, trailing commas, missing quotes,
+  // truncated JSON, single quotes, comments, and many more LLM quirks
+  let repairError: JSONRepairError | undefined;
   try {
-    return JSON.parse(stripped);
-  } catch { /* continue */ }
-
-  // Attempt 3: remove trailing commas (LLMs often produce these)
-  const repaired = removeTrailingCommas(stripped);
-  try {
+    const repaired = jsonrepair(trimmed);
     const parsed = JSON.parse(repaired);
-    console.warn(`[chat-service] JSON required trailing-comma repair (contentLen=${raw.length})`);
+    console.warn(`[chat-service] JSON required jsonrepair (contentLen=${raw.length})`);
     return parsed;
-  } catch { /* continue */ }
+  } catch (err) {
+    if (err instanceof JSONRepairError) {
+      repairError = err;
+    }
+    // continue to LLM repair
+  }
+
+  // Attempt 3: LLM-assisted repair (up to 3 rounds)
+  if (repairCtx) {
+    let current = trimmed;
+    for (let round = 1; round <= LLM_REPAIR_MAX_ROUNDS; round++) {
+      // Build diagnostic from jsonrepair error or JSON.parse error
+      let diagnostic: string;
+      try {
+        JSON.parse(current);
+        // If somehow it parses now, return it (shouldn't happen but be safe)
+        return JSON.parse(current);
+      } catch (parseErr) {
+        const parseError = parseErr as SyntaxError & { message: string };
+        // Extract position from JSON.parse error (e.g. "at position 1847")
+        const posMatch = parseError.message.match(/position\s+(\d+)/);
+        const pos = posMatch ? parseInt(posMatch[1], 10) : undefined;
+
+        diagnostic = `JSON.parse error: ${parseError.message}`;
+        if (pos != null) {
+          diagnostic += `\nContext around position ${pos}:\n${snippetAround(current, pos)}`;
+        }
+        if (repairError && round === 1) {
+          diagnostic += `\njsonrepair also failed: ${repairError.message}`;
+        }
+      }
+
+      console.warn(
+        `[chat-service] LLM JSON repair round ${round}/${LLM_REPAIR_MAX_ROUNDS} (contentLen=${current.length})`,
+      );
+
+      try {
+        const repaired = await llmRepairJson(current, diagnostic, repairCtx);
+        const repairedTrimmed = repaired.trim();
+
+        // Try direct parse first
+        try {
+          const parsed = JSON.parse(repairedTrimmed);
+          console.warn(
+            `[chat-service] LLM JSON repair succeeded on round ${round} (contentLen=${raw.length})`,
+          );
+          return parsed;
+        } catch { /* continue */ }
+
+        // Try jsonrepair on the LLM output too
+        try {
+          const doubleRepaired = jsonrepair(repairedTrimmed);
+          const parsed = JSON.parse(doubleRepaired);
+          console.warn(
+            `[chat-service] LLM JSON repair + jsonrepair succeeded on round ${round} (contentLen=${raw.length})`,
+          );
+          return parsed;
+        } catch { /* continue */ }
+
+        // Feed this round's output into the next round
+        current = repairedTrimmed;
+      } catch (llmErr) {
+        console.error(
+          `[chat-service] LLM JSON repair round ${round} call failed:`,
+          llmErr,
+        );
+        // Don't retry if the LLM call itself failed — likely a transient issue
+        break;
+      }
+    }
+  }
 
   throw new Error(
     `Model returned non-parsable JSON despite responseFormat: "json". ` +
@@ -461,7 +581,11 @@ app.post("/complete", requireAuth, async (req, res) => {
 
     // Parse JSON if requested
     if (responseFormat === "json") {
-      response.json = parseModelJson(result.content);
+      response.json = await parseModelJson(result.content, {
+        apiKey: resolvedKey.key,
+        model: effectiveModel,
+        isGemini,
+      });
     }
 
     res.json(response);
@@ -558,7 +682,11 @@ app.post("/internal/platform-complete", requireInternalAuth, async (req, res) =>
     };
 
     if (responseFormat === "json") {
-      response.json = parseModelJson(result.content);
+      response.json = await parseModelJson(result.content, {
+        apiKey,
+        model: effectiveModel,
+        isGemini,
+      });
     }
 
     res.json(response);

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ import {
 import { authorizeCredits, BillingError } from "./lib/billing-client.js";
 import { getCampaignFeatureInputs } from "./lib/campaign-client.js";
 import { ChatRequestSchema, CompleteRequestSchema, InternalPlatformCompleteRequestSchema, AppConfigRequestSchema, PlatformConfigRequestSchema } from "./schemas.js";
+import { JSON_RESPONSE_SYSTEM_SUFFIX } from "./lib/json-prompt.js";
 import { requireAuth, requireInternalAuth, type AuthLocals } from "./middleware/auth.js";
 import type { ButtonRecord, ToolCallRecord } from "./db/schema.js";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
@@ -542,7 +543,7 @@ app.post("/complete", requireAuth, async (req, res) => {
       effectiveSystemPrompt = buildSystemPrompt(systemPrompt, undefined, campaignFeatureInputs);
     }
     if (responseFormat === "json") {
-      effectiveSystemPrompt += `\n\nIMPORTANT: You MUST respond with valid JSON only. No markdown, no code fences, no extra text — just a single JSON object or array.`;
+      effectiveSystemPrompt += JSON_RESPONSE_SYSTEM_SUFFIX;
     }
 
     let result: { content: string; tokensInput: number; tokensOutput: number; model: string };
@@ -651,7 +652,7 @@ app.post("/internal/platform-complete", requireInternalAuth, async (req, res) =>
   try {
     let effectiveSystemPrompt = systemPrompt;
     if (responseFormat === "json") {
-      effectiveSystemPrompt += `\n\nIMPORTANT: You MUST respond with valid JSON only. No markdown, no code fences, no extra text — just a single JSON object or array.`;
+      effectiveSystemPrompt += JSON_RESPONSE_SYSTEM_SUFFIX;
     }
 
     let result: { content: string; tokensInput: number; tokensOutput: number; model: string };

--- a/src/lib/json-prompt.ts
+++ b/src/lib/json-prompt.ts
@@ -1,0 +1,6 @@
+/**
+ * System prompt suffix appended when responseFormat is "json".
+ * Instructs the LLM to return a plain JSON object — never an array.
+ */
+export const JSON_RESPONSE_SYSTEM_SUFFIX =
+  `\n\nIMPORTANT: You MUST respond with valid JSON only. No markdown, no code fences, no extra text — just a single JSON object. Never wrap the result in an array.`;

--- a/tests/integration/db.test.ts
+++ b/tests/integration/db.test.ts
@@ -6,7 +6,7 @@ import * as schema from "../../src/db/schema.js";
 
 const connectionString = process.env.CHAT_SERVICE_DATABASE_URL;
 
-describe("database integration", () => {
+describe("database integration", { timeout: 15000 }, () => {
   let client: ReturnType<typeof postgres>;
   let db: ReturnType<typeof drizzle<typeof schema>>;
 

--- a/tests/integration/db.test.ts
+++ b/tests/integration/db.test.ts
@@ -141,41 +141,54 @@ describe("database integration", () => {
       .where(eq(schema.sessions.id, session.id));
   });
 
-  it("should create and upsert app_configs by orgId", async () => {
+  it("should create and upsert app_configs by orgId + key", async () => {
     // Insert
     const [config] = await db
       .insert(schema.appConfigs)
       .values({
         orgId: "test-org-config",
+        key: "test-key",
         systemPrompt: "You are a test assistant.",
+        allowedTools: ["search"],
       })
       .returning();
 
     expect(config.orgId).toBe("test-org-config");
+    expect(config.key).toBe("test-key");
     expect(config.systemPrompt).toBe("You are a test assistant.");
+    expect(config.allowedTools).toEqual(["search"]);
 
-    // Upsert (update on conflict by orgId)
+    // Upsert (update on conflict by orgId + key)
     const [updated] = await db
       .insert(schema.appConfigs)
       .values({
         orgId: "test-org-config",
+        key: "test-key",
         systemPrompt: "Updated prompt.",
+        allowedTools: ["search", "browse"],
       })
       .onConflictDoUpdate({
-        target: [schema.appConfigs.orgId],
+        target: [schema.appConfigs.orgId, schema.appConfigs.key],
         set: {
           systemPrompt: "Updated prompt.",
+          allowedTools: ["search", "browse"],
           updatedAt: new Date(),
         },
       })
       .returning();
 
     expect(updated.systemPrompt).toBe("Updated prompt.");
+    expect(updated.allowedTools).toEqual(["search", "browse"]);
     expect(updated.id).toBe(config.id); // Same row
 
     // Cleanup
     await db
       .delete(schema.appConfigs)
-      .where(eq(schema.appConfigs.orgId, "test-org-config"));
+      .where(
+        and(
+          eq(schema.appConfigs.orgId, "test-org-config"),
+          eq(schema.appConfigs.key, "test-key"),
+        ),
+      );
   });
 });

--- a/tests/unit/json-markdown-strip.test.ts
+++ b/tests/unit/json-markdown-strip.test.ts
@@ -1,138 +1,333 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+import { jsonrepair, JSONRepairError } from "jsonrepair";
 
 // ---------------------------------------------------------------------------
 // Mirrors parseModelJson from src/index.ts — progressive JSON repair for LLM output
 // ---------------------------------------------------------------------------
 
-function removeTrailingCommas(s: string): string {
-  return s.replace(/,\s*([\]}])/g, "$1");
+interface JsonRepairContext {
+  apiKey: string;
+  model: string;
+  isGemini: boolean;
 }
 
-function parseModelJson(raw: string): unknown {
+const LLM_REPAIR_MAX_ROUNDS = 3;
+
+function snippetAround(text: string, pos: number, radius = 200): string {
+  const start = Math.max(0, pos - radius);
+  const end = Math.min(text.length, pos + radius);
+  return (
+    (start > 0 ? "..." : "") +
+    text.slice(start, end) +
+    (end < text.length ? "..." : "")
+  );
+}
+
+/**
+ * Minimal mock-friendly version: accepts an async llmRepairFn instead of
+ * calling the real Gemini/Anthropic clients. The production code uses the
+ * same logic but calls the real LLM; tests inject a fake.
+ */
+async function parseModelJson(
+  raw: string,
+  repairCtx?: JsonRepairContext,
+  llmRepairFn?: (broken: string, diag: string) => Promise<string>,
+): Promise<unknown> {
   const trimmed = raw.trim();
 
+  // Attempt 1: direct parse
   try {
     return JSON.parse(trimmed);
   } catch { /* continue */ }
 
-  const stripped = trimmed
-    .replace(/^```(?:json)?\s*\n?/i, "")
-    .replace(/\n?```\s*$/i, "")
-    .trim();
+  // Attempt 2: jsonrepair
+  let repairError: JSONRepairError | undefined;
   try {
-    return JSON.parse(stripped);
-  } catch { /* continue */ }
-
-  const repaired = removeTrailingCommas(stripped);
-  try {
+    const repaired = jsonrepair(trimmed);
     return JSON.parse(repaired);
-  } catch { /* continue */ }
+  } catch (err) {
+    if (err instanceof JSONRepairError) {
+      repairError = err;
+    }
+  }
+
+  // Attempt 3: LLM-assisted repair (up to 3 rounds)
+  if (repairCtx && llmRepairFn) {
+    let current = trimmed;
+    for (let round = 1; round <= LLM_REPAIR_MAX_ROUNDS; round++) {
+      let diagnostic: string;
+      try {
+        return JSON.parse(current);
+      } catch (parseErr) {
+        const parseError = parseErr as SyntaxError & { message: string };
+        const posMatch = parseError.message.match(/position\s+(\d+)/);
+        const pos = posMatch ? parseInt(posMatch[1], 10) : undefined;
+        diagnostic = `JSON.parse error: ${parseError.message}`;
+        if (pos != null) {
+          diagnostic += `\nContext around position ${pos}:\n${snippetAround(current, pos)}`;
+        }
+        if (repairError && round === 1) {
+          diagnostic += `\njsonrepair also failed: ${repairError.message}`;
+        }
+      }
+
+      try {
+        const repaired = await llmRepairFn(current, diagnostic);
+        const repairedTrimmed = repaired.trim();
+
+        try {
+          return JSON.parse(repairedTrimmed);
+        } catch { /* continue */ }
+
+        try {
+          const doubleRepaired = jsonrepair(repairedTrimmed);
+          return JSON.parse(doubleRepaired);
+        } catch { /* continue */ }
+
+        current = repairedTrimmed;
+      } catch {
+        break;
+      }
+    }
+  }
 
   throw new Error(
     `Model returned non-parsable JSON despite responseFormat: "json". ` +
     `contentLen=${raw.length}, ` +
     `first500=${raw.slice(0, 500)}, ` +
-    `last200=${raw.slice(-200)}`
+    `last200=${raw.slice(-200)}`,
   );
 }
 
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
 describe("parseModelJson — JSON parsing with progressive repair", () => {
-  // --- Direct parse ---
-  it("parses plain JSON object", () => {
-    expect(parseModelJson('{"key": "value"}')).toEqual({ key: "value" });
+  // --- Attempt 1: Direct parse ---
+  it("parses plain JSON object", async () => {
+    expect(await parseModelJson('{"key": "value"}')).toEqual({ key: "value" });
   });
 
-  it("parses plain JSON array", () => {
-    expect(parseModelJson('[1, 2, 3]')).toEqual([1, 2, 3]);
+  it("parses plain JSON array", async () => {
+    expect(await parseModelJson('[1, 2, 3]')).toEqual([1, 2, 3]);
   });
 
-  it("handles leading/trailing whitespace", () => {
-    expect(parseModelJson('  \n{"key": "value"}\n  ')).toEqual({ key: "value" });
+  it("handles leading/trailing whitespace", async () => {
+    expect(await parseModelJson('  \n{"key": "value"}\n  ')).toEqual({ key: "value" });
   });
 
-  // --- Markdown fence stripping ---
-  it("strips ```json fences and parses", () => {
+  // --- Attempt 2: jsonrepair ---
+  it("strips ```json fences and parses", async () => {
     const content = '```json\n{"key": "value"}\n```';
-    expect(parseModelJson(content)).toEqual({ key: "value" });
+    expect(await parseModelJson(content)).toEqual({ key: "value" });
   });
 
-  it("strips ``` fences without json tag", () => {
+  it("strips ``` fences without json tag", async () => {
     const content = '```\n{"key": "value"}\n```';
-    expect(parseModelJson(content)).toEqual({ key: "value" });
+    expect(await parseModelJson(content)).toEqual({ key: "value" });
   });
 
-  it("strips ```JSON fences (case-insensitive)", () => {
+  it("strips ```JSON fences (case-insensitive)", async () => {
     const content = '```JSON\n{"items": [1, 2, 3]}\n```';
-    expect(parseModelJson(content)).toEqual({ items: [1, 2, 3] });
+    expect(await parseModelJson(content)).toEqual({ items: [1, 2, 3] });
   });
 
-  it("handles array responses wrapped in fences", () => {
+  it("handles array responses wrapped in fences", async () => {
     const content = '```json\n[{"id": 1}, {"id": 2}]\n```';
-    expect(parseModelJson(content)).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(await parseModelJson(content)).toEqual([{ id: 1 }, { id: 2 }]);
   });
 
-  it("handles fences with no trailing newline", () => {
+  it("handles fences with no trailing newline", async () => {
     const content = '```json\n{"ok": true}```';
-    expect(parseModelJson(content)).toEqual({ ok: true });
+    expect(await parseModelJson(content)).toEqual({ ok: true });
   });
 
-  it("handles leading/trailing whitespace around fences", () => {
+  it("handles leading/trailing whitespace around fences", async () => {
     const content = '\n```json\n{"isArticle": false, "authors": [], "publishedAt": null}\n```\n';
-    expect(parseModelJson(content)).toEqual({ isArticle: false, authors: [], publishedAt: null });
+    expect(await parseModelJson(content)).toEqual({ isArticle: false, authors: [], publishedAt: null });
   });
 
-  it("handles whitespace inside fences around JSON", () => {
+  it("handles whitespace inside fences around JSON", async () => {
     const content = '```json\n\n  {"key": "value"}\n\n```';
-    expect(parseModelJson(content)).toEqual({ key: "value" });
+    expect(await parseModelJson(content)).toEqual({ key: "value" });
   });
 
-  it("handles \\r\\n line endings", () => {
+  it("handles \\r\\n line endings", async () => {
     const content = '```json\r\n{"key": "value"}\r\n```';
-    expect(parseModelJson(content)).toEqual({ key: "value" });
+    expect(await parseModelJson(content)).toEqual({ key: "value" });
   });
 
-  // --- Trailing comma repair ---
-  it("repairs trailing comma in object", () => {
-    expect(parseModelJson('{"a": 1, "b": 2,}')).toEqual({ a: 1, b: 2 });
+  it("repairs trailing comma in object", async () => {
+    expect(await parseModelJson('{"a": 1, "b": 2,}')).toEqual({ a: 1, b: 2 });
   });
 
-  it("repairs trailing comma in array", () => {
-    expect(parseModelJson('["url1", "url2", "url3",]')).toEqual(["url1", "url2", "url3"]);
+  it("repairs trailing comma in array", async () => {
+    expect(await parseModelJson('["url1", "url2", "url3",]')).toEqual(["url1", "url2", "url3"]);
   });
 
-  it("repairs trailing comma with whitespace", () => {
+  it("repairs trailing comma with whitespace", async () => {
     const content = '[\n  "https://example.com/a",\n  "https://example.com/b",\n]';
-    expect(parseModelJson(content)).toEqual(["https://example.com/a", "https://example.com/b"]);
+    expect(await parseModelJson(content)).toEqual(["https://example.com/a", "https://example.com/b"]);
   });
 
-  it("repairs trailing comma inside fenced JSON", () => {
+  it("repairs trailing comma inside fenced JSON", async () => {
     const content = '```json\n{"items": [1, 2, 3,],}\n```';
-    expect(parseModelJson(content)).toEqual({ items: [1, 2, 3] });
+    expect(await parseModelJson(content)).toEqual({ items: [1, 2, 3] });
   });
 
-  it("repairs nested trailing commas", () => {
+  it("repairs nested trailing commas", async () => {
     const content = '{"a": {"b": [1, 2,], "c": 3,},}';
-    expect(parseModelJson(content)).toEqual({ a: { b: [1, 2], c: 3 } });
+    expect(await parseModelJson(content)).toEqual({ a: { b: [1, 2], c: 3 } });
   });
 
-  // --- Error cases ---
-  it("throws for truly unparsable content", () => {
-    expect(() => parseModelJson("This is not JSON at all")).toThrow(
+  // --- jsonrepair-specific: things the old manual repair couldn't handle ---
+  it("repairs single quotes to double quotes", async () => {
+    expect(await parseModelJson("{'key': 'value'}")).toEqual({ key: "value" });
+  });
+
+  it("repairs unquoted keys", async () => {
+    expect(await parseModelJson("{key: \"value\"}")).toEqual({ key: "value" });
+  });
+
+  it("repairs missing closing bracket", async () => {
+    expect(await parseModelJson('{"key": "value"')).toEqual({ key: "value" });
+  });
+
+  it("strips JavaScript comments", async () => {
+    const content = '{"key": "value" /* comment */}';
+    expect(await parseModelJson(content)).toEqual({ key: "value" });
+  });
+
+  // --- Error cases (no LLM repair context) ---
+  // jsonrepair treats bare text as a valid JSON string, so we use text
+  // surrounding JSON — the kind of thing LLMs actually produce — to trigger failure.
+  const UNPARSABLE = 'Here is your JSON: {"key": "value"}. I hope this helps!';
+
+  it("throws for truly unparsable content without repairCtx", async () => {
+    await expect(parseModelJson(UNPARSABLE)).rejects.toThrow(
       "Model returned non-parsable JSON",
     );
   });
 
-  it("throws for fenced non-JSON content", () => {
-    const content = '```json\nnot actually json\n```';
-    expect(() => parseModelJson(content)).toThrow(
-      "Model returned non-parsable JSON",
-    );
+  it("includes contentLen and preview in error", async () => {
+    await expect(parseModelJson(UNPARSABLE)).rejects.toThrow(/contentLen=\d+/);
+    await expect(parseModelJson(UNPARSABLE)).rejects.toThrow(/first500=/);
+    await expect(parseModelJson(UNPARSABLE)).rejects.toThrow(/last200=/);
+  });
+});
+
+describe("parseModelJson — LLM-assisted repair", () => {
+  const ctx: JsonRepairContext = { apiKey: "test-key", model: "test-model", isGemini: true };
+  // Inputs that defeat both JSON.parse AND jsonrepair (text wrapping JSON)
+  const BROKEN = 'Here is your JSON: {"key": "value"}. I hope this helps!';
+  const BROKEN2 = 'Sure! Here is the result: {"a": 1}. Let me know if you need more.';
+  const BROKEN3 = 'The output is: {"x": true}. Please review it carefully.';
+
+  it("calls LLM when jsonrepair fails, succeeds on first round", async () => {
+    const llmRepairFn = vi.fn().mockResolvedValueOnce('{"key": "value"}');
+
+    const result = await parseModelJson(BROKEN, ctx, llmRepairFn);
+    expect(result).toEqual({ key: "value" });
+    expect(llmRepairFn).toHaveBeenCalledTimes(1);
+    // Verify diagnostic is passed
+    expect(llmRepairFn.mock.calls[0][1]).toContain("JSON.parse error:");
   });
 
-  it("includes contentLen and preview in error", () => {
-    const content = "broken json content here";
-    expect(() => parseModelJson(content)).toThrow(/contentLen=\d+/);
-    expect(() => parseModelJson(content)).toThrow(/first500=/);
-    expect(() => parseModelJson(content)).toThrow(/last200=/);
+  it("retries when first LLM round still returns broken JSON", async () => {
+    const llmRepairFn = vi
+      .fn()
+      .mockResolvedValueOnce(BROKEN2)
+      .mockResolvedValueOnce('{"fixed": true}');
+
+    const result = await parseModelJson(BROKEN, ctx, llmRepairFn);
+    expect(result).toEqual({ fixed: true });
+    expect(llmRepairFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("succeeds on third round", async () => {
+    const llmRepairFn = vi
+      .fn()
+      .mockResolvedValueOnce(BROKEN2)
+      .mockResolvedValueOnce(BROKEN3)
+      .mockResolvedValueOnce('{"ok": true}');
+
+    const result = await parseModelJson(BROKEN, ctx, llmRepairFn);
+    expect(result).toEqual({ ok: true });
+    expect(llmRepairFn).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws after 3 failed LLM rounds", async () => {
+    const llmRepairFn = vi
+      .fn()
+      .mockResolvedValueOnce(BROKEN)
+      .mockResolvedValueOnce(BROKEN2)
+      .mockResolvedValueOnce(BROKEN3);
+
+    await expect(parseModelJson(BROKEN, ctx, llmRepairFn)).rejects.toThrow(
+      "Model returned non-parsable JSON",
+    );
+    expect(llmRepairFn).toHaveBeenCalledTimes(3);
+  });
+
+  it("stops retrying if LLM call itself throws", async () => {
+    const llmRepairFn = vi.fn().mockRejectedValueOnce(new Error("API error"));
+
+    await expect(parseModelJson(BROKEN, ctx, llmRepairFn)).rejects.toThrow(
+      "Model returned non-parsable JSON",
+    );
+    expect(llmRepairFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies jsonrepair to LLM output as fallback", async () => {
+    // LLM returns something with trailing commas — jsonrepair can fix it
+    const llmRepairFn = vi.fn().mockResolvedValueOnce('{"a": 1, "b": 2,}');
+
+    const result = await parseModelJson(BROKEN, ctx, llmRepairFn);
+    expect(result).toEqual({ a: 1, b: 2 });
+    expect(llmRepairFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call LLM when repairCtx is not provided", async () => {
+    await expect(parseModelJson(BROKEN)).rejects.toThrow("Model returned non-parsable JSON");
+  });
+
+  it("includes jsonrepair error in diagnostic on first round", async () => {
+    const llmRepairFn = vi.fn().mockResolvedValueOnce('{"ok": true}');
+
+    await parseModelJson(BROKEN, ctx, llmRepairFn);
+    const diagnostic = llmRepairFn.mock.calls[0][1] as string;
+    expect(diagnostic).toContain("jsonrepair also failed:");
+  });
+});
+
+describe("snippetAround", () => {
+  it("returns full text if shorter than 2*radius", () => {
+    const text = '{"short": "text"}';
+    const result = snippetAround(text, 5, 200);
+    expect(result).toBe(text);
+  });
+
+  it("adds ellipsis for text exceeding radius", () => {
+    const text = "A".repeat(600);
+    const result = snippetAround(text, 300, 50);
+    expect(result.startsWith("...")).toBe(true);
+    expect(result.endsWith("...")).toBe(true);
+    // 100 chars from the text + 6 chars for "..." on each side
+    expect(result.length).toBe(106);
+  });
+
+  it("no leading ellipsis when position is near start", () => {
+    const text = "A".repeat(600);
+    const result = snippetAround(text, 10, 50);
+    expect(result.startsWith("...")).toBe(false);
+    expect(result.endsWith("...")).toBe(true);
+  });
+
+  it("no trailing ellipsis when position is near end", () => {
+    const text = "A".repeat(600);
+    const result = snippetAround(text, 590, 50);
+    expect(result.startsWith("...")).toBe(true);
+    expect(result.endsWith("...")).toBe(false);
   });
 });

--- a/tests/unit/json-response-prompt.test.ts
+++ b/tests/unit/json-response-prompt.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from "vitest";
+import { JSON_RESPONSE_SYSTEM_SUFFIX } from "../../src/lib/json-prompt.js";
+
+describe("JSON_RESPONSE_SYSTEM_SUFFIX", () => {
+  it("instructs the model to return a plain object, never an array", () => {
+    expect(JSON_RESPONSE_SYSTEM_SUFFIX).toContain("single JSON object");
+    expect(JSON_RESPONSE_SYSTEM_SUFFIX).toContain("Never wrap the result in an array");
+    expect(JSON_RESPONSE_SYSTEM_SUFFIX).not.toContain("or array");
+  });
+});


### PR DESCRIPTION
## Summary
- When `responseFormat: "json"` is set, the system prompt suffix previously said "just a single JSON object **or array**", which invited Google Flash to wrap results in single-element arrays (e.g. `[{"personTitles": ["CEO"]}]` instead of `{"personTitles": ["CEO"]}`)
- Changed to "just a single JSON object. Never wrap the result in an array."
- Extracted the suffix into `src/lib/json-prompt.ts` as a shared constant used by both `/complete` and `/internal/platform-complete`

## Test plan
- [x] Regression test verifying the prompt says "single JSON object", "Never wrap the result in an array", and does NOT contain "or array"
- [x] All 456 unit tests pass
- [ ] Verify with apollo-service's POST /search/params call that Flash returns unwrapped objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)