### PR TITLE
feat: add structured trace event logging via traceEvent helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token st
 | `KEY_SERVICE_URL` | No | Key-service endpoint (default: `https://key.mcpfactory.org`) |
 | `CHAT_SERVICE_DATABASE_URL` | Yes | PostgreSQL connection string |
 | `RUNS_SERVICE_URL` | No | RunsService endpoint (default: `https://runs.mcpfactory.org`) |
-| `RUNS_SERVICE_API_KEY` | No | API key for RunsService (runs tracking disabled if unset) |
+| `RUNS_SERVICE_API_KEY` | No | API key for RunsService (runs tracking and trace events disabled if unset) |
 | `BILLING_SERVICE_URL` | No | Billing-service endpoint (default: `https://billing.mcpfactory.org`) |
 | `BILLING_SERVICE_API_KEY` | Yes | API key for billing-service — required for credit authorization on platform-key requests |
 | `PORT` | No | Server port (default: `3002`) |
@@ -495,6 +495,17 @@ Migrations run automatically on server start. To generate new migrations after s
 ```bash
 npm run db:generate
 ```
+
+## Trace Events
+
+`/chat` and `/complete` emit structured trace events to runs-service via `POST /v1/runs/{runId}/events`. Calls are fire-and-forget — failures are logged but never throw or block the request. Disabled when `RUNS_SERVICE_API_KEY` is unset.
+
+| Endpoint | Events emitted |
+|---|---|
+| `/complete` | `run-created`, `llm-call-start`, `llm-call-done`, `llm-call-failed` |
+| `/chat` | `run-created`, `stream-start`, `stream-done`, `stream-failed` |
+
+Body shape: `{ service: "chat-service", event, detail?, level?, data? }`. All identity (`x-org-id`, `x-user-id`, `x-run-id`, `x-api-key`) and tracking headers (`x-brand-id`, `x-campaign-id`, `x-workflow-slug`, `x-feature-slug`) are forwarded.
 
 ## Scripts
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import {
 import { getPromptTemplate, updatePromptTemplate } from "./lib/content-generation-client.js";
 import { listServices, listServiceEndpoints } from "./lib/api-registry-client.js";
 import { createRun, updateRunStatus, addRunCosts } from "./lib/runs-client.js";
+import { traceEvent } from "./lib/trace-event.js";
 import { createFeature, updateFeature, listFeatures, getFeature, getFeatureInputs, prefillFeature, getFeatureStats } from "./lib/features-client.js";
 import { extractBrandFields } from "./lib/brand-client.js";
 import { scrapeUrl } from "./lib/scraping-client.js";
@@ -527,6 +528,9 @@ app.post("/complete", requireAuth, async (req, res) => {
       trackingHeaders,
     );
     runId = run.id;
+    traceEvent(runId, "run-created", { orgId, userId }, workflowTracking, {
+      data: { taskName: "complete", parentRunId, provider, model: effectiveModel },
+    });
   } catch (runErr) {
     console.error(`[complete] org="${orgId}" run creation failed:`, runErr);
     return res.status(502).json({
@@ -562,6 +566,12 @@ app.post("/complete", requireAuth, async (req, res) => {
 
     let result: { content: string; tokensInput: number; tokensOutput: number; model: string };
 
+    if (runId) {
+      traceEvent(runId, "llm-call-start", { orgId, userId }, workflowTracking, {
+        data: { provider, model: effectiveModel, responseFormat },
+      });
+    }
+
     if (isGemini) {
       result = await completeWithGemini({
         apiKey: resolvedKey.key,
@@ -586,6 +596,17 @@ app.post("/complete", requireAuth, async (req, res) => {
     totalPromptTokens = result.tokensInput;
     totalOutputTokens = result.tokensOutput;
 
+    if (runId) {
+      traceEvent(runId, "llm-call-done", { orgId, userId }, workflowTracking, {
+        data: {
+          provider,
+          model: result.model,
+          tokensInput: result.tokensInput,
+          tokensOutput: result.tokensOutput,
+        },
+      });
+    }
+
     // Build response
     const response: Record<string, unknown> = {
       content: result.content,
@@ -607,6 +628,13 @@ app.post("/complete", requireAuth, async (req, res) => {
   } catch (err) {
     completeFailed = true;
     console.error(`[complete] org="${orgId}" error:`, err);
+    if (runId) {
+      traceEvent(runId, "llm-call-failed", { orgId, userId }, workflowTracking, {
+        level: "error",
+        detail: err instanceof Error ? err.message : String(err),
+        data: { provider, model: effectiveModel },
+      });
+    }
     res.status(502).json({
       error: "LLM call failed. Please try again.",
     });
@@ -895,6 +923,16 @@ app.post("/chat", requireAuth, async (req, res) => {
         trackingHeaders,
       );
       runId = run.id;
+      traceEvent(runId, "run-created", { orgId, userId }, workflowTracking, {
+        data: {
+          taskName: "chat",
+          parentRunId,
+          sessionId: currentSessionId,
+          provider: chatProvider,
+          model: resolvedModelInfo.apiModelId,
+          configKey,
+        },
+      });
       // Update session with this service's run ID
       await db.update(sessions)
         .set({ runId, updatedAt: new Date() })
@@ -1436,6 +1474,17 @@ app.post("/chat", requireAuth, async (req, res) => {
     // Provider-specific: Gemini uses streamGeminiChat(), Anthropic uses SDK
     // -----------------------------------------------------------------------
 
+    if (runId) {
+      traceEvent(runId, "stream-start", { orgId, userId }, workflowTracking, {
+        data: {
+          provider: chatProvider,
+          model: resolvedModelInfo.apiModelId,
+          historyLength: history.length,
+          toolCount: allTools.length,
+        },
+      });
+    }
+
     if (isGeminiChat) {
       // --- Gemini streaming path ---
       const geminiToolDefs: ToolDefinition[] = allTools.map((t) => ({
@@ -1730,11 +1779,35 @@ app.post("/chat", requireAuth, async (req, res) => {
       tokenCount: totalPromptTokens + totalOutputTokens || null,
     });
 
+    if (runId) {
+      traceEvent(runId, "stream-done", { orgId, userId }, workflowTracking, {
+        data: {
+          provider: chatProvider,
+          model: resolvedModelInfo.apiModelId,
+          tokensInput: totalPromptTokens,
+          tokensOutput: totalOutputTokens,
+          toolCallCount: toolCalls.length,
+          buttonCount: buttons.length,
+        },
+      });
+    }
+
     sendSSE(res, "[DONE]");
   } catch (err) {
     chatFailed = true;
     const { message: errorMessage, code: errorCode } = classifyErrorForClient(err);
     console.error(`[chat] org="${orgId}" error code="${errorCode}":`, err);
+    if (runId) {
+      traceEvent(runId, "stream-failed", { orgId, userId }, workflowTracking, {
+        level: "error",
+        detail: err instanceof Error ? err.message : String(err),
+        data: {
+          provider: chatProvider,
+          model: resolvedModelInfo.apiModelId,
+          code: errorCode,
+        },
+      });
+    }
     sendSSE(res, {
       type: "error",
       code: errorCode,

--- a/src/lib/trace-event.ts
+++ b/src/lib/trace-event.ts
@@ -1,0 +1,83 @@
+import type { WorkflowTrackingHeaders } from "../middleware/auth.js";
+
+const RUNS_SERVICE_URL =
+  process.env.RUNS_SERVICE_URL || "https://runs.mcpfactory.org";
+const RUNS_SERVICE_API_KEY = process.env.RUNS_SERVICE_API_KEY;
+
+const SERVICE_NAME = "chat-service";
+
+export interface TraceIdentity {
+  orgId: string;
+  userId: string;
+}
+
+export interface TraceEventOptions {
+  detail?: string;
+  level?: "info" | "warn" | "error";
+  data?: Record<string, unknown>;
+}
+
+interface TraceEventBody {
+  service: string;
+  event: string;
+  detail?: string;
+  level?: "info" | "warn" | "error";
+  data?: Record<string, unknown>;
+}
+
+function buildTraceHeaders(
+  runId: string,
+  identity: TraceIdentity,
+  tracking: WorkflowTrackingHeaders,
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "x-api-key": RUNS_SERVICE_API_KEY as string,
+    "x-org-id": identity.orgId,
+    "x-user-id": identity.userId,
+    "x-run-id": runId,
+  };
+  if (tracking.brandId) headers["x-brand-id"] = tracking.brandId;
+  if (tracking.campaignId) headers["x-campaign-id"] = tracking.campaignId;
+  if (tracking.workflowSlug) headers["x-workflow-slug"] = tracking.workflowSlug;
+  if (tracking.featureSlug) headers["x-feature-slug"] = tracking.featureSlug;
+  return headers;
+}
+
+export function traceEvent(
+  runId: string,
+  event: string,
+  identity: TraceIdentity,
+  tracking: WorkflowTrackingHeaders,
+  options?: TraceEventOptions,
+): void {
+  if (!RUNS_SERVICE_API_KEY) return;
+
+  const body: TraceEventBody = { service: SERVICE_NAME, event };
+  if (options?.detail !== undefined) body.detail = options.detail;
+  if (options?.level !== undefined) body.level = options.level;
+  if (options?.data !== undefined) body.data = options.data;
+
+  const url = `${RUNS_SERVICE_URL}/v1/runs/${runId}/events`;
+  const headers = buildTraceHeaders(runId, identity, tracking);
+
+  fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  })
+    .then(async (res) => {
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        console.warn(
+          `[chat-service] traceEvent failed event="${event}" runId="${runId}" status=${res.status}: ${text}`,
+        );
+      }
+    })
+    .catch((err) => {
+      console.warn(
+        `[chat-service] traceEvent fetch error event="${event}" runId="${runId}":`,
+        err,
+      );
+    });
+}

--- a/tests/unit/trace-event.test.ts
+++ b/tests/unit/trace-event.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  process.env.RUNS_SERVICE_API_KEY = "test-runs-key";
+  process.env.RUNS_SERVICE_URL = "https://runs.test.local";
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.restoreAllMocks();
+});
+
+async function loadModule() {
+  vi.resetModules();
+  return import("../../src/lib/trace-event.js");
+}
+
+const identity = { orgId: "org-uuid-123", userId: "user-uuid-456" };
+const tracking = {
+  brandId: "brand-1",
+  campaignId: "camp-1",
+  workflowSlug: "wf-1",
+  featureSlug: "ft-1",
+};
+
+function flushAsync() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe("traceEvent — happy path", () => {
+  it("POSTs to /v1/runs/{runId}/events with correct method and URL", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(""),
+    });
+
+    const { traceEvent } = await loadModule();
+    traceEvent("run-1", "stream-start", identity, {});
+    await flushAsync();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe("https://runs.test.local/v1/runs/run-1/events");
+    expect(init.method).toBe("POST");
+  });
+
+  it("body always includes service and event", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(""),
+    });
+
+    const { traceEvent } = await loadModule();
+    traceEvent("run-1", "llm-call-start", identity, {});
+    await flushAsync();
+
+    const body = JSON.parse(
+      (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body,
+    );
+    expect(body.service).toBe("chat-service");
+    expect(body.event).toBe("llm-call-start");
+  });
+});
+
+describe("traceEvent — header forwarding", () => {
+  it("forwards identity headers and api key", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(""),
+    });
+
+    const { traceEvent } = await loadModule();
+    traceEvent("run-1", "stream-start", identity, {});
+    await flushAsync();
+
+    const headers = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].headers;
+    expect(headers["x-api-key"]).toBe("test-runs-key");
+    expect(headers["x-org-id"]).toBe("org-uuid-123");
+    expect(headers["x-user-id"]).toBe("user-uuid-456");
+    expect(headers["x-run-id"]).toBe("run-1");
+    expect(headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("forwards tracking headers when provided", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(""),
+    });
+
+    const { traceEvent } = await loadModule();
+    traceEvent("run-1", "stream-start", identity, tracking);
+    await flushAsync();
+
+    const headers = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].headers;
+    expect(headers["x-brand-id"]).toBe("brand-1");
+    expect(headers["x-campaign-id"]).toBe("camp-1");
+    expect(headers["x-workflow-slug"]).toBe("wf-1");
+    expect(headers["x-feature-slug"]).toBe("ft-1");
+  });
+
+  it("omits tracking headers that are absent", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(""),
+    });
+
+    const { traceEvent } = await loadModule();
+    traceEvent("run-1", "stream-start", identity, { brandId: "brand-1" });
+    await flushAsync();
+
+    const headers = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].headers;
+    expect(headers["x-brand-id"]).toBe("brand-1");
+    expect(headers).not.toHaveProperty("x-campaign-id");
+    expect(headers).not.toHaveProperty("x-workflow-slug");
+    expect(headers).not.toHaveProperty("x-feature-slug");
+  });
+});
+
+describe("traceEvent — optional fields", () => {
+  it("includes detail, level, and data when provided", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(""),
+    });
+
+    const { traceEvent } = await loadModule();
+    traceEvent("run-1", "llm-call-failed", identity, {}, {
+      detail: "timeout",
+      level: "error",
+      data: { provider: "anthropic", attempt: 2 },
+    });
+    await flushAsync();
+
+    const body = JSON.parse(
+      (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body,
+    );
+    expect(body.detail).toBe("timeout");
+    expect(body.level).toBe("error");
+    expect(body.data).toEqual({ provider: "anthropic", attempt: 2 });
+  });
+
+  it("omits detail, level, and data when absent", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(""),
+    });
+
+    const { traceEvent } = await loadModule();
+    traceEvent("run-1", "stream-start", identity, {});
+    await flushAsync();
+
+    const body = JSON.parse(
+      (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body,
+    );
+    expect(body).not.toHaveProperty("detail");
+    expect(body).not.toHaveProperty("level");
+    expect(body).not.toHaveProperty("data");
+  });
+});
+
+describe("traceEvent — missing API key", () => {
+  it("skips fetch and does not throw when RUNS_SERVICE_API_KEY is unset", async () => {
+    delete process.env.RUNS_SERVICE_API_KEY;
+
+    const { traceEvent } = await loadModule();
+    expect(() =>
+      traceEvent("run-1", "stream-start", identity, tracking),
+    ).not.toThrow();
+    await flushAsync();
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("traceEvent — error swallowing (fire-and-forget)", () => {
+  it("does not throw when fetch rejects", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("ECONNREFUSED"),
+    );
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { traceEvent } = await loadModule();
+    expect(() =>
+      traceEvent("run-1", "stream-start", identity, {}),
+    ).not.toThrow();
+    await flushAsync();
+
+    expect(fetch).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("does not throw on HTTP non-ok response", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("Internal Server Error"),
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { traceEvent } = await loadModule();
+    expect(() =>
+      traceEvent("run-1", "stream-start", identity, {}),
+    ).not.toThrow();
+    await flushAsync();
+
+    expect(fetch).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `src/lib/trace-event.ts` — fire-and-forget helper POSTing to runs-service `/v1/runs/{runId}/events`
- Instruments `/complete` with `run-created`, `llm-call-start`, `llm-call-done`, `llm-call-failed`
- Instruments `/chat` with `run-created`, `stream-start`, `stream-done`, `stream-failed`
- Reuses `RUNS_SERVICE_URL` / `RUNS_SERVICE_API_KEY` and matching identity + tracking header pattern from `runs-client.ts`. No new env vars.
- Skips silently when `RUNS_SERVICE_API_KEY` unset; swallows all fetch errors (logs warning) so trace failures never affect the request

## Test plan
- [x] New unit tests in `tests/unit/trace-event.test.ts` (10 cases): happy POST, body shape, identity header forwarding, tracking header forwarding/omission, missing API key skip, fetch reject swallow, HTTP non-ok swallow, optional `detail`/`level`/`data` fields
- [x] `npm run test:unit` — 503 passed
- [x] `npm run build` — typecheck + openapi generate clean
- [x] `git diff openapi.json` — empty (no schema changes)
- [x] README updated: env table note + new "Trace Events" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)