### PR TITLE
fix: add migration 0013 to drizzle journal

### DIFF
--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1775145600000,
       "tag": "0012_move_tracking_to_sessions",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1775232000000,
+      "tag": "0013_add_provider_model_to_configs",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- The SQL migration file `0013_add_provider_model_to_configs.sql` existed but was missing from `drizzle/meta/_journal.json`
- Drizzle's `migrate()` only runs migrations listed in the journal, so the `provider`/`model` columns were never created
- This caused `PostgresError: column "provider" of relation "platform_configs" does not exist` on startup when api-service's instrumentation calls `PUT /platform-config`

## Test plan

- [x] Build passes
- [x] All 485 unit tests pass
- [ ] Deploy to staging — verify migration runs and service starts without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)