### PR TITLE
fix: split transfer-brand into two separate UPDATE statements

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1748,23 +1748,24 @@ app.post("/internal/transfer-brand", requireInternalAuth, async (req, res) => {
 
   const { sourceBrandId, sourceOrgId, targetOrgId, targetBrandId } = parsed.data;
 
-  // Find sessions with solo-brand: brand_ids = ARRAY[sourceBrandId] (exactly one element)
-  // When targetBrandId is present (conflict), rewrite brand reference too
-  const result = targetBrandId
-    ? await db.execute(sql`
-        UPDATE sessions
-        SET org_id = ${targetOrgId}, brand_ids = ARRAY[${targetBrandId}]::text[], updated_at = NOW()
-        WHERE org_id = ${sourceOrgId}
-          AND brand_ids = ARRAY[${sourceBrandId}]::text[]
-      `) as unknown as { rowCount: number }
-    : await db.execute(sql`
-        UPDATE sessions
-        SET org_id = ${targetOrgId}, updated_at = NOW()
-        WHERE org_id = ${sourceOrgId}
-          AND brand_ids = ARRAY[${sourceBrandId}]::text[]
-      `) as unknown as { rowCount: number };
+  // Step 1: Move solo-brand sessions to target org
+  const moveResult = await db.execute(sql`
+    UPDATE sessions
+    SET org_id = ${targetOrgId}, updated_at = NOW()
+    WHERE org_id = ${sourceOrgId}
+      AND brand_ids = ARRAY[${sourceBrandId}]::text[]
+  `) as unknown as { rowCount: number };
 
-  const updatedCount = result.rowCount ?? 0;
+  const updatedCount = moveResult.rowCount ?? 0;
+
+  // Step 2: Rewrite brand reference (no org_id filter — catches all remaining references)
+  if (targetBrandId) {
+    await db.execute(sql`
+      UPDATE sessions
+      SET brand_ids = ARRAY[${targetBrandId}]::text[], updated_at = NOW()
+      WHERE brand_ids = ARRAY[${sourceBrandId}]::text[]
+    `);
+  }
 
   console.log(
     `[chat-service] transfer-brand: sourceBrandId="${sourceBrandId}" targetBrandId="${targetBrandId ?? "same"}" from="${sourceOrgId}" to="${targetOrgId}" sessions=${updatedCount}`,


### PR DESCRIPTION
## Summary

Splits the conflict-case transfer-brand logic into two separate UPDATE statements per the cross-service spec:

1. **Step 1** — `UPDATE SET org_id = targetOrgId WHERE org_id = sourceOrgId AND brand_ids = ARRAY[sourceBrandId]` (move to target org)
2. **Step 2** — `UPDATE SET brand_ids = ARRAY[targetBrandId] WHERE brand_ids = ARRAY[sourceBrandId]` (rewrite brand reference, no org_id filter)

Previously these were combined into a single UPDATE which doesn't match the spec.

**Data fix check:** Queried staging DB — 0 rows match old brand_id `7f433ef5-3e33-4c67-97da-0a9fa97ae74f`. No data fix needed for chat-service.

## Test plan

- [x] 469 unit tests pass
- [x] Type-check clean
- [ ] Integration tests (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)