### PR TITLE
feat: rename brandId → sourceBrandId + add optional targetBrandId for conflict case

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,13 +244,14 @@ Error responses: 400 (validation), 401 (auth), 502 (upstream failure).
 
 ```json
 {
-  "brandId": "brand-uuid",
+  "sourceBrandId": "brand-aaa-uuid",
   "sourceOrgId": "org-source-uuid",
-  "targetOrgId": "org-target-uuid"
+  "targetOrgId": "org-target-uuid",
+  "targetBrandId": "brand-bbb-uuid"  // optional — when present, rewrites brand reference
 }
 ```
 
-Updates all sessions where `org_id = sourceOrgId` AND `brand_ids` contains exactly one element matching `brandId`. Sessions with multiple brand IDs (co-branding) are skipped.
+Updates all sessions where `org_id = sourceOrgId` AND `brand_ids` contains exactly one element matching `sourceBrandId`. When `targetBrandId` is provided (conflict case — target org already has a brand for this domain), brand references are rewritten to `targetBrandId`. Sessions with multiple brand IDs (co-branding) are skipped.
 
 Response:
 ```json

--- a/openapi.json
+++ b/openapi.json
@@ -744,10 +744,10 @@
       "TransferBrandRequest": {
         "type": "object",
         "properties": {
-          "brandId": {
+          "sourceBrandId": {
             "type": "string",
             "minLength": 1,
-            "description": "The brand UUID to transfer"
+            "description": "The brand UUID to transfer (in the source org)"
           },
           "sourceOrgId": {
             "type": "string",
@@ -758,10 +758,15 @@
             "type": "string",
             "minLength": 1,
             "description": "The org UUID to transfer the brand to"
+          },
+          "targetBrandId": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The brand UUID in the target org to rewrite to. When present (conflict case), brand references are rewritten from sourceBrandId to targetBrandId. When absent, only org_id is updated."
           }
         },
         "required": [
-          "brandId",
+          "sourceBrandId",
           "sourceOrgId",
           "targetOrgId"
         ],
@@ -1409,7 +1414,7 @@
           "Internal"
         ],
         "summary": "Transfer brand ownership between orgs",
-        "description": "Re-assigns all solo-brand sessions from sourceOrgId to targetOrgId. Solo-brand = sessions where brand_ids contains exactly one element matching brandId. Sessions with multiple brand IDs (co-branding) are skipped. Idempotent.",
+        "description": "Re-assigns all solo-brand sessions from sourceOrgId to targetOrgId. Solo-brand = sessions where brand_ids contains exactly one element matching sourceBrandId. When targetBrandId is provided (conflict case), brand references are rewritten to targetBrandId. Sessions with multiple brand IDs (co-branding) are skipped. Idempotent.",
         "parameters": [
           {
             "schema": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1746,20 +1746,28 @@ app.post("/internal/transfer-brand", requireInternalAuth, async (req, res) => {
       .json({ error: "Invalid request", details: parsed.error.flatten() });
   }
 
-  const { brandId, sourceOrgId, targetOrgId } = parsed.data;
+  const { sourceBrandId, sourceOrgId, targetOrgId, targetBrandId } = parsed.data;
 
-  // Find sessions with solo-brand: brand_ids = ARRAY[brandId] (exactly one element)
-  const result = await db.execute(sql`
-    UPDATE sessions
-    SET org_id = ${targetOrgId}, updated_at = NOW()
-    WHERE org_id = ${sourceOrgId}
-      AND brand_ids = ARRAY[${brandId}]::text[]
-  `) as unknown as { rowCount: number };
+  // Find sessions with solo-brand: brand_ids = ARRAY[sourceBrandId] (exactly one element)
+  // When targetBrandId is present (conflict), rewrite brand reference too
+  const result = targetBrandId
+    ? await db.execute(sql`
+        UPDATE sessions
+        SET org_id = ${targetOrgId}, brand_ids = ARRAY[${targetBrandId}]::text[], updated_at = NOW()
+        WHERE org_id = ${sourceOrgId}
+          AND brand_ids = ARRAY[${sourceBrandId}]::text[]
+      `) as unknown as { rowCount: number }
+    : await db.execute(sql`
+        UPDATE sessions
+        SET org_id = ${targetOrgId}, updated_at = NOW()
+        WHERE org_id = ${sourceOrgId}
+          AND brand_ids = ARRAY[${sourceBrandId}]::text[]
+      `) as unknown as { rowCount: number };
 
   const updatedCount = result.rowCount ?? 0;
 
   console.log(
-    `[chat-service] transfer-brand: brandId="${brandId}" from="${sourceOrgId}" to="${targetOrgId}" sessions=${updatedCount}`,
+    `[chat-service] transfer-brand: sourceBrandId="${sourceBrandId}" targetBrandId="${targetBrandId ?? "same"}" from="${sourceOrgId}" to="${targetOrgId}" sessions=${updatedCount}`,
   );
 
   res.json({

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -843,14 +843,20 @@ Each \`data:\` line contains a JSON object. Events arrive in this order:
 
 export const TransferBrandRequestSchema = z
   .object({
-    brandId: z.string().min(1).openapi({
-      description: "The brand UUID to transfer",
+    sourceBrandId: z.string().min(1).openapi({
+      description: "The brand UUID to transfer (in the source org)",
     }),
     sourceOrgId: z.string().min(1).openapi({
       description: "The org UUID the brand is currently in",
     }),
     targetOrgId: z.string().min(1).openapi({
       description: "The org UUID to transfer the brand to",
+    }),
+    targetBrandId: z.string().min(1).optional().openapi({
+      description:
+        "The brand UUID in the target org to rewrite to. " +
+        "When present (conflict case), brand references are rewritten from sourceBrandId to targetBrandId. " +
+        "When absent, only org_id is updated.",
     }),
   })
   .strict()
@@ -878,7 +884,8 @@ registry.registerPath({
   summary: "Transfer brand ownership between orgs",
   description:
     "Re-assigns all solo-brand sessions from sourceOrgId to targetOrgId. " +
-    "Solo-brand = sessions where brand_ids contains exactly one element matching brandId. " +
+    "Solo-brand = sessions where brand_ids contains exactly one element matching sourceBrandId. " +
+    "When targetBrandId is provided (conflict case), brand references are rewritten to targetBrandId. " +
     "Sessions with multiple brand IDs (co-branding) are skipped. Idempotent.",
   request: {
     headers: z.object({

--- a/tests/unit/transfer-brand.test.ts
+++ b/tests/unit/transfer-brand.test.ts
@@ -2,21 +2,35 @@ import { describe, it, expect } from "vitest";
 import { TransferBrandRequestSchema } from "../../src/schemas.js";
 
 describe("TransferBrandRequestSchema", () => {
-  it("accepts valid request with all required fields", () => {
+  it("accepts valid request with required fields only", () => {
     const result = TransferBrandRequestSchema.safeParse({
-      brandId: "brand-abc",
+      sourceBrandId: "brand-abc",
       sourceOrgId: "org-source",
       targetOrgId: "org-target",
     });
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data.brandId).toBe("brand-abc");
+      expect(result.data.sourceBrandId).toBe("brand-abc");
       expect(result.data.sourceOrgId).toBe("org-source");
       expect(result.data.targetOrgId).toBe("org-target");
+      expect(result.data.targetBrandId).toBeUndefined();
     }
   });
 
-  it("rejects missing brandId", () => {
+  it("accepts valid request with targetBrandId (conflict case)", () => {
+    const result = TransferBrandRequestSchema.safeParse({
+      sourceBrandId: "brand-abc",
+      sourceOrgId: "org-source",
+      targetOrgId: "org-target",
+      targetBrandId: "brand-xyz",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.targetBrandId).toBe("brand-xyz");
+    }
+  });
+
+  it("rejects missing sourceBrandId", () => {
     const result = TransferBrandRequestSchema.safeParse({
       sourceOrgId: "org-source",
       targetOrgId: "org-target",
@@ -26,7 +40,7 @@ describe("TransferBrandRequestSchema", () => {
 
   it("rejects missing sourceOrgId", () => {
     const result = TransferBrandRequestSchema.safeParse({
-      brandId: "brand-abc",
+      sourceBrandId: "brand-abc",
       targetOrgId: "org-target",
     });
     expect(result.success).toBe(false);
@@ -34,27 +48,46 @@ describe("TransferBrandRequestSchema", () => {
 
   it("rejects missing targetOrgId", () => {
     const result = TransferBrandRequestSchema.safeParse({
-      brandId: "brand-abc",
+      sourceBrandId: "brand-abc",
       sourceOrgId: "org-source",
     });
     expect(result.success).toBe(false);
   });
 
-  it("rejects empty brandId", () => {
+  it("rejects empty sourceBrandId", () => {
     const result = TransferBrandRequestSchema.safeParse({
-      brandId: "",
+      sourceBrandId: "",
       sourceOrgId: "org-source",
       targetOrgId: "org-target",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty targetBrandId when provided", () => {
+    const result = TransferBrandRequestSchema.safeParse({
+      sourceBrandId: "brand-abc",
+      sourceOrgId: "org-source",
+      targetOrgId: "org-target",
+      targetBrandId: "",
     });
     expect(result.success).toBe(false);
   });
 
   it("rejects extra fields (strict mode)", () => {
     const result = TransferBrandRequestSchema.safeParse({
-      brandId: "brand-abc",
+      sourceBrandId: "brand-abc",
       sourceOrgId: "org-source",
       targetOrgId: "org-target",
       extraField: "should-fail",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects old brandId field name", () => {
+    const result = TransferBrandRequestSchema.safeParse({
+      brandId: "brand-abc",
+      sourceOrgId: "org-source",
+      targetOrgId: "org-target",
     });
     expect(result.success).toBe(false);
   });


### PR DESCRIPTION
## Summary

- **Rename `brandId` → `sourceBrandId`** in `POST /internal/transfer-brand` request schema
- **Add optional `targetBrandId`** — when present (conflict case: target org already has a brand for this domain), brand references in `brand_ids` are rewritten from `sourceBrandId` to `targetBrandId`
- When absent, behavior unchanged — only `org_id` is updated

Part of big-bang deploy across all services.

## Test plan

- [x] 469 unit tests pass (9 transfer-brand tests including conflict case and old field rejection)
- [ ] Integration tests (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)