### PR TITLE
feat: add provider/model support to chat configs (Gemini + Anthropic)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,10 @@ Before using `/chat`, register a config for each chat mode your app needs. Each 
 
 Fields:
 - `key` (required) — config identifier, unique per org. Clients pass this as `configKey` in `POST /chat`.
-- `systemPrompt` (required) — the system prompt sent to Claude for this chat mode
+- `systemPrompt` (required) — the system prompt sent to the LLM for this chat mode
 - `allowedTools` (required, min 1) — which tools the LLM can use. The service rejects any tool call not in this list. See [Available Tools](#available-tools) for the full list.
+- `provider` (optional) — LLM provider: `"anthropic"` or `"google"`. Defaults to `"anthropic"` when omitted.
+- `model` (optional) — Model alias (version-free). Must match the provider: anthropic → `haiku|sonnet|opus`, google → `flash-lite|flash|pro`. Defaults to `"sonnet"` for anthropic, `"pro"` for google.
 
 This endpoint is **idempotent** (upsert on `(orgId, key)`). Call it on every cold start.
 
@@ -101,6 +103,8 @@ Response:
   "key": "workflow",
   "systemPrompt": "...",
   "allowedTools": ["..."],
+  "provider": "google",
+  "model": "pro",
   "createdAt": "2026-02-26T00:00:00.000Z",
   "updatedAt": "2026-02-26T00:00:00.000Z"
 }
@@ -122,7 +126,7 @@ Register a platform-wide config for a given key. Used as fallback when no per-or
 }
 ```
 
-Fields: same as `PUT /config` — `key`, `systemPrompt`, `allowedTools` (all required).
+Fields: same as `PUT /config` — `key`, `systemPrompt`, `allowedTools` (all required), plus optional `provider` and `model`.
 
 This endpoint is **idempotent** (upsert on `key`). Called on every cold start by api-service.
 
@@ -550,7 +554,8 @@ src/
     schema.ts       # sessions + messages + app_configs + platform_configs table definitions
   lib/
     anthropic.ts       # Claude AI client (Sonnet 4.6), streaming + non-streaming, tool calling, adaptive thinking, context management (compaction), built-in tool declarations. Streaming retries transient errors (overloaded, 429, 5xx) up to 2× with exponential backoff when no tokens have been emitted yet
-    gemini.ts          # Gemini REST API client — retry with exponential backoff (3 retries) + fallback to stable 2.5 models on failure
+    gemini.ts          # Gemini REST API client (non-streaming) — retry with exponential backoff (3 retries) + fallback to stable 2.5 models on failure
+    gemini-chat.ts     # Gemini streaming chat client — streaming + function calling for /chat endpoint
     merge-messages.ts  # Ensures alternating user/assistant roles by merging orphaned consecutive same-role messages
     billing-client.ts  # Billing-service client for credit authorization before platform-key operations
     key-client.ts      # Key-service client: resolveKey (decrypt), listOrgKeys, getKeySource, listKeySources, checkProviderRequirements

--- a/drizzle/0013_add_provider_model_to_configs.sql
+++ b/drizzle/0013_add_provider_model_to_configs.sql
@@ -1,0 +1,7 @@
+-- Add provider and model columns to chat config tables
+-- NULL = use default (anthropic / sonnet) for backward compatibility
+
+ALTER TABLE "app_configs" ADD COLUMN "provider" text;
+ALTER TABLE "app_configs" ADD COLUMN "model" text;
+ALTER TABLE "platform_configs" ADD COLUMN "provider" text;
+ALTER TABLE "platform_configs" ADD COLUMN "model" text;

--- a/openapi.json
+++ b/openapi.json
@@ -315,6 +315,21 @@
               "type": "string"
             }
           },
+          "provider": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "anthropic",
+              "google",
+              null
+            ],
+            "description": "LLM provider. Null means default (anthropic)."
+          },
+          "model": {
+            "type": "string",
+            "nullable": true,
+            "description": "Model alias. Null means provider default (sonnet for anthropic, pro for google)."
+          },
           "createdAt": {
             "type": "string"
           },
@@ -327,6 +342,8 @@
           "key",
           "systemPrompt",
           "allowedTools",
+          "provider",
+          "model",
           "createdAt",
           "updatedAt"
         ]
@@ -378,6 +395,28 @@
               "get_workflow_details",
               "list_workflows"
             ]
+          },
+          "provider": {
+            "type": "string",
+            "enum": [
+              "anthropic",
+              "google"
+            ],
+            "description": "LLM provider for this chat mode. Omit to use the default (anthropic).\n\n- `anthropic` — Claude models (haiku, sonnet, opus)\n- `google` — Gemini models (flash-lite, flash, pro)",
+            "example": "google"
+          },
+          "model": {
+            "type": "string",
+            "enum": [
+              "haiku",
+              "sonnet",
+              "opus",
+              "flash-lite",
+              "flash",
+              "pro"
+            ],
+            "description": "Model alias (version-free). Omit to use the provider's default (sonnet for anthropic, pro for google). Must match the provider:\n\n- anthropic → haiku, sonnet, opus\n- google → flash-lite, flash, pro",
+            "example": "pro"
           }
         },
         "required": [
@@ -402,6 +441,21 @@
               "type": "string"
             }
           },
+          "provider": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "anthropic",
+              "google",
+              null
+            ],
+            "description": "LLM provider. Null means default (anthropic)."
+          },
+          "model": {
+            "type": "string",
+            "nullable": true,
+            "description": "Model alias. Null means provider default (sonnet for anthropic, pro for google)."
+          },
           "createdAt": {
             "type": "string"
           },
@@ -413,6 +467,8 @@
           "key",
           "systemPrompt",
           "allowedTools",
+          "provider",
+          "model",
           "createdAt",
           "updatedAt"
         ]
@@ -447,6 +503,28 @@
               "get_workflow_details",
               "list_workflows"
             ]
+          },
+          "provider": {
+            "type": "string",
+            "enum": [
+              "anthropic",
+              "google"
+            ],
+            "description": "LLM provider for this chat mode. Omit to use the default (anthropic).\n\n- `anthropic` — Claude models (haiku, sonnet, opus)\n- `google` — Gemini models (flash-lite, flash, pro)",
+            "example": "google"
+          },
+          "model": {
+            "type": "string",
+            "enum": [
+              "haiku",
+              "sonnet",
+              "opus",
+              "flash-lite",
+              "flash",
+              "pro"
+            ],
+            "description": "Model alias (version-free). Omit to use the provider's default (sonnet for anthropic, pro for google). Must match the provider.",
+            "example": "pro"
           }
         },
         "required": [

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -36,6 +36,8 @@ export const appConfigs = pgTable(
     key: text("key").notNull(),
     systemPrompt: text("system_prompt").notNull(),
     allowedTools: jsonb("allowed_tools").notNull().$type<string[]>(),
+    provider: text("provider").$type<"anthropic" | "google">(),
+    model: text("model"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
@@ -47,6 +49,8 @@ export const platformConfigs = pgTable("platform_configs", {
   key: text("key").notNull().unique(),
   systemPrompt: text("system_prompt").notNull(),
   allowedTools: jsonb("allowed_tools").notNull().$type<string[]>(),
+  provider: text("provider").$type<"anthropic" | "google">(),
+  model: text("model"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,7 @@ const __dirname = dirname(__filename);
 const openapiPath = join(__dirname, "..", "openapi.json");
 
 import { mergeConsecutiveMessages, stripToolUseBlocks } from "./lib/merge-messages.js";
+import { streamGeminiChat, type ToolDefinition } from "./lib/gemini-chat.js";
 
 // ---------------------------------------------------------------------------
 // Anthropic stream retry
@@ -335,7 +336,7 @@ app.put("/config", requireAuth, async (req, res) => {
       .json({ error: "Invalid request", details: parsed.error.flatten() });
   }
 
-  const { key, systemPrompt, allowedTools } = parsed.data;
+  const { key, systemPrompt, allowedTools, provider, model } = parsed.data;
 
   // Validate all tool names
   const unknownTools = allowedTools.filter((t) => !AVAILABLE_TOOL_NAMES.includes(t));
@@ -352,12 +353,16 @@ app.put("/config", requireAuth, async (req, res) => {
       key,
       systemPrompt,
       allowedTools,
+      provider: provider ?? null,
+      model: model ?? null,
     })
     .onConflictDoUpdate({
       target: [appConfigs.orgId, appConfigs.key],
       set: {
         systemPrompt,
         allowedTools,
+        provider: provider ?? null,
+        model: model ?? null,
         updatedAt: new Date(),
       },
     })
@@ -368,6 +373,8 @@ app.put("/config", requireAuth, async (req, res) => {
     key: config.key,
     systemPrompt: config.systemPrompt,
     allowedTools: config.allowedTools,
+    provider: config.provider,
+    model: config.model,
     createdAt: config.createdAt.toISOString(),
     updatedAt: config.updatedAt.toISOString(),
   });
@@ -383,7 +390,7 @@ app.put("/platform-config", requireInternalAuth, async (req, res) => {
       .json({ error: "Invalid request", details: parsed.error.flatten() });
   }
 
-  const { key, systemPrompt, allowedTools } = parsed.data;
+  const { key, systemPrompt, allowedTools, provider, model } = parsed.data;
 
   // Validate all tool names
   const unknownTools = allowedTools.filter((t) => !AVAILABLE_TOOL_NAMES.includes(t));
@@ -399,12 +406,16 @@ app.put("/platform-config", requireInternalAuth, async (req, res) => {
       key,
       systemPrompt,
       allowedTools,
+      provider: provider ?? null,
+      model: model ?? null,
     })
     .onConflictDoUpdate({
       target: [platformConfigs.key],
       set: {
         systemPrompt,
         allowedTools,
+        provider: provider ?? null,
+        model: model ?? null,
         updatedAt: new Date(),
       },
     })
@@ -414,6 +425,8 @@ app.put("/platform-config", requireInternalAuth, async (req, res) => {
     key: config.key,
     systemPrompt: config.systemPrompt,
     allowedTools: config.allowedTools,
+    provider: config.provider,
+    model: config.model,
     createdAt: config.createdAt.toISOString(),
     updatedAt: config.updatedAt.toISOString(),
   });
@@ -741,11 +754,16 @@ app.post("/chat", requireAuth, async (req, res) => {
 
   const allowedToolNames: string[] = appConfig.allowedTools as string[];
 
-  // Resolve Anthropic API key per-request (supports BYOK per org)
+  // Resolve provider/model from config (NULL = default: anthropic/sonnet)
+  const chatProvider = (appConfig.provider ?? "anthropic") as Provider;
+  const chatModelAlias = (appConfig.model ?? (chatProvider === "anthropic" ? "sonnet" : "pro")) as ModelAlias;
+  const resolvedModelInfo = resolveModel(chatProvider, chatModelAlias);
+
+  // Resolve API key for the configured provider
   let resolvedKey: ResolvedKey;
   try {
     resolvedKey = await resolveKey({
-      provider: "anthropic",
+      provider: resolvedModelInfo.provider,
       orgId,
       userId,
       runId: parentRunId,
@@ -753,9 +771,9 @@ app.post("/chat", requireAuth, async (req, res) => {
       trackingHeaders,
     });
   } catch (err) {
-    console.error(`Failed to resolve Anthropic key for org="${orgId}":`, err);
+    console.error(`Failed to resolve ${resolvedModelInfo.provider} key for org="${orgId}":`, err);
     return res.status(502).json({
-      error: `Failed to resolve Anthropic API key. Ensure the key is configured in key-service.`,
+      error: `Failed to resolve ${resolvedModelInfo.provider} API key. Ensure the key is configured in key-service.`,
     });
   }
 
@@ -768,10 +786,10 @@ app.post("/chat", requireAuth, async (req, res) => {
     try {
       const authResult = await authorizeCredits({
         items: [
-          { costName: `${COST_PREFIX}-tokens-input`, quantity: estimatedInputTokens },
-          { costName: `${COST_PREFIX}-tokens-output`, quantity: estimatedOutputTokens },
+          { costName: `${resolvedModelInfo.costPrefix}-tokens-input`, quantity: estimatedInputTokens },
+          { costName: `${resolvedModelInfo.costPrefix}-tokens-output`, quantity: estimatedOutputTokens },
         ],
-        description: `chat — ${MODEL}`,
+        description: `chat — ${resolvedModelInfo.apiModelId}`,
         orgId,
         userId,
         runId: parentRunId,
@@ -817,7 +835,8 @@ app.post("/chat", requireAuth, async (req, res) => {
 
   // Build system prompt with optional context and campaign feature inputs
   const systemPrompt = buildSystemPrompt(appConfig.systemPrompt, context, campaignFeatureInputs);
-  const claude = createAnthropicClient({ apiKey: resolvedKey.key, systemPrompt });
+  const isGeminiChat = chatProvider === "google";
+  const claude = isGeminiChat ? null : createAnthropicClient({ apiKey: resolvedKey.key, systemPrompt });
 
   let runId: string | null = null;
   let chatFailed = false;
@@ -888,35 +907,11 @@ app.post("/chat", requireAuth, async (req, res) => {
       return;
     }
 
-    // Load conversation history
+    // Load conversation history (shared by both providers)
     const history = await db.query.messages.findMany({
       where: eq(messages.sessionId, currentSessionId),
       orderBy: (m, { asc }) => [asc(m.createdAt)],
     });
-
-    // Build Anthropic message history — use contentBlocks if available (preserves compaction blocks)
-    // Strip tool_use blocks: intermediate tool calls are ephemeral and not persisted with
-    // matching tool_result messages, so including them causes Anthropic API validation errors.
-    // Ensure alternating user/assistant roles (merge consecutive same-role messages)
-    const rawHistory: Anthropic.MessageParam[] = history
-      .filter((m) => m.role !== "tool")
-      .map((m) => {
-        if (m.role === "assistant" && m.contentBlocks) {
-          const blocks = stripToolUseBlocks(
-            m.contentBlocks as Anthropic.ContentBlockParam[],
-          );
-          return {
-            role: "assistant" as const,
-            content: blocks.length > 0 ? blocks : (m.content as string),
-          };
-        }
-        return {
-          role: m.role as "user" | "assistant",
-          content: m.content as string | Anthropic.ContentBlockParam[],
-        };
-      });
-
-    const anthropicHistory = mergeConsecutiveMessages(rawHistory);
 
     // Save user message
     await db.insert(messages).values({
@@ -925,13 +920,15 @@ app.post("/chat", requireAuth, async (req, res) => {
       content: message.trim(),
     });
 
-    // Stream response from Claude
+    // Shared state for both providers
     let fullResponse = "";
     let emittedInputRequest = false;
     const toolCalls: ToolCallRecord[] = [];
+    let lastContentBlocks: Anthropic.ContentBlock[] = [];
+    // Track workflows forked during this turn (used by executeTool)
+    const forkedWorkflowMap = new Map<string, string>();
 
-    // Line buffer: hold back trailing lines that match button syntax
-    // so they aren't streamed as tokens (only sent as buttons event)
+    // Anthropic-specific: line buffer for button detection during streaming
     const BUTTON_RE = /^[-*]\s*\[.+?\]\s*$/;
     let lineBuf = "";
     let held = "";
@@ -1432,7 +1429,68 @@ app.post("/chat", requireAuth, async (req, res) => {
 
     // -----------------------------------------------------------------------
     // Agentic loop: stream → handle tools → repeat
+    // Provider-specific: Gemini uses streamGeminiChat(), Anthropic uses SDK
     // -----------------------------------------------------------------------
+
+    if (isGeminiChat) {
+      // --- Gemini streaming path ---
+      const geminiToolDefs: ToolDefinition[] = allTools.map((t) => ({
+        name: t.name,
+        description: t.description ?? "",
+        input_schema: t.input_schema as ToolDefinition["input_schema"],
+      }));
+
+      const plainHistory = history
+        .filter((m) => m.role !== "tool")
+        .map((m) => ({
+          role: m.role as "user" | "assistant",
+          content: m.content as string,
+        }));
+
+      const geminiResult = await streamGeminiChat({
+        apiKey: resolvedKey.key,
+        model: resolvedModelInfo.apiModelId,
+        systemPrompt,
+        history: plainHistory,
+        userMessage: message.trim(),
+        tools: geminiToolDefs,
+        res,
+        sendSSE,
+        executeTool,
+        signal: abortController.signal,
+      });
+
+      fullResponse = geminiResult.fullResponse;
+      emittedInputRequest = geminiResult.emittedInputRequest;
+      toolCalls.push(...geminiResult.toolCalls);
+      totalPromptTokens = geminiResult.tokensInput;
+      totalOutputTokens = geminiResult.tokensOutput;
+
+      // Shared post-processing: buttons, empty response check, save message
+      // (no line buffering for Gemini — tokens are streamed directly)
+
+    } else {
+    // --- Anthropic streaming path ---
+
+    // Build Anthropic message history — use contentBlocks if available (preserves compaction blocks)
+    const rawHistory: Anthropic.MessageParam[] = history
+      .filter((m) => m.role !== "tool")
+      .map((m) => {
+        if (m.role === "assistant" && m.contentBlocks) {
+          const blocks = stripToolUseBlocks(
+            m.contentBlocks as Anthropic.ContentBlockParam[],
+          );
+          return {
+            role: "assistant" as const,
+            content: blocks.length > 0 ? blocks : (m.content as string),
+          };
+        }
+        return {
+          role: m.role as "user" | "assistant",
+          content: m.content as string | Anthropic.ContentBlockParam[],
+        };
+      });
+    const anthropicHistory = mergeConsecutiveMessages(rawHistory);
 
     const turnMessages: Anthropic.MessageParam[] = [
       ...anthropicHistory,
@@ -1441,12 +1499,6 @@ app.post("/chat", requireAuth, async (req, res) => {
 
     const MAX_TOOL_CHAIN_DEPTH = 10;
     let depth = 0;
-    let lastContentBlocks: Anthropic.ContentBlock[] = [];
-
-    // Track workflows that were forked during this turn so the LLM
-    // doesn't accidentally fork the same source workflow multiple times.
-    // Maps: originalWorkflowId → forkedWorkflowId
-    const forkedWorkflowMap = new Map<string, string>();
 
     agenticLoop:
     while (depth <= MAX_TOOL_CHAIN_DEPTH) {
@@ -1457,7 +1509,7 @@ app.post("/chat", requireAuth, async (req, res) => {
       }
 
       let currentBlockType: string | null = null;
-      let stream: ReturnType<typeof claude.createStream> | undefined;
+      let stream: ReturnType<NonNullable<typeof claude>["createStream"]> | undefined;
       let tokensEmitted = false;
 
       // Retry loop for transient Anthropic errors (overloaded, 429, 5xx).
@@ -1465,7 +1517,7 @@ app.post("/chat", requireAuth, async (req, res) => {
       for (let attempt = 0; attempt <= ANTHROPIC_STREAM_MAX_RETRIES; attempt++) {
         tokensEmitted = false;
         currentBlockType = null;
-        stream = claude.createStream(turnMessages, allTools, abortController.signal);
+        stream = claude!.createStream(turnMessages, allTools, abortController.signal);
 
         try {
           for await (const event of stream) {
@@ -1595,9 +1647,7 @@ app.post("/chat", requireAuth, async (req, res) => {
       depth++;
     }
 
-    console.log(`[chat] session="${currentSessionId}" stream complete — tokens=${totalPromptTokens}+${totalOutputTokens} response=${fullResponse.length}chars`);
-
-    // Finalize buffer: handle any remaining incomplete line
+    // Finalize Anthropic line buffer
     if (lineBuf) {
       if (BUTTON_RE.test(lineBuf.trim())) {
         held += lineBuf;
@@ -1611,22 +1661,41 @@ app.post("/chat", requireAuth, async (req, res) => {
       lineBuf = "";
     }
 
-    // Process held content as buttons
-    const buttons: ButtonRecord[] = held ? extractButtons(held) : [];
-    if (held && buttons.length === 0) {
-      sendSSE(res, { type: "token", content: held });
+    } // end else (Anthropic path)
+
+    // -----------------------------------------------------------------------
+    // Shared post-processing (both providers)
+    // -----------------------------------------------------------------------
+
+    console.log(`[chat] session="${currentSessionId}" stream complete — provider=${chatProvider} tokens=${totalPromptTokens}+${totalOutputTokens} response=${fullResponse.length}chars`);
+
+    // Process held content as buttons (Anthropic buffer or raw Gemini response)
+    const BUTTON_LINE_RE = /^[-*]\s*\[.+?\]\s*$/;
+    const trailingButtonLines: string[] = [];
+    const responseLines = fullResponse.split("\n");
+    for (let i = responseLines.length - 1; i >= 0; i--) {
+      if (BUTTON_LINE_RE.test(responseLines[i].trim())) {
+        trailingButtonLines.unshift(responseLines[i]);
+      } else if (trailingButtonLines.length > 0) {
+        break;
+      } else if (responseLines[i].trim() !== "") {
+        break;
+      }
     }
+    const buttons: ButtonRecord[] = trailingButtonLines.length > 0
+      ? extractButtons(trailingButtonLines.join("\n"))
+      : [];
     if (buttons.length > 0) {
       sendSSE(res, { type: "buttons", buttons });
     }
 
-    // Detect empty stream: Claude returned no content (safety refusal, context overflow, etc.)
+    // Detect empty stream
     if (!fullResponse && !emittedInputRequest && toolCalls.length === 0) {
       chatFailed = true;
       console.error(
-        `Empty Claude response for session="${currentSessionId}" org="${orgId}" — ` +
+        `Empty ${chatProvider} response for session="${currentSessionId}" org="${orgId}" — ` +
           `promptTokens=${totalPromptTokens} outputTokens=${totalOutputTokens} ` +
-          `historyLength=${anthropicHistory.length} messageLength=${message.length}`,
+          `historyLength=${history.length} messageLength=${message.length}`,
       );
       sendSSE(res, {
         type: "error",
@@ -1641,13 +1710,12 @@ app.post("/chat", requireAuth, async (req, res) => {
     }
 
     // Save assistant message with cleaned response + content blocks for compaction
-    // Strip tool_use blocks — they are ephemeral (tool results aren't saved as separate
-    // messages), so persisting them causes missing tool_result errors on next load.
     const cleanedResponse =
       buttons.length > 0 ? stripButtons(fullResponse) : fullResponse;
-    const persistBlocks = stripToolUseBlocks(
-      lastContentBlocks as Anthropic.ContentBlockParam[],
-    );
+    // Content blocks are Anthropic-specific (compaction). Gemini stores null.
+    const persistBlocks = (!isGeminiChat && lastContentBlocks.length > 0)
+      ? stripToolUseBlocks(lastContentBlocks as Anthropic.ContentBlockParam[])
+      : [];
     await db.insert(messages).values({
       sessionId: currentSessionId,
       role: "assistant",
@@ -1674,11 +1742,12 @@ app.post("/chat", requireAuth, async (req, res) => {
     if (runId) {
       const costSource: "platform" | "org" =
         resolvedKey.keySource === "org" ? "org" : "platform";
+      const chatCostPrefix = resolvedModelInfo.costPrefix;
       const costItems = [
         ...(totalPromptTokens > 0
           ? [
               {
-                costName: `${COST_PREFIX}-tokens-input`,
+                costName: `${chatCostPrefix}-tokens-input`,
                 quantity: totalPromptTokens,
                 costSource,
               },
@@ -1687,7 +1756,7 @@ app.post("/chat", requireAuth, async (req, res) => {
         ...(totalOutputTokens > 0
           ? [
               {
-                costName: `${COST_PREFIX}-tokens-output`,
+                costName: `${chatCostPrefix}-tokens-output`,
                 quantity: totalOutputTokens,
                 costSource,
               },

--- a/src/lib/gemini-chat.ts
+++ b/src/lib/gemini-chat.ts
@@ -1,0 +1,408 @@
+// ---------------------------------------------------------------------------
+// Gemini streaming chat client — REST-based, no SDK dependency
+// Handles streaming + function calling (agentic loop) for /chat endpoint
+// ---------------------------------------------------------------------------
+
+import type { Response as ExpressResponse } from "express";
+import type { ToolCallRecord } from "../db/schema.js";
+
+const GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta";
+
+/** Model-specific API timeouts in milliseconds. */
+const GEMINI_TIMEOUT_MS: Record<string, number> = {
+  "gemini-3.1-pro-preview": 15 * 60_000,
+  "gemini-3-flash-preview": 10 * 60_000,
+  "gemini-3.1-flash-lite-preview": 5 * 60_000,
+  "gemini-2.5-pro": 15 * 60_000,
+  "gemini-2.5-flash": 10 * 60_000,
+};
+const DEFAULT_GEMINI_TIMEOUT_MS = 10 * 60_000;
+
+const MAX_TOOL_CHAIN_DEPTH = 10;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Provider-agnostic tool definition (matches Anthropic's shape). */
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  input_schema: {
+    type: "object";
+    properties: Record<string, unknown>;
+    required?: string[];
+  };
+}
+
+/** Gemini function declaration format. */
+interface GeminiFunctionDeclaration {
+  name: string;
+  description: string;
+  parameters: {
+    type: "object";
+    properties: Record<string, unknown>;
+    required?: string[];
+  };
+}
+
+/** Gemini message part types. */
+interface GeminiTextPart { text: string }
+interface GeminiFunctionCallPart {
+  functionCall: { name: string; args: Record<string, unknown> };
+}
+interface GeminiFunctionResponsePart {
+  functionResponse: { name: string; response: unknown };
+}
+type GeminiPart = GeminiTextPart | GeminiFunctionCallPart | GeminiFunctionResponsePart;
+
+interface GeminiMessage {
+  role: "user" | "model";
+  parts: GeminiPart[];
+}
+
+/** SSE event sender (same signature as index.ts sendSSE). */
+type SendSSE = (res: ExpressResponse, data: unknown) => void;
+
+/** Tool executor return type — matches what the /chat handler's executeTool returns. */
+export type ToolExecutorResult =
+  | { name: string; result: unknown }
+  | "input_request"
+  | null;
+
+export type ToolExecutor = (
+  call: { name: string; args: Record<string, unknown> },
+) => Promise<ToolExecutorResult>;
+
+export interface StreamGeminiChatOptions {
+  apiKey: string;
+  model: string;
+  systemPrompt: string;
+  history: Array<{ role: "user" | "assistant"; content: string }>;
+  userMessage: string;
+  tools: ToolDefinition[];
+  res: ExpressResponse;
+  sendSSE: SendSSE;
+  executeTool: ToolExecutor;
+  signal: AbortSignal;
+}
+
+export interface StreamGeminiChatResult {
+  tokensInput: number;
+  tokensOutput: number;
+  fullResponse: string;
+  toolCalls: ToolCallRecord[];
+  emittedInputRequest: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Conversion helpers
+// ---------------------------------------------------------------------------
+
+/** Convert Anthropic-style tool definitions to Gemini functionDeclarations. */
+export function toGeminiFunctionDeclarations(
+  tools: ToolDefinition[],
+): GeminiFunctionDeclaration[] {
+  return tools.map((t) => ({
+    name: t.name,
+    description: t.description,
+    parameters: {
+      type: "object" as const,
+      properties: t.input_schema.properties,
+      ...(t.input_schema.required?.length ? { required: t.input_schema.required } : {}),
+    },
+  }));
+}
+
+/** Convert DB message history to Gemini format. */
+function toGeminiHistory(
+  history: Array<{ role: "user" | "assistant"; content: string }>,
+): GeminiMessage[] {
+  const result: GeminiMessage[] = [];
+  for (const msg of history) {
+    const geminiRole = msg.role === "assistant" ? "model" : "user";
+    // Merge consecutive same-role messages (Gemini requires alternating roles)
+    const prev = result[result.length - 1];
+    if (prev && prev.role === geminiRole) {
+      prev.parts.push({ text: msg.content });
+    } else {
+      result.push({ role: geminiRole, parts: [{ text: msg.content }] });
+    }
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Streaming SSE parser
+// ---------------------------------------------------------------------------
+
+interface GeminiStreamChunk {
+  candidates?: Array<{
+    content?: {
+      parts?: Array<{
+        text?: string;
+        thought?: boolean;
+        functionCall?: { name: string; args: Record<string, unknown> };
+      }>;
+    };
+    finishReason?: string;
+  }>;
+  usageMetadata?: {
+    promptTokenCount?: number;
+    candidatesTokenCount?: number;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main streaming function
+// ---------------------------------------------------------------------------
+
+/**
+ * Stream a Gemini chat with function calling support.
+ * Emits the same SSE events as the Anthropic path for frontend compatibility.
+ */
+export async function streamGeminiChat(
+  options: StreamGeminiChatOptions,
+): Promise<StreamGeminiChatResult> {
+  const {
+    apiKey,
+    model,
+    systemPrompt,
+    history,
+    userMessage,
+    tools,
+    res,
+    sendSSE: sse,
+    executeTool,
+    signal,
+  } = options;
+
+  let totalTokensInput = 0;
+  let totalTokensOutput = 0;
+  let fullResponse = "";
+  const allToolCalls: ToolCallRecord[] = [];
+  let emittedInputRequest = false;
+
+  // Build Gemini message history
+  const geminiHistory = toGeminiHistory(history);
+
+  // Build turn messages — history + current user message
+  const turnMessages: GeminiMessage[] = [
+    ...geminiHistory,
+    { role: "user", parts: [{ text: userMessage }] },
+  ];
+
+  // Convert tools to Gemini format
+  const functionDeclarations = tools.length > 0
+    ? toGeminiFunctionDeclarations(tools)
+    : [];
+
+  const timeoutMs = GEMINI_TIMEOUT_MS[model] ?? DEFAULT_GEMINI_TIMEOUT_MS;
+
+  // Agentic loop
+  for (let depth = 0; depth <= MAX_TOOL_CHAIN_DEPTH; depth++) {
+    if (signal.aborted) break;
+
+    // Build request body
+    const body: Record<string, unknown> = {
+      contents: turnMessages,
+      systemInstruction: { parts: [{ text: systemPrompt }] },
+      generationConfig: {
+        thinkingConfig: { thinkingBudget: 8192 },
+      },
+      ...(functionDeclarations.length > 0
+        ? { tools: [{ functionDeclarations }] }
+        : {}),
+    };
+
+    const url = `${GEMINI_API_BASE}/models/${encodeURIComponent(model)}:streamGenerateContent?alt=sse&key=${encodeURIComponent(apiKey)}`;
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        signal: AbortSignal.any([signal, AbortSignal.timeout(timeoutMs)]),
+      });
+    } catch (err: unknown) {
+      if (signal.aborted) break;
+      throw err;
+    }
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => "unknown error");
+      throw new Error(`[gemini-chat] API error ${response.status}: ${errorText}`);
+    }
+
+    // Parse SSE stream from Gemini
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error("[gemini-chat] No response body");
+
+    const decoder = new TextDecoder();
+    let sseBuffer = "";
+    let inThinking = false;
+    const functionCalls: Array<{ name: string; args: Record<string, unknown> }> = [];
+    let chunkTokensInput = 0;
+    let chunkTokensOutput = 0;
+
+    try {
+      while (true) {
+        if (signal.aborted) break;
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        sseBuffer += decoder.decode(value, { stream: true });
+
+        // Process complete SSE events
+        let eventEnd: number;
+        while ((eventEnd = sseBuffer.indexOf("\n\n")) !== -1) {
+          const eventBlock = sseBuffer.slice(0, eventEnd);
+          sseBuffer = sseBuffer.slice(eventEnd + 2);
+
+          // Extract data from SSE event
+          const dataLine = eventBlock.split("\n").find((l) => l.startsWith("data: "));
+          if (!dataLine) continue;
+          const jsonStr = dataLine.slice(6);
+
+          let chunk: GeminiStreamChunk;
+          try {
+            chunk = JSON.parse(jsonStr);
+          } catch {
+            continue;
+          }
+
+          // Track usage
+          if (chunk.usageMetadata) {
+            chunkTokensInput = chunk.usageMetadata.promptTokenCount ?? chunkTokensInput;
+            chunkTokensOutput = chunk.usageMetadata.candidatesTokenCount ?? chunkTokensOutput;
+          }
+
+          const parts = chunk.candidates?.[0]?.content?.parts;
+          if (!parts) continue;
+
+          for (const part of parts) {
+            // Thinking support (Gemini 3.x)
+            if (part.thought && part.text) {
+              if (!inThinking) {
+                sse(res, { type: "thinking_start" });
+                inThinking = true;
+              }
+              sse(res, { type: "thinking_delta", thinking: part.text });
+              continue;
+            }
+
+            // Close thinking if we get a non-thought part
+            if (inThinking && !part.thought) {
+              sse(res, { type: "thinking_stop" });
+              inThinking = false;
+            }
+
+            // Text content
+            if (part.text && !part.thought) {
+              fullResponse += part.text;
+              sse(res, { type: "token", content: part.text });
+            }
+
+            // Function call
+            if (part.functionCall) {
+              functionCalls.push({
+                name: part.functionCall.name,
+                args: part.functionCall.args ?? {},
+              });
+            }
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    // Close thinking if stream ended mid-thought
+    if (inThinking) {
+      sse(res, { type: "thinking_stop" });
+    }
+
+    totalTokensInput = chunkTokensInput;
+    totalTokensOutput += chunkTokensOutput;
+
+    // No function calls — we're done
+    if (functionCalls.length === 0) break;
+
+    // Execute function calls
+    const modelParts: GeminiPart[] = [];
+    const responseParts: GeminiPart[] = [];
+
+    for (const fc of functionCalls) {
+      modelParts.push({ functionCall: fc });
+
+      const toolCallId = `tc_${crypto.randomUUID()}`;
+      if (fc.name !== "request_user_input") {
+        sse(res, {
+          type: "tool_call",
+          id: toolCallId,
+          name: fc.name,
+          args: fc.args,
+        });
+      }
+
+      try {
+        const toolResult = await executeTool({ name: fc.name, args: fc.args });
+
+        if (toolResult === "input_request") {
+          emittedInputRequest = true;
+          // Still add partial results so far
+          return {
+            tokensInput: totalTokensInput,
+            tokensOutput: totalTokensOutput,
+            fullResponse,
+            toolCalls: allToolCalls,
+            emittedInputRequest,
+          };
+        }
+
+        if (toolResult === null) {
+          responseParts.push({
+            functionResponse: {
+              name: fc.name,
+              response: { error: "Unknown tool" },
+            },
+          });
+          continue;
+        }
+
+        allToolCalls.push({ name: fc.name, args: fc.args, result: toolResult.result });
+        sse(res, { type: "tool_result", id: toolCallId, name: fc.name, result: toolResult.result });
+        responseParts.push({
+          functionResponse: {
+            name: fc.name,
+            response: toolResult.result,
+          },
+        });
+      } catch (toolErr: unknown) {
+        const rawMsg = toolErr instanceof Error ? toolErr.message : String(toolErr);
+        console.error(`[gemini-chat] Tool call ${fc.name} failed:`, rawMsg);
+        const errorResult = { error: rawMsg };
+        sse(res, { type: "tool_result", id: toolCallId, name: fc.name, result: errorResult });
+        responseParts.push({
+          functionResponse: {
+            name: fc.name,
+            response: errorResult,
+          },
+        });
+      }
+    }
+
+    // Append model function calls + tool results to conversation
+    turnMessages.push({ role: "model", parts: modelParts });
+    turnMessages.push({ role: "user", parts: responseParts });
+  }
+
+  return {
+    tokensInput: totalTokensInput,
+    tokensOutput: totalTokensOutput,
+    fullResponse,
+    toolCalls: allToolCalls,
+    emittedInputRequest,
+  };
+}

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -130,8 +130,37 @@ export const AppConfigRequestSchema = z
         "list_workflows",
       ],
     }),
+    provider: z.enum(["anthropic", "google"]).optional().openapi({
+      description:
+        "LLM provider for this chat mode. Omit to use the default (anthropic).\n\n" +
+        "- `anthropic` — Claude models (haiku, sonnet, opus)\n" +
+        "- `google` — Gemini models (flash-lite, flash, pro)",
+      example: "google",
+    }),
+    model: z.enum(["haiku", "sonnet", "opus", "flash-lite", "flash", "pro"]).optional().openapi({
+      description:
+        "Model alias (version-free). Omit to use the provider's default " +
+        "(sonnet for anthropic, pro for google). Must match the provider:\n\n" +
+        "- anthropic → haiku, sonnet, opus\n" +
+        "- google → flash-lite, flash, pro",
+      example: "pro",
+    }),
   })
   .strict()
+  .refine(
+    (data) => {
+      if (!data.provider || !data.model) return true;
+      const anthropicModels = ["haiku", "sonnet", "opus"];
+      const googleModels = ["flash-lite", "flash", "pro"];
+      if (data.provider === "anthropic") return anthropicModels.includes(data.model);
+      if (data.provider === "google") return googleModels.includes(data.model);
+      return false;
+    },
+    {
+      message: "Model must match provider: anthropic → haiku|sonnet|opus, google → flash-lite|flash|pro",
+      path: ["model"],
+    },
+  )
   .openapi("AppConfigRequest");
 
 export const AppConfigResponseSchema = z
@@ -140,6 +169,12 @@ export const AppConfigResponseSchema = z
     key: z.string(),
     systemPrompt: z.string(),
     allowedTools: z.array(z.string()),
+    provider: z.enum(["anthropic", "google"]).nullable().openapi({
+      description: "LLM provider. Null means default (anthropic).",
+    }),
+    model: z.string().nullable().openapi({
+      description: "Model alias. Null means provider default (sonnet for anthropic, pro for google).",
+    }),
     createdAt: z.string(),
     updatedAt: z.string(),
   })
@@ -232,8 +267,35 @@ export const PlatformConfigRequestSchema = z
         "list_workflows",
       ],
     }),
+    provider: z.enum(["anthropic", "google"]).optional().openapi({
+      description:
+        "LLM provider for this chat mode. Omit to use the default (anthropic).\n\n" +
+        "- `anthropic` — Claude models (haiku, sonnet, opus)\n" +
+        "- `google` — Gemini models (flash-lite, flash, pro)",
+      example: "google",
+    }),
+    model: z.enum(["haiku", "sonnet", "opus", "flash-lite", "flash", "pro"]).optional().openapi({
+      description:
+        "Model alias (version-free). Omit to use the provider's default " +
+        "(sonnet for anthropic, pro for google). Must match the provider.",
+      example: "pro",
+    }),
   })
   .strict()
+  .refine(
+    (data) => {
+      if (!data.provider || !data.model) return true;
+      const anthropicModels = ["haiku", "sonnet", "opus"];
+      const googleModels = ["flash-lite", "flash", "pro"];
+      if (data.provider === "anthropic") return anthropicModels.includes(data.model);
+      if (data.provider === "google") return googleModels.includes(data.model);
+      return false;
+    },
+    {
+      message: "Model must match provider: anthropic → haiku|sonnet|opus, google → flash-lite|flash|pro",
+      path: ["model"],
+    },
+  )
   .openapi("PlatformConfigRequest");
 
 export const PlatformConfigResponseSchema = z
@@ -241,6 +303,12 @@ export const PlatformConfigResponseSchema = z
     key: z.string(),
     systemPrompt: z.string(),
     allowedTools: z.array(z.string()),
+    provider: z.enum(["anthropic", "google"]).nullable().openapi({
+      description: "LLM provider. Null means default (anthropic).",
+    }),
+    model: z.string().nullable().openapi({
+      description: "Model alias. Null means provider default (sonnet for anthropic, pro for google).",
+    }),
     createdAt: z.string(),
     updatedAt: z.string(),
   })

--- a/tests/unit/config-provider-model.test.ts
+++ b/tests/unit/config-provider-model.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import { AppConfigRequestSchema, PlatformConfigRequestSchema } from "../../src/schemas.js";
+
+const validBase = {
+  key: "workflow",
+  systemPrompt: "You are a helpful assistant.",
+  allowedTools: ["request_user_input"],
+};
+
+describe("AppConfigRequestSchema provider/model", () => {
+  it("accepts config without provider/model (backward compat)", () => {
+    const result = AppConfigRequestSchema.safeParse(validBase);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.provider).toBeUndefined();
+      expect(result.data.model).toBeUndefined();
+    }
+  });
+
+  it("accepts anthropic provider with sonnet model", () => {
+    const result = AppConfigRequestSchema.safeParse({
+      ...validBase,
+      provider: "anthropic",
+      model: "sonnet",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts google provider with pro model", () => {
+    const result = AppConfigRequestSchema.safeParse({
+      ...validBase,
+      provider: "google",
+      model: "pro",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts google provider with flash-lite model", () => {
+    const result = AppConfigRequestSchema.safeParse({
+      ...validBase,
+      provider: "google",
+      model: "flash-lite",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects anthropic provider with google model", () => {
+    const result = AppConfigRequestSchema.safeParse({
+      ...validBase,
+      provider: "anthropic",
+      model: "pro",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects google provider with anthropic model", () => {
+    const result = AppConfigRequestSchema.safeParse({
+      ...validBase,
+      provider: "google",
+      model: "sonnet",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects unknown provider", () => {
+    const result = AppConfigRequestSchema.safeParse({
+      ...validBase,
+      provider: "openai",
+      model: "gpt-4",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts provider without model (uses default)", () => {
+    const result = AppConfigRequestSchema.safeParse({
+      ...validBase,
+      provider: "google",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.provider).toBe("google");
+      expect(result.data.model).toBeUndefined();
+    }
+  });
+
+  it("accepts model without provider (cross-validation skipped)", () => {
+    const result = AppConfigRequestSchema.safeParse({
+      ...validBase,
+      model: "sonnet",
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("PlatformConfigRequestSchema provider/model", () => {
+  it("accepts config without provider/model", () => {
+    const result = PlatformConfigRequestSchema.safeParse(validBase);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts google/pro", () => {
+    const result = PlatformConfigRequestSchema.safeParse({
+      ...validBase,
+      provider: "google",
+      model: "pro",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects mismatched provider/model", () => {
+    const result = PlatformConfigRequestSchema.safeParse({
+      ...validBase,
+      provider: "google",
+      model: "opus",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/unit/gemini-chat.test.ts
+++ b/tests/unit/gemini-chat.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { toGeminiFunctionDeclarations, type ToolDefinition } from "../../src/lib/gemini-chat.js";
+
+describe("toGeminiFunctionDeclarations", () => {
+  it("converts Anthropic-style tool definitions to Gemini format", () => {
+    const tools: ToolDefinition[] = [
+      {
+        name: "get_weather",
+        description: "Get the weather for a city",
+        input_schema: {
+          type: "object",
+          properties: {
+            city: { type: "string", description: "City name" },
+            units: { type: "string", enum: ["celsius", "fahrenheit"] },
+          },
+          required: ["city"],
+        },
+      },
+    ];
+
+    const result = toGeminiFunctionDeclarations(tools);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("get_weather");
+    expect(result[0].description).toBe("Get the weather for a city");
+    expect(result[0].parameters.type).toBe("object");
+    expect(result[0].parameters.properties).toEqual({
+      city: { type: "string", description: "City name" },
+      units: { type: "string", enum: ["celsius", "fahrenheit"] },
+    });
+    expect(result[0].parameters.required).toEqual(["city"]);
+  });
+
+  it("omits required when empty", () => {
+    const tools: ToolDefinition[] = [
+      {
+        name: "list_items",
+        description: "List all items",
+        input_schema: {
+          type: "object",
+          properties: {},
+        },
+      },
+    ];
+
+    const result = toGeminiFunctionDeclarations(tools);
+    expect(result[0].parameters.required).toBeUndefined();
+  });
+
+  it("converts multiple tools", () => {
+    const tools: ToolDefinition[] = [
+      {
+        name: "tool_a",
+        description: "Tool A",
+        input_schema: { type: "object", properties: { x: { type: "string" } }, required: ["x"] },
+      },
+      {
+        name: "tool_b",
+        description: "Tool B",
+        input_schema: { type: "object", properties: { y: { type: "number" } } },
+      },
+    ];
+
+    const result = toGeminiFunctionDeclarations(tools);
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe("tool_a");
+    expect(result[1].name).toBe("tool_b");
+  });
+
+  it("handles empty tools array", () => {
+    expect(toGeminiFunctionDeclarations([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Chat configs (`PUT /config`, `PUT /platform-config`) now accept optional `provider` and `model` fields
- `/chat` endpoint resolves the configured provider and branches to **Gemini streaming** or **Anthropic streaming** accordingly
- Existing configs without `provider`/`model` default to Anthropic Sonnet (backward compatible)
- New Gemini streaming chat client (`gemini-chat.ts`) with function calling and thinking support via REST SSE
- Shared tool execution logic — both providers use the same `executeTool()` function
- Cost reporting uses the resolved model's cost prefix (not hardcoded Anthropic)

## Key changes

| File | What |
|------|------|
| `drizzle/0013_add_provider_model_to_configs.sql` | Migration: nullable `provider`/`model` columns on both config tables |
| `src/db/schema.ts` | Drizzle schema update |
| `src/schemas.ts` | Zod schemas with provider/model cross-validation |
| `src/index.ts` | Config endpoints persist provider/model; `/chat` branches by provider |
| `src/lib/gemini-chat.ts` | **New** — Gemini streaming chat with function calling |
| `openapi.json` | Regenerated |

## Test plan

- [x] `npm run build` — compiles clean
- [x] All 485 unit tests pass (43 suites)
- [x] New tests: `config-provider-model.test.ts` (12 tests), `gemini-chat.test.ts` (4 tests)
- [ ] Manual: PUT /platform-config with `provider: "google", model: "pro"` → verify stored
- [ ] Manual: POST /chat with Gemini config → verify streaming + tool calling works

🤖 Generated with [Claude Code](https://claude.com/claude-code)