### PR TITLE
feat: add `/orgs/rag/score` semantic scoring endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,66 @@ Response:
 
 Idempotent — running it twice with the same params is a no-op (all rows already updated).
 
+## RAG Score (`/orgs/rag/score`)
+
+`POST /orgs/rag/score` — score a batch of documents against a brand profile using semantic similarity.
+
+Used by **journalists-quotes-service** to rank quote requests against a brand for outreach, and by any other consumer that needs cheap document-vs-brand scoring without spending an LLM call per document.
+
+**Auth:** `x-api-key` + `x-org-id` + `x-user-id` + `x-run-id` (standard).
+
+**Request:**
+```json
+{
+  "brandId": "550e8400-e29b-41d4-a716-446655440000",
+  "documents": [
+    { "id": "quote-7c2b", "text": "Looking to interview a B2B SaaS founder about pricing experiments." },
+    { "id": "quote-9f1a", "text": "Need a quote on AI safety from a research lab." }
+  ],
+  "query": "B2B SaaS pricing experiments"   // optional override
+}
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `brandId` | yes | UUID. Brand whose profile is used as the semantic query. |
+| `documents` | yes | 1–100 items. Each has `id` (caller-supplied, returned verbatim) and `text` (body to embed). |
+| `query` | no | When omitted, the service synthesizes a query from the brand profile (industry, expertise, target audience, voice). When present, the override is used directly. |
+
+**Response:**
+```json
+{
+  "brandId": "550e8400-e29b-41d4-a716-446655440000",
+  "queryText": "industry: B2B SaaS\nexpertise: pricing experiments\ntarget audience: founders\nvoice: data-driven",
+  "cacheHit": true,
+  "model": "gemini-embedding-001",
+  "results": [
+    { "id": "quote-7c2b", "score": 0.92 },
+    { "id": "quote-9f1a", "score": 0.18 }
+  ]
+}
+```
+
+`results` is sorted by `score` descending. Scores are cosine similarity in `[0, 1]` (negatives clamped to `0`).
+
+**Pipeline:**
+1. Resolve brand context from brand-service (`industry`, `expertise`, `target_audience`, `voice`).
+2. Synthesize a brand-profile query string (or use `query` override).
+3. Compute the brand-profile embedding via Gemini `gemini-embedding-001` (cached per `(orgId, brandId, contentHash)` in the `brand_profile_embeddings` table — only the brand-profile vector is cached; document vectors are recomputed per request).
+4. Batch-embed every `documents[i].text`.
+5. Cosine similarity between brand-profile vector and each document vector.
+
+The cache automatically invalidates when **any** resolved brand field changes (the hash covers all fields). Repeated calls with unchanged brand context skip the brand-profile Gemini call entirely.
+
+**Errors:**
+- `400` — validation (`documents` empty, `documents.length > 100`, `brandId` not UUID, etc.) or empty resolved brand profile (provide an explicit `query` when this happens).
+- `404` — `brandId` not found in brand-service.
+- `502` — upstream failure (brand-service, key-service, runs-service, or Gemini).
+
+**Volume:** designed for batches of up to **100** documents per request. Larger batches must be chunked by the caller.
+
+The Gemini embedding model defaults to `gemini-embedding-001` and is overridable via `GEMINI_EMBEDDING_MODEL`. Key resolution uses the standard `google` provider in key-service.
+
 ## Campaign Context Enrichment
 
 When the `x-campaign-id` header is present, both `/chat` and `/complete` automatically fetch the campaign's `featureInputs` from campaign-service and inject them into the system prompt. This ensures every LLM call is informed by the user's campaign-specific inputs (editorial angle, target geography, audience type, etc.).
@@ -493,16 +553,18 @@ Listen for the `{"type":"buttons"}` SSE event. It arrives **after** all token st
 | `RUNS_SERVICE_API_KEY` | No | API key for RunsService (runs tracking and trace events disabled if unset) |
 | `BILLING_SERVICE_URL` | No | Billing-service endpoint (default: `https://billing.mcpfactory.org`) |
 | `BILLING_SERVICE_API_KEY` | Yes | API key for billing-service — required for credit authorization on platform-key requests |
+| `GEMINI_EMBEDDING_MODEL` | No | Gemini embedding model used by `/orgs/rag/score` (default: `gemini-embedding-001`) |
 | `PORT` | No | Server port (default: `3002`) |
 
 ## Database
 
-Uses PostgreSQL via Drizzle ORM. Four tables:
+Uses PostgreSQL via Drizzle ORM. Five tables:
 
 - **sessions** — conversation sessions scoped by `orgId` and `userId`. Stores all identity/tracking context: `runId` (this service's run), `parentRunId` (caller's run from `x-run-id` header), `campaignId`, `brandIds` (text array for multi-brand support), `workflowSlug`, `featureSlug`
 - **messages** — chat messages with role, content, optional `toolCalls`, `buttons`, `contentBlocks` JSONB (stores full Anthropic content blocks for context management)
 - **app_configs** — per-org configuration keyed by `(orgId, key)`. Each entry defines a system prompt and `allowedTools` for a specific chat mode.
 - **platform_configs** — platform-wide configuration keyed by `key`. Fallback when no per-org config exists for the same key.
+- **brand_profile_embeddings** — cached Gemini embeddings of the brand-profile query, keyed by `(orgId, brandId, contentHash)`. Used by `/orgs/rag/score` so identical brand contexts skip the brand-profile embedding call. Document embeddings are not cached.
 
 Migrations run automatically on server start. To generate new migrations after schema changes:
 
@@ -516,6 +578,7 @@ npm run db:generate
 
 | Endpoint | Events emitted |
 |---|---|
+| `/orgs/rag/score` | `run-created`, `rag-score-done`, `rag-score-failed` |
 | `/complete` | `run-created`, `llm-call-start`, `llm-call-done`, `llm-call-failed` |
 | `/chat` | `run-created`, `stream-start`, `stream-done`, `stream-failed` |
 

--- a/drizzle/0014_add_brand_profile_embeddings.sql
+++ b/drizzle/0014_add_brand_profile_embeddings.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS "brand_profile_embeddings" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"org_id" text NOT NULL,
+	"brand_id" text NOT NULL,
+	"content_hash" text NOT NULL,
+	"query_text" text NOT NULL,
+	"embedding" jsonb NOT NULL,
+	"model" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "brand_profile_embeddings_org_brand_hash_unique" UNIQUE("org_id","brand_id","content_hash")
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "brand_profile_embeddings_org_brand_idx" ON "brand_profile_embeddings" ("org_id","brand_id");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1775232000000,
       "tag": "0013_add_provider_model_to_configs",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1776009600000,
+      "tag": "0014_add_brand_profile_embeddings",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -891,6 +891,111 @@
           "targetOrgId"
         ],
         "additionalProperties": false
+      },
+      "RagScoreResponse": {
+        "type": "object",
+        "properties": {
+          "brandId": {
+            "type": "string",
+            "description": "Echo of the request brandId."
+          },
+          "queryText": {
+            "type": "string",
+            "description": "The brand-profile query string that was embedded. Useful for debugging and auditing."
+          },
+          "cacheHit": {
+            "type": "boolean",
+            "description": "Whether the brand-profile embedding was served from cache."
+          },
+          "model": {
+            "type": "string",
+            "description": "The Gemini embedding model used.",
+            "example": "gemini-embedding-001"
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RagScoreResult"
+            },
+            "description": "Per-document scores, sorted by score descending."
+          }
+        },
+        "required": [
+          "brandId",
+          "queryText",
+          "cacheHit",
+          "model",
+          "results"
+        ]
+      },
+      "RagScoreResult": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Document id from the request, preserved verbatim."
+          },
+          "score": {
+            "type": "number",
+            "description": "Cosine similarity in [0, 1] between the document embedding and the brand-profile embedding. Negative values are clamped to 0."
+          }
+        },
+        "required": [
+          "id",
+          "score"
+        ]
+      },
+      "RagScoreRequest": {
+        "type": "object",
+        "properties": {
+          "documents": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RagScoreDocument"
+            },
+            "minItems": 1,
+            "maxItems": 100,
+            "description": "List of documents to score against the brand profile. At most 100 items per request."
+          },
+          "brandId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Brand whose profile is used as the semantic query. Resolved via brand-service (industry, expertise, target audience, voice).",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "query": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Optional override for the brand-profile query string. When omitted, the service synthesizes a query from the resolved brand fields."
+          }
+        },
+        "required": [
+          "documents",
+          "brandId"
+        ],
+        "additionalProperties": false
+      },
+      "RagScoreDocument": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Caller-supplied identifier; preserved verbatim in the response.",
+            "example": "quote-7c2b"
+          },
+          "text": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Free-form text body to embed and score against the brand profile.",
+            "example": "Looking to interview a B2B SaaS founder about pricing experiments for an upcoming feature."
+          }
+        },
+        "required": [
+          "id",
+          "text"
+        ],
+        "additionalProperties": false
       }
     },
     "parameters": {}
@@ -1579,6 +1684,160 @@
           },
           "401": {
             "description": "Missing or invalid x-api-key header",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/orgs/rag/score": {
+      "post": {
+        "tags": [
+          "RAG"
+        ],
+        "summary": "Score documents against a brand profile (semantic similarity)",
+        "description": "RAG-style semantic similarity scoring for picking the best document(s) for a brand.\n\nUsed by journalists-quotes-service to rank quote requests against a brand profile, and by any other consumer that needs cheap document-vs-brand scoring.\n\n**Pipeline:**\n1. Resolve brand context via brand-service (industry, expertise, target audience, voice).\n2. Synthesize a brand-profile query string (or use the caller-supplied `query`).\n3. Compute the brand-profile embedding via Gemini's `gemini-embedding-001` (cached per (orgId, brandId, contentHash)).\n4. Compute embeddings for each `documents[i].text` in a single batch call.\n5. Score = cosine similarity, sorted descending.\n\n**Caching:** the brand-profile embedding is cached. Repeated calls with the same brand context (same resolved fields) reuse the cached vector — only document embeddings are recomputed. The cache automatically invalidates when any resolved brand field changes.\n\n**Volume:** designed for batches up to 100 documents per request.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Service-to-service API key"
+            },
+            "required": true,
+            "description": "Service-to-service API key",
+            "name": "x-api-key",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal org UUID from client-service"
+            },
+            "required": true,
+            "description": "Internal org UUID from client-service",
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal user UUID from client-service"
+            },
+            "required": true,
+            "description": "Internal user UUID from client-service",
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Caller's run ID — used as parentRunId when creating this service's own run in runs-service"
+            },
+            "required": true,
+            "description": "Caller's run ID — used as parentRunId when creating this service's own run in runs-service",
+            "name": "x-run-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID — injected automatically by workflow-service"
+            },
+            "required": false,
+            "description": "Campaign ID — injected automatically by workflow-service",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID(s) — injected automatically by workflow-service. May be a single UUID or a comma-separated list of UUIDs for multi-brand campaigns (e.g. 'uuid1,uuid2,uuid3').",
+              "example": "550e8400-e29b-41d4-a716-446655440000,660f9500-f30c-52e5-b827-557766551111"
+            },
+            "required": false,
+            "description": "Brand ID(s) — injected automatically by workflow-service. May be a single UUID or a comma-separated list of UUIDs for multi-brand campaigns (e.g. 'uuid1,uuid2,uuid3').",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow slug — injected automatically by workflow-service"
+            },
+            "required": false,
+            "description": "Workflow slug — injected automatically by workflow-service",
+            "name": "x-workflow-slug",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug — propagated through the entire service chain"
+            },
+            "required": false,
+            "description": "Feature slug — propagated through the entire service chain",
+            "name": "x-feature-slug",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RagScoreRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Scored results, sorted by score descending",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RagScoreResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid request fields (including documents > cap)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid x-api-key header",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Brand not found in brand-service",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream service unavailable (brand-service, key-service, runs-service, or Gemini)",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, text, timestamp, jsonb, integer, unique } from "drizzle-orm/pg-core";
+import { pgTable, uuid, text, timestamp, jsonb, integer, unique, index } from "drizzle-orm/pg-core";
 
 export const sessions = pgTable("sessions", {
   id: uuid("id").primaryKey().defaultRandom(),
@@ -43,6 +43,31 @@ export const appConfigs = pgTable(
   },
   (table) => [unique("app_configs_org_id_key_unique").on(table.orgId, table.key)],
 );
+
+export const brandProfileEmbeddings = pgTable(
+  "brand_profile_embeddings",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    orgId: text("org_id").notNull(),
+    brandId: text("brand_id").notNull(),
+    contentHash: text("content_hash").notNull(),
+    queryText: text("query_text").notNull(),
+    embedding: jsonb("embedding").notNull().$type<number[]>(),
+    model: text("model").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    unique("brand_profile_embeddings_org_brand_hash_unique").on(
+      table.orgId,
+      table.brandId,
+      table.contentHash,
+    ),
+    index("brand_profile_embeddings_org_brand_idx").on(table.orgId, table.brandId),
+  ],
+);
+
+export type BrandProfileEmbedding = typeof brandProfileEmbeddings.$inferSelect;
+export type NewBrandProfileEmbedding = typeof brandProfileEmbeddings.$inferInsert;
 
 export const platformConfigs = pgTable("platform_configs", {
   id: uuid("id").primaryKey().defaultRandom(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 import { jsonrepair, JSONRepairError } from "jsonrepair";
 import { db } from "./db/index.js";
-import { sessions, messages, appConfigs, platformConfigs } from "./db/schema.js";
+import { sessions, messages, appConfigs, platformConfigs, brandProfileEmbeddings } from "./db/schema.js";
 import { eq, and, sql } from "drizzle-orm";
 import Anthropic from "@anthropic-ai/sdk";
 import {
@@ -34,7 +34,14 @@ import { listServices, listServiceEndpoints } from "./lib/api-registry-client.js
 import { createRun, updateRunStatus, addRunCosts } from "./lib/runs-client.js";
 import { traceEvent } from "./lib/trace-event.js";
 import { createFeature, updateFeature, listFeatures, getFeature, getFeatureInputs, prefillFeature, getFeatureStats } from "./lib/features-client.js";
-import { extractBrandFields } from "./lib/brand-client.js";
+import { extractBrandFields, BrandError } from "./lib/brand-client.js";
+import {
+  embedText,
+  embedTexts,
+  cosineSimilarity,
+  contentHash,
+  DEFAULT_EMBEDDING_MODEL,
+} from "./lib/embeddings.js";
 import { scrapeUrl } from "./lib/scraping-client.js";
 import { formatToolError } from "./lib/tool-errors.js";
 import {
@@ -48,7 +55,7 @@ import {
 } from "./lib/key-client.js";
 import { authorizeCredits, BillingError } from "./lib/billing-client.js";
 import { getCampaignFeatureInputs } from "./lib/campaign-client.js";
-import { ChatRequestSchema, CompleteRequestSchema, InternalPlatformCompleteRequestSchema, AppConfigRequestSchema, PlatformConfigRequestSchema, TransferBrandRequestSchema } from "./schemas.js";
+import { ChatRequestSchema, CompleteRequestSchema, InternalPlatformCompleteRequestSchema, AppConfigRequestSchema, PlatformConfigRequestSchema, TransferBrandRequestSchema, RagScoreRequestSchema } from "./schemas.js";
 import { JSON_RESPONSE_SYSTEM_SUFFIX } from "./lib/json-prompt.js";
 import { requireAuth, requireInternalAuth, type AuthLocals } from "./middleware/auth.js";
 import type { ButtonRecord, ToolCallRecord } from "./db/schema.js";
@@ -661,6 +668,237 @@ app.post("/complete", requireAuth, async (req, res) => {
         ]);
       } catch (runErr) {
         console.error(`[chat-service] /complete failed to finalize run runId="${runId}" orgId="${orgId}":`, runErr);
+      }
+    }
+  }
+});
+
+// --- Org RAG Score (semantic similarity) ---
+//
+// Brand-profile fields used to synthesize the cached query string.
+// Order is fixed so contentHash is stable across calls.
+const RAG_BRAND_FIELDS: Array<{ key: string; description: string }> = [
+  { key: "industry", description: "The brand's primary industry vertical (1-3 words)." },
+  { key: "expertise", description: "Specific topics, problems, or angles the brand is qualified to comment on." },
+  { key: "target_audience", description: "Who the brand sells to or speaks to (job titles, segments, geographies)." },
+  { key: "voice", description: "Brand voice / tone in 1-2 sentences (e.g. data-driven, founder-led, casual)." },
+];
+
+function buildBrandProfileQuery(fields: Record<string, string>): string {
+  const lines: string[] = [];
+  for (const def of RAG_BRAND_FIELDS) {
+    const value = fields[def.key];
+    if (value && value.trim().length > 0) {
+      lines.push(`${def.key.replace(/_/g, " ")}: ${value.trim()}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+app.post("/orgs/rag/score", requireAuth, async (req, res) => {
+  const { orgId, userId, parentRunId, workflowTracking } = res.locals as AuthLocals;
+
+  const baseTrackingHeaders: Record<string, string> = {};
+  if (workflowTracking.campaignId) baseTrackingHeaders["x-campaign-id"] = workflowTracking.campaignId;
+  if (workflowTracking.workflowSlug) baseTrackingHeaders["x-workflow-slug"] = workflowTracking.workflowSlug;
+  if (workflowTracking.featureSlug) baseTrackingHeaders["x-feature-slug"] = workflowTracking.featureSlug;
+
+  const parsed = RagScoreRequestSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res
+      .status(400)
+      .json({ error: "Invalid request", details: parsed.error.flatten() });
+  }
+  const { documents, brandId, query: queryOverride } = parsed.data;
+
+  // Body brandId is the authoritative target — overrides any forwarded x-brand-id.
+  const trackingHeaders: Record<string, string> = {
+    ...baseTrackingHeaders,
+    "x-brand-id": brandId,
+  };
+
+  // Register run (mandatory)
+  let runId: string | null = null;
+  try {
+    const run = await createRun(
+      { serviceName: "chat-service", taskName: "rag-score" },
+      { orgId, userId, runId: parentRunId },
+      trackingHeaders,
+    );
+    runId = run.id;
+    traceEvent(runId, "run-created", { orgId, userId }, workflowTracking, {
+      data: { taskName: "rag-score", parentRunId, brandId, documentCount: documents.length },
+    });
+  } catch (runErr) {
+    console.error(`[rag-score] org="${orgId}" run creation failed:`, runErr);
+    return res.status(502).json({
+      error: "Service temporarily unavailable (run tracking). Please try again.",
+    });
+  }
+
+  let scoreFailed = false;
+  try {
+    // Resolve brand context. Pass own runId so brand-service sees us as the parent.
+    let brandResults;
+    try {
+      brandResults = await extractBrandFields(RAG_BRAND_FIELDS, {
+        orgId,
+        userId,
+        runId,
+        trackingHeaders,
+      });
+    } catch (err) {
+      if (err instanceof BrandError && err.status === 404) {
+        return res.status(404).json({
+          error: `Brand not found: ${brandId}`,
+        });
+      }
+      throw err;
+    }
+
+    // Flatten results into a {key: stringValue} map. Skip null/empty values.
+    const fieldValues: Record<string, string> = {};
+    for (const r of brandResults.results) {
+      if (r.value == null) continue;
+      const str = typeof r.value === "string" ? r.value : JSON.stringify(r.value);
+      if (str.trim().length === 0) continue;
+      fieldValues[r.key] = str;
+    }
+
+    const queryText = queryOverride ?? buildBrandProfileQuery(fieldValues);
+    if (queryText.trim().length === 0) {
+      scoreFailed = true;
+      console.warn(
+        `[rag-score] org="${orgId}" brand="${brandId}" produced empty brand profile (no resolvable fields)`,
+      );
+      return res.status(400).json({
+        error:
+          "Brand profile is empty — no resolvable brand fields. Provide an explicit `query` or enrich the brand in brand-service first.",
+      });
+    }
+
+    // Cache key: hash of the resolved field values (or the override string).
+    const hash = queryOverride
+      ? contentHash({ __override__: queryOverride })
+      : contentHash(fieldValues);
+
+    // Resolve Gemini key once — needed for either branch (cache miss embeds query;
+    // documents always need fresh embeddings).
+    let resolvedKey;
+    try {
+      resolvedKey = await resolveKey({
+        provider: "google",
+        orgId,
+        userId,
+        runId,
+        caller: { method: "POST", path: "/orgs/rag/score" },
+        trackingHeaders,
+      });
+    } catch (err) {
+      console.error(`[rag-score] Failed to resolve google key for org="${orgId}":`, err);
+      return res.status(502).json({
+        error: "Failed to resolve google API key. Ensure the key is configured in key-service.",
+      });
+    }
+
+    // Cache lookup
+    let queryEmbedding: number[];
+    let cacheHit = false;
+    const cached = await db
+      .select()
+      .from(brandProfileEmbeddings)
+      .where(
+        and(
+          eq(brandProfileEmbeddings.orgId, orgId),
+          eq(brandProfileEmbeddings.brandId, brandId),
+          eq(brandProfileEmbeddings.contentHash, hash),
+        ),
+      )
+      .limit(1);
+
+    if (cached.length > 0) {
+      queryEmbedding = cached[0].embedding;
+      cacheHit = true;
+    } else {
+      queryEmbedding = await embedText(resolvedKey.key, queryText);
+      // Race-safe insert: another concurrent request may have already populated it.
+      await db
+        .insert(brandProfileEmbeddings)
+        .values({
+          orgId,
+          brandId,
+          contentHash: hash,
+          queryText,
+          embedding: queryEmbedding,
+          model: DEFAULT_EMBEDDING_MODEL,
+        })
+        .onConflictDoNothing({
+          target: [
+            brandProfileEmbeddings.orgId,
+            brandProfileEmbeddings.brandId,
+            brandProfileEmbeddings.contentHash,
+          ],
+        });
+    }
+
+    // Embed documents in batch
+    const docTexts = documents.map((d) => d.text);
+    const docEmbeddings = await embedTexts(resolvedKey.key, docTexts);
+
+    // Score
+    const scored = documents.map((d, i) => {
+      const raw = cosineSimilarity(queryEmbedding, docEmbeddings[i]);
+      // Clamp negatives to 0 so consumers can treat the score as a [0, 1] confidence.
+      const score = raw < 0 ? 0 : raw;
+      return { id: d.id, score };
+    });
+    scored.sort((a, b) => b.score - a.score);
+
+    if (runId) {
+      traceEvent(runId, "rag-score-done", { orgId, userId }, workflowTracking, {
+        data: {
+          brandId,
+          documentCount: documents.length,
+          cacheHit,
+          model: DEFAULT_EMBEDDING_MODEL,
+        },
+      });
+    }
+
+    res.json({
+      brandId,
+      queryText,
+      cacheHit,
+      model: DEFAULT_EMBEDDING_MODEL,
+      results: scored,
+    });
+  } catch (err) {
+    scoreFailed = true;
+    console.error(`[rag-score] org="${orgId}" brand="${brandId}" error:`, err);
+    if (runId) {
+      traceEvent(runId, "rag-score-failed", { orgId, userId }, workflowTracking, {
+        level: "error",
+        detail: err instanceof Error ? err.message : String(err),
+        data: { brandId },
+      });
+    }
+    res.status(502).json({
+      error: "RAG score failed. Please try again.",
+    });
+  } finally {
+    if (runId) {
+      try {
+        await updateRunStatus(
+          runId,
+          scoreFailed ? "failed" : "completed",
+          { orgId, userId, runId },
+          trackingHeaders,
+        );
+      } catch (runErr) {
+        console.error(
+          `[rag-score] failed to finalize run runId="${runId}" orgId="${orgId}":`,
+          runErr,
+        );
       }
     }
   }

--- a/src/lib/brand-client.ts
+++ b/src/lib/brand-client.ts
@@ -2,6 +2,16 @@ import { apiServiceFetch, type ApiCallParams } from "./api-client.js";
 
 export type BrandCallParams = ApiCallParams;
 
+export class BrandError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly upstreamBody: string,
+  ) {
+    super(`[brand-client] extract-fields failed (${status}): ${upstreamBody}`);
+    this.name = "BrandError";
+  }
+}
+
 // ---------------------------------------------------------------------------
 // POST /brands/extract-fields  (reads x-brand-id from forwarded headers)
 // ---------------------------------------------------------------------------
@@ -38,7 +48,7 @@ export async function extractBrandFields(
 
   if (!res.ok) {
     const text = await res.text().catch(() => "unknown error");
-    throw new Error(`[brand-client] extract-fields failed (${res.status}): ${text}`);
+    throw new BrandError(res.status, text);
   }
 
   return res.json() as Promise<ExtractFieldsResponse>;

--- a/src/lib/embeddings.ts
+++ b/src/lib/embeddings.ts
@@ -1,0 +1,194 @@
+// ---------------------------------------------------------------------------
+// Gemini embeddings client + cosine similarity utilities.
+// Used by POST /orgs/rag/score for RAG-style semantic similarity scoring.
+// ---------------------------------------------------------------------------
+
+import crypto from "crypto";
+
+const GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta";
+
+/** Default Gemini text embedding model. Override per call if needed. */
+export const DEFAULT_EMBEDDING_MODEL =
+  process.env.GEMINI_EMBEDDING_MODEL || "gemini-embedding-001";
+
+/** Cost-name prefix used for billing the embedding model. */
+export function embeddingCostPrefix(model: string): string {
+  return model;
+}
+
+/** HTTP timeout for a single embedding call in ms. */
+const EMBEDDING_TIMEOUT_MS = 30_000;
+
+/** HTTP statuses that warrant a retry. */
+const RETRYABLE_STATUS_CODES = new Set([429, 500, 503, 504]);
+
+/** Max retries before giving up. */
+const MAX_RETRIES = 3;
+
+/** Base delay for exponential backoff. */
+const RETRY_BASE_DELAY_MS = 1_000;
+
+/** Max delay cap. */
+const RETRY_MAX_DELAY_MS = 15_000;
+
+class EmbeddingRetryableError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "EmbeddingRetryableError";
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function retryDelay(attempt: number): number {
+  const exponential = Math.min(RETRY_BASE_DELAY_MS * 2 ** attempt, RETRY_MAX_DELAY_MS);
+  return exponential + Math.random() * 250;
+}
+
+interface BatchEmbedResponseBody {
+  embeddings?: Array<{ values?: number[] }>;
+  error?: { message?: string };
+}
+
+async function callBatchEmbedOnce(
+  model: string,
+  apiKey: string,
+  texts: string[],
+): Promise<number[][]> {
+  const url =
+    `${GEMINI_API_BASE}/models/${encodeURIComponent(model)}:batchEmbedContents` +
+    `?key=${encodeURIComponent(apiKey)}`;
+
+  const requests = texts.map((text) => ({
+    model: `models/${model}`,
+    content: { parts: [{ text }] },
+  }));
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ requests }),
+      signal: AbortSignal.timeout(EMBEDDING_TIMEOUT_MS),
+    });
+  } catch (err: unknown) {
+    if (err instanceof DOMException && err.name === "TimeoutError") {
+      throw new EmbeddingRetryableError(
+        504,
+        `[embeddings] Gemini batchEmbedContents timed out after ${EMBEDDING_TIMEOUT_MS / 1000}s | model=${model}`,
+      );
+    }
+    throw err;
+  }
+
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => "unknown error");
+    if (RETRYABLE_STATUS_CODES.has(res.status)) {
+      throw new EmbeddingRetryableError(
+        res.status,
+        `[embeddings] Gemini API error ${res.status}: ${errorText}`,
+      );
+    }
+    throw new Error(`[embeddings] Gemini API error ${res.status}: ${errorText}`);
+  }
+
+  const data = (await res.json()) as BatchEmbedResponseBody;
+  const embeddings = data.embeddings;
+  if (!Array.isArray(embeddings) || embeddings.length !== texts.length) {
+    throw new Error(
+      `[embeddings] Gemini returned ${embeddings?.length ?? 0} embeddings for ${texts.length} inputs`,
+    );
+  }
+
+  return embeddings.map((e, i) => {
+    const v = e.values;
+    if (!Array.isArray(v) || v.length === 0) {
+      throw new Error(`[embeddings] empty embedding at index ${i}`);
+    }
+    return v;
+  });
+}
+
+/**
+ * Batch-embed a list of text inputs via Gemini's batchEmbedContents endpoint.
+ * Retries on transient errors (429, 500, 503, 504, timeout) with exponential backoff.
+ */
+export async function embedTexts(
+  apiKey: string,
+  texts: string[],
+  model: string = DEFAULT_EMBEDDING_MODEL,
+): Promise<number[][]> {
+  if (texts.length === 0) return [];
+
+  let lastError: Error | undefined;
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    if (attempt > 0) {
+      const delay = retryDelay(attempt - 1);
+      console.warn(
+        `[chat-service] Gemini embed retry ${attempt}/${MAX_RETRIES} after ${Math.round(delay)}ms | model=${model}`,
+      );
+      await sleep(delay);
+    }
+    try {
+      return await callBatchEmbedOnce(model, apiKey, texts);
+    } catch (err: unknown) {
+      if (err instanceof EmbeddingRetryableError) {
+        lastError = err;
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw lastError;
+}
+
+/** Embed a single text input. Convenience wrapper around `embedTexts`. */
+export async function embedText(
+  apiKey: string,
+  text: string,
+  model: string = DEFAULT_EMBEDDING_MODEL,
+): Promise<number[]> {
+  const [vec] = await embedTexts(apiKey, [text], model);
+  return vec;
+}
+
+/**
+ * Cosine similarity between two equal-length vectors.
+ * Returns a value in [-1, 1] (typically [0, 1] for normalized embeddings).
+ * Returns 0 when either vector is the zero vector.
+ */
+export function cosineSimilarity(a: number[], b: number[]): number {
+  if (a.length !== b.length) {
+    throw new Error(`[embeddings] cosineSimilarity: length mismatch ${a.length} vs ${b.length}`);
+  }
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  if (normA === 0 || normB === 0) return 0;
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+/**
+ * Stable content hash of a key/value map. Keys are sorted lexicographically
+ * before hashing so the result is order-independent.
+ *
+ * Used to key the brand-profile embedding cache so that any change to the
+ * resolved brand fields (industry, expertise, target audience, voice, ...)
+ * invalidates the cached embedding.
+ */
+export function contentHash(fields: Record<string, unknown>): string {
+  const sortedKeys = Object.keys(fields).sort();
+  const canonical = JSON.stringify(sortedKeys.map((k) => [k, fields[k]]));
+  return crypto.createHash("sha256").update(canonical).digest("hex");
+}

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1022,3 +1022,154 @@ registry.registerPath({
     },
   },
 });
+
+// --- Org RAG Score ---
+
+export const RAG_SCORE_DOCUMENTS_MAX = 100;
+
+export const RagScoreDocumentSchema = z
+  .object({
+    id: z.string().min(1, "id is required").openapi({
+      description: "Caller-supplied identifier; preserved verbatim in the response.",
+      example: "quote-7c2b",
+    }),
+    text: z.string().min(1, "text is required").openapi({
+      description: "Free-form text body to embed and score against the brand profile.",
+      example:
+        "Looking to interview a B2B SaaS founder about pricing experiments for an upcoming feature.",
+    }),
+  })
+  .strict()
+  .openapi("RagScoreDocument");
+
+export const RagScoreRequestSchema = z
+  .object({
+    documents: z
+      .array(RagScoreDocumentSchema)
+      .min(1, "documents must contain at least one item")
+      .max(
+        RAG_SCORE_DOCUMENTS_MAX,
+        `documents may contain at most ${RAG_SCORE_DOCUMENTS_MAX} items`,
+      )
+      .openapi({
+        description: `List of documents to score against the brand profile. At most ${RAG_SCORE_DOCUMENTS_MAX} items per request.`,
+      }),
+    brandId: z.string().uuid("brandId must be a UUID").openapi({
+      description:
+        "Brand whose profile is used as the semantic query. Resolved via brand-service " +
+        "(industry, expertise, target audience, voice).",
+      example: "550e8400-e29b-41d4-a716-446655440000",
+    }),
+    query: z.string().min(1).optional().openapi({
+      description:
+        "Optional override for the brand-profile query string. When omitted, the service " +
+        "synthesizes a query from the resolved brand fields.",
+    }),
+  })
+  .strict()
+  .openapi("RagScoreRequest");
+
+export const RagScoreResultSchema = z
+  .object({
+    id: z.string().openapi({
+      description: "Document id from the request, preserved verbatim.",
+    }),
+    score: z.number().openapi({
+      description:
+        "Cosine similarity in [0, 1] between the document embedding and the brand-profile " +
+        "embedding. Negative values are clamped to 0.",
+    }),
+  })
+  .openapi("RagScoreResult");
+
+export const RagScoreResponseSchema = z
+  .object({
+    brandId: z.string().openapi({ description: "Echo of the request brandId." }),
+    queryText: z.string().openapi({
+      description:
+        "The brand-profile query string that was embedded. Useful for debugging and auditing.",
+    }),
+    cacheHit: z.boolean().openapi({
+      description: "Whether the brand-profile embedding was served from cache.",
+    }),
+    model: z.string().openapi({
+      description: "The Gemini embedding model used.",
+      example: "gemini-embedding-001",
+    }),
+    results: z.array(RagScoreResultSchema).openapi({
+      description: "Per-document scores, sorted by score descending.",
+    }),
+  })
+  .openapi("RagScoreResponse");
+
+export type RagScoreRequest = z.infer<typeof RagScoreRequestSchema>;
+export type RagScoreResponse = z.infer<typeof RagScoreResponseSchema>;
+
+registry.registerPath({
+  method: "post",
+  path: "/orgs/rag/score",
+  tags: ["RAG"],
+  summary: "Score documents against a brand profile (semantic similarity)",
+  description: `RAG-style semantic similarity scoring for picking the best document(s) for a brand.
+
+Used by journalists-quotes-service to rank quote requests against a brand profile, and by any other consumer that needs cheap document-vs-brand scoring.
+
+**Pipeline:**
+1. Resolve brand context via brand-service (industry, expertise, target audience, voice).
+2. Synthesize a brand-profile query string (or use the caller-supplied \`query\`).
+3. Compute the brand-profile embedding via Gemini's \`gemini-embedding-001\` (cached per (orgId, brandId, contentHash)).
+4. Compute embeddings for each \`documents[i].text\` in a single batch call.
+5. Score = cosine similarity, sorted descending.
+
+**Caching:** the brand-profile embedding is cached. Repeated calls with the same brand context (same resolved fields) reuse the cached vector — only document embeddings are recomputed. The cache automatically invalidates when any resolved brand field changes.
+
+**Volume:** designed for batches up to ${RAG_SCORE_DOCUMENTS_MAX} documents per request.`,
+  request: {
+    headers: z.object({
+      "x-api-key": z.string().openapi({
+        description: "Service-to-service API key",
+      }),
+      "x-org-id": z.string().openapi({
+        description: "Internal org UUID from client-service",
+      }),
+      "x-user-id": z.string().openapi({
+        description: "Internal user UUID from client-service",
+      }),
+      "x-run-id": z.string().uuid().openapi({
+        description:
+          "Caller's run ID — used as parentRunId when creating this service's own run in runs-service",
+      }),
+      ...workflowTrackingHeaders,
+    }),
+    body: {
+      content: { "application/json": { schema: RagScoreRequestSchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Scored results, sorted by score descending",
+      content: {
+        "application/json": { schema: RagScoreResponseSchema },
+      },
+    },
+    400: {
+      description: "Missing or invalid request fields (including documents > cap)",
+      content: {
+        "application/json": { schema: ValidationErrorResponseSchema },
+      },
+    },
+    401: {
+      description: "Missing or invalid x-api-key header",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    404: {
+      description: "Brand not found in brand-service",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    502: {
+      description:
+        "Upstream service unavailable (brand-service, key-service, runs-service, or Gemini)",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});

--- a/tests/integration/rag-score.test.ts
+++ b/tests/integration/rag-score.test.ts
@@ -1,0 +1,497 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach, afterAll } from "vitest";
+import request from "supertest";
+import crypto from "crypto";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { eq, and } from "drizzle-orm";
+import * as schema from "../../src/db/schema.js";
+
+// Force test mode so app.listen() does not run
+process.env.NODE_ENV = "test";
+process.env.KEY_SERVICE_API_KEY = process.env.KEY_SERVICE_API_KEY || "test-key-svc-key";
+process.env.KEY_SERVICE_URL = process.env.KEY_SERVICE_URL || "https://key.test.local";
+process.env.ADMIN_DISTRIBUTE_API_KEY = process.env.ADMIN_DISTRIBUTE_API_KEY || "test-api-svc-key";
+process.env.API_SERVICE_URL = process.env.API_SERVICE_URL || "https://api.test.local";
+process.env.RUNS_SERVICE_API_KEY = process.env.RUNS_SERVICE_API_KEY || "test-runs-key";
+process.env.RUNS_SERVICE_URL = process.env.RUNS_SERVICE_URL || "https://runs.test.local";
+
+const connectionString = process.env.CHAT_SERVICE_DATABASE_URL;
+
+interface MockRoute {
+  match: (url: string, init?: RequestInit) => boolean;
+  respond: (url: string, init?: RequestInit) =>
+    | Promise<{ ok: boolean; status?: number; body: unknown }>
+    | { ok: boolean; status?: number; body: unknown };
+}
+
+let routes: MockRoute[] = [];
+let fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
+
+function installFetchMock() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      fetchCalls.push({ url, init });
+      for (const route of routes) {
+        if (route.match(url, init)) {
+          const out = await route.respond(url, init);
+          return {
+            ok: out.ok,
+            status: out.status ?? (out.ok ? 200 : 500),
+            json: () => Promise.resolve(out.body),
+            text: () =>
+              Promise.resolve(
+                typeof out.body === "string" ? out.body : JSON.stringify(out.body),
+              ),
+            headers: new Headers(),
+          } as unknown as Response;
+        }
+      }
+      throw new Error(`[test] Unmocked fetch: ${url}`);
+    }),
+  );
+}
+
+const RUN_ID_REGEX = /^[0-9a-f-]{36}$/;
+
+function mockRunsCreate(returnRunId: string, capture?: { headers?: Record<string, string> }) {
+  return {
+    match: (url: string, init?: RequestInit) =>
+      url.endsWith("/v1/runs") && (init?.method ?? "GET") === "POST",
+    respond: (_url: string, init?: RequestInit) => {
+      if (capture && init?.headers) {
+        const h = init.headers as Record<string, string>;
+        capture.headers = { ...h };
+      }
+      return {
+        ok: true,
+        status: 201,
+        body: {
+          id: returnRunId,
+          organizationId: "org",
+          serviceName: "chat-service",
+          taskName: "rag-score",
+          status: "running",
+          startedAt: new Date().toISOString(),
+          createdAt: new Date().toISOString(),
+        },
+      };
+    },
+  } satisfies MockRoute;
+}
+
+function mockRunsPatch() {
+  return {
+    match: (url: string, init?: RequestInit) =>
+      /\/v1\/runs\/[^/]+$/.test(url) && (init?.method ?? "GET") === "PATCH",
+    respond: () => ({ ok: true, body: { id: "ok" } }),
+  } satisfies MockRoute;
+}
+
+function mockKeyServiceDecrypt() {
+  return {
+    match: (url: string) => url.includes("/keys/google/decrypt"),
+    respond: () => ({
+      ok: true,
+      body: { provider: "google", key: "fake-google-key", keySource: "platform" },
+    }),
+  } satisfies MockRoute;
+}
+
+function mockBrandExtract(
+  fields: Record<string, string>,
+  capture?: { headers?: Record<string, string>; body?: unknown },
+) {
+  return {
+    match: (url: string, init?: RequestInit) =>
+      url.endsWith("/v1/brands/extract-fields") && (init?.method ?? "GET") === "POST",
+    respond: (_url: string, init?: RequestInit) => {
+      if (capture && init?.headers) {
+        capture.headers = { ...(init.headers as Record<string, string>) };
+      }
+      if (capture && init?.body) {
+        capture.body = JSON.parse(init.body as string);
+      }
+      return {
+        ok: true,
+        body: {
+          brandId: "fake-brand",
+          results: Object.entries(fields).map(([key, value]) => ({
+            key,
+            value,
+            cached: false,
+            extractedAt: new Date().toISOString(),
+            expiresAt: null,
+            sourceUrls: null,
+          })),
+        },
+      };
+    },
+  } satisfies MockRoute;
+}
+
+function mockBrandExtract404() {
+  return {
+    match: (url: string) => url.endsWith("/v1/brands/extract-fields"),
+    respond: () => ({ ok: false, status: 404, body: "brand not found" }),
+  } satisfies MockRoute;
+}
+
+function mockGeminiBatchEmbed(
+  vectors: number[][],
+  capture?: { calls: number; bodies: unknown[] },
+) {
+  return {
+    match: (url: string) =>
+      url.includes(":batchEmbedContents") && url.includes("generativelanguage.googleapis.com"),
+    respond: (_url: string, init?: RequestInit) => {
+      if (capture) {
+        capture.calls += 1;
+        if (init?.body) capture.bodies.push(JSON.parse(init.body as string));
+      }
+      return {
+        ok: true,
+        body: { embeddings: vectors.map((v) => ({ values: v })) },
+      };
+    },
+  } satisfies MockRoute;
+}
+
+beforeAll(() => {
+  if (!connectionString) {
+    throw new Error("CHAT_SERVICE_DATABASE_URL required for integration tests");
+  }
+});
+
+beforeEach(() => {
+  routes = [];
+  fetchCalls = [];
+  installFetchMock();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("POST /orgs/rag/score", { timeout: 30_000 }, () => {
+  let client: ReturnType<typeof postgres>;
+  let db: ReturnType<typeof drizzle<typeof schema>>;
+  let app: Awaited<ReturnType<typeof loadApp>>;
+
+  async function loadApp() {
+    vi.resetModules();
+    const mod = await import("../../src/index.js");
+    return mod.default;
+  }
+
+  beforeAll(async () => {
+    client = postgres(connectionString!);
+    db = drizzle(client, { schema });
+    app = await loadApp();
+  });
+
+  afterAll(async () => {
+    await client?.end();
+  });
+
+  function authHeaders(orgId: string, runId: string) {
+    return {
+      "x-api-key": "test-api-key",
+      "x-org-id": orgId,
+      "x-user-id": crypto.randomUUID(),
+      "x-run-id": runId,
+    };
+  }
+
+  async function cleanupBrandCache(orgId: string, brandId: string) {
+    await db
+      .delete(schema.brandProfileEmbeddings)
+      .where(
+        and(
+          eq(schema.brandProfileEmbeddings.orgId, orgId),
+          eq(schema.brandProfileEmbeddings.brandId, brandId),
+        ),
+      );
+  }
+
+  it("returns sorted results, preserves ids, hits Gemini once for query + once for docs", async () => {
+    const orgId = `org-${crypto.randomUUID()}`;
+    const brandId = crypto.randomUUID();
+    await cleanupBrandCache(orgId, brandId);
+
+    const queryVector = [1, 0, 0];
+    const docVectors = [
+      [-1, 0, 0], // doc-c — opposite, lowest
+      [0.1, 0.99, 0], // doc-a — orthogonal-ish
+      [0.99, 0.1, 0], // doc-b — close, highest
+    ];
+
+    const embedCapture = { calls: 0, bodies: [] as unknown[] };
+    const brandCapture = { headers: undefined as Record<string, string> | undefined, body: undefined as unknown };
+    const runsCapture = { headers: undefined as Record<string, string> | undefined };
+    const ownRunId = crypto.randomUUID();
+
+    routes.push(mockRunsCreate(ownRunId, runsCapture));
+    routes.push(mockRunsPatch());
+    routes.push(
+      mockBrandExtract(
+        { industry: "B2B SaaS", expertise: "pricing experiments", target_audience: "founders", voice: "data-driven" },
+        brandCapture,
+      ),
+    );
+    routes.push(mockKeyServiceDecrypt());
+    // Two batchEmbed calls expected: 1 for query (cache miss), 1 for docs.
+    let embedCallIdx = 0;
+    routes.push({
+      match: (url: string) =>
+        url.includes(":batchEmbedContents") && url.includes("generativelanguage.googleapis.com"),
+      respond: (_url: string, init?: RequestInit) => {
+        embedCapture.calls += 1;
+        if (init?.body) embedCapture.bodies.push(JSON.parse(init.body as string));
+        const idx = embedCallIdx++;
+        const body = idx === 0
+          ? { embeddings: [{ values: queryVector }] }
+          : { embeddings: docVectors.map((v) => ({ values: v })) };
+        return { ok: true, body };
+      },
+    });
+
+    const parentRunId = crypto.randomUUID();
+    const res = await request(app)
+      .post("/orgs/rag/score")
+      .set(authHeaders(orgId, parentRunId))
+      .send({
+        brandId,
+        documents: [
+          { id: "doc-c", text: "irrelevant" },
+          { id: "doc-a", text: "tangential" },
+          { id: "doc-b", text: "perfect match" },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.brandId).toBe(brandId);
+    expect(res.body.cacheHit).toBe(false);
+    expect(res.body.model).toBe("gemini-embedding-001");
+    expect(res.body.results.map((r: { id: string }) => r.id)).toEqual(["doc-b", "doc-a", "doc-c"]);
+    expect(res.body.results[0].score).toBeGreaterThan(res.body.results[1].score);
+    expect(res.body.results[1].score).toBeGreaterThan(res.body.results[2].score);
+    // All scores in [0, 1]
+    for (const r of res.body.results) {
+      expect(r.score).toBeGreaterThanOrEqual(0);
+      expect(r.score).toBeLessThanOrEqual(1);
+    }
+
+    // Expect 2 embed calls (one for query, one batch for docs)
+    expect(embedCapture.calls).toBe(2);
+    // First call is the query, single-text
+    expect((embedCapture.bodies[0] as { requests: unknown[] }).requests).toHaveLength(1);
+    // Second call is the docs batch
+    expect((embedCapture.bodies[1] as { requests: unknown[] }).requests).toHaveLength(3);
+
+    // brand-service got our own runId (not the parent), and our own brandId in headers
+    expect(brandCapture.headers?.["x-run-id"]).toBe(ownRunId);
+    expect(brandCapture.headers?.["x-brand-id"]).toBe(brandId);
+    // runs-service create was called with the parent runId from the request
+    expect(runsCapture.headers?.["x-run-id"]).toBe(parentRunId);
+
+    // Cache row was written
+    const cached = await db
+      .select()
+      .from(schema.brandProfileEmbeddings)
+      .where(
+        and(
+          eq(schema.brandProfileEmbeddings.orgId, orgId),
+          eq(schema.brandProfileEmbeddings.brandId, brandId),
+        ),
+      );
+    expect(cached).toHaveLength(1);
+    expect(cached[0].embedding).toEqual(queryVector);
+
+    await cleanupBrandCache(orgId, brandId);
+  });
+
+  it("hits the cache on second call with unchanged brand context (no second query embed)", async () => {
+    const orgId = `org-${crypto.randomUUID()}`;
+    const brandId = crypto.randomUUID();
+    await cleanupBrandCache(orgId, brandId);
+
+    const queryVector = [1, 0];
+    const docVectors = [[1, 0], [0, 1]];
+
+    type EmbedCapture = { bodies: unknown[] };
+    const setup = (capture: EmbedCapture) => {
+      routes = [];
+      fetchCalls = [];
+      installFetchMock();
+      routes.push(mockRunsCreate(crypto.randomUUID()));
+      routes.push(mockRunsPatch());
+      routes.push(
+        mockBrandExtract({
+          industry: "SaaS",
+          expertise: "pricing",
+          target_audience: "founders",
+          voice: "data-driven",
+        }),
+      );
+      routes.push(mockKeyServiceDecrypt());
+      routes.push({
+        match: (url: string) => url.includes(":batchEmbedContents"),
+        respond: (_url: string, init?: RequestInit) => {
+          const body = JSON.parse(init!.body as string) as { requests: unknown[] };
+          capture.bodies.push(body);
+          return {
+            ok: true,
+            body:
+              body.requests.length === 1
+                ? { embeddings: [{ values: queryVector }] }
+                : { embeddings: docVectors.map((v) => ({ values: v })) },
+          };
+        },
+      });
+    };
+
+    const send = () =>
+      request(app)
+        .post("/orgs/rag/score")
+        .set(authHeaders(orgId, crypto.randomUUID()))
+        .send({
+          brandId,
+          documents: [
+            { id: "x", text: "hello" },
+            { id: "y", text: "world" },
+          ],
+        });
+
+    const cap1: EmbedCapture = { bodies: [] };
+    setup(cap1);
+    const r1 = await send();
+    expect(r1.status).toBe(200);
+    expect(r1.body.cacheHit).toBe(false);
+    const queryCalls1 = cap1.bodies.filter(
+      (b) => (b as { requests: unknown[] }).requests.length === 1,
+    ).length;
+    expect(queryCalls1).toBe(1);
+
+    const cap2: EmbedCapture = { bodies: [] };
+    setup(cap2);
+    const r2 = await send();
+    expect(r2.status).toBe(200);
+    expect(r2.body.cacheHit).toBe(true);
+    const queryCalls2 = cap2.bodies.filter(
+      (b) => (b as { requests: unknown[] }).requests.length === 1,
+    ).length;
+    expect(queryCalls2).toBe(0);
+
+    await cleanupBrandCache(orgId, brandId);
+  });
+
+  it("invalidates cache when brand context changes", async () => {
+    const orgId = `org-${crypto.randomUUID()}`;
+    const brandId = crypto.randomUUID();
+    await cleanupBrandCache(orgId, brandId);
+
+    const queryVector1 = [1, 0];
+    const queryVector2 = [0, 1];
+    const docVectors = [[1, 0]];
+
+    const setup = (brandFields: Record<string, string>, queryVec: number[]) => {
+      routes = [];
+      fetchCalls = [];
+      installFetchMock();
+      routes.push(mockRunsCreate(crypto.randomUUID()));
+      routes.push(mockRunsPatch());
+      routes.push(mockBrandExtract(brandFields));
+      routes.push(mockKeyServiceDecrypt());
+      routes.push({
+        match: (url: string) => url.includes(":batchEmbedContents"),
+        respond: (_url: string, init?: RequestInit) => {
+          const body = JSON.parse(init!.body as string) as { requests: unknown[] };
+          return {
+            ok: true,
+            body:
+              body.requests.length === 1
+                ? { embeddings: [{ values: queryVec }] }
+                : { embeddings: docVectors.map((v) => ({ values: v })) },
+          };
+        },
+      });
+    };
+
+    const send = () =>
+      request(app)
+        .post("/orgs/rag/score")
+        .set(authHeaders(orgId, crypto.randomUUID()))
+        .send({
+          brandId,
+          documents: [{ id: "x", text: "hello" }],
+        });
+
+    setup({ industry: "SaaS", expertise: "pricing", target_audience: "founders", voice: "data-driven" }, queryVector1);
+    const r1 = await send();
+    expect(r1.status).toBe(200);
+    expect(r1.body.cacheHit).toBe(false);
+
+    // Same content → cache hit
+    setup({ industry: "SaaS", expertise: "pricing", target_audience: "founders", voice: "data-driven" }, queryVector1);
+    const r2 = await send();
+    expect(r2.body.cacheHit).toBe(true);
+
+    // Brand voice changed → cache miss → re-embed
+    setup({ industry: "SaaS", expertise: "pricing", target_audience: "founders", voice: "founder-led" }, queryVector2);
+    const r3 = await send();
+    expect(r3.body.cacheHit).toBe(false);
+
+    // Two distinct cache rows now exist (one per content hash)
+    const rows = await db
+      .select()
+      .from(schema.brandProfileEmbeddings)
+      .where(
+        and(
+          eq(schema.brandProfileEmbeddings.orgId, orgId),
+          eq(schema.brandProfileEmbeddings.brandId, brandId),
+        ),
+      );
+    expect(rows).toHaveLength(2);
+
+    await cleanupBrandCache(orgId, brandId);
+  });
+
+  it("returns 400 when documents.length exceeds the cap", async () => {
+    const orgId = `org-${crypto.randomUUID()}`;
+    const brandId = crypto.randomUUID();
+    routes.push(mockRunsCreate(crypto.randomUUID()));
+    routes.push(mockRunsPatch());
+
+    const docs = Array.from({ length: 101 }, (_, i) => ({ id: `d-${i}`, text: "x" }));
+    const res = await request(app)
+      .post("/orgs/rag/score")
+      .set(authHeaders(orgId, crypto.randomUUID()))
+      .send({ brandId, documents: docs });
+
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(res.body)).toMatch(/at most/);
+  });
+
+  it("returns 404 when brand-service reports the brand is missing", async () => {
+    const orgId = `org-${crypto.randomUUID()}`;
+    const brandId = crypto.randomUUID();
+    await cleanupBrandCache(orgId, brandId);
+
+    routes.push(mockRunsCreate(crypto.randomUUID()));
+    routes.push(mockRunsPatch());
+    routes.push(mockBrandExtract404());
+
+    const res = await request(app)
+      .post("/orgs/rag/score")
+      .set(authHeaders(orgId, crypto.randomUUID()))
+      .send({
+        brandId,
+        documents: [{ id: "x", text: "hello" }],
+      });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/Brand not found/);
+  });
+});

--- a/tests/unit/embeddings.test.ts
+++ b/tests/unit/embeddings.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.restoreAllMocks();
+});
+
+async function loadModule() {
+  vi.resetModules();
+  return import("../../src/lib/embeddings.js");
+}
+
+describe("cosineSimilarity", () => {
+  it("returns 1 for identical vectors", async () => {
+    const { cosineSimilarity } = await loadModule();
+    expect(cosineSimilarity([1, 2, 3], [1, 2, 3])).toBeCloseTo(1, 6);
+  });
+
+  it("returns 0 for orthogonal vectors", async () => {
+    const { cosineSimilarity } = await loadModule();
+    expect(cosineSimilarity([1, 0], [0, 1])).toBeCloseTo(0, 6);
+  });
+
+  it("returns -1 for opposite vectors", async () => {
+    const { cosineSimilarity } = await loadModule();
+    expect(cosineSimilarity([1, 0], [-1, 0])).toBeCloseTo(-1, 6);
+  });
+
+  it("returns 0 when either vector is zero", async () => {
+    const { cosineSimilarity } = await loadModule();
+    expect(cosineSimilarity([0, 0, 0], [1, 2, 3])).toBe(0);
+    expect(cosineSimilarity([1, 2, 3], [0, 0, 0])).toBe(0);
+  });
+
+  it("ranks documents by similarity to a query vector", async () => {
+    const { cosineSimilarity } = await loadModule();
+    const query = [1, 0, 0];
+    const docs = [
+      [0, 1, 0], // orthogonal
+      [0.9, 0.1, 0], // close
+      [-1, 0, 0], // opposite
+    ];
+    const scores = docs.map((d) => cosineSimilarity(query, d));
+    expect(scores[1]).toBeGreaterThan(scores[0]);
+    expect(scores[0]).toBeGreaterThan(scores[2]);
+  });
+
+  it("throws on length mismatch", async () => {
+    const { cosineSimilarity } = await loadModule();
+    expect(() => cosineSimilarity([1, 2], [1, 2, 3])).toThrow(/length mismatch/);
+  });
+});
+
+describe("contentHash", () => {
+  it("is deterministic for the same input", async () => {
+    const { contentHash } = await loadModule();
+    const h1 = contentHash({ industry: "SaaS", voice: "data-driven" });
+    const h2 = contentHash({ industry: "SaaS", voice: "data-driven" });
+    expect(h1).toBe(h2);
+  });
+
+  it("is order-independent across keys", async () => {
+    const { contentHash } = await loadModule();
+    const h1 = contentHash({ industry: "SaaS", voice: "data-driven" });
+    const h2 = contentHash({ voice: "data-driven", industry: "SaaS" });
+    expect(h1).toBe(h2);
+  });
+
+  it("changes when any value changes", async () => {
+    const { contentHash } = await loadModule();
+    const h1 = contentHash({ industry: "SaaS", voice: "data-driven" });
+    const h2 = contentHash({ industry: "SaaS", voice: "founder-led" });
+    expect(h1).not.toBe(h2);
+  });
+
+  it("changes when a key is added or removed", async () => {
+    const { contentHash } = await loadModule();
+    const h1 = contentHash({ industry: "SaaS" });
+    const h2 = contentHash({ industry: "SaaS", expertise: "pricing" });
+    expect(h1).not.toBe(h2);
+  });
+
+  it("returns hex sha256 (64 chars)", async () => {
+    const { contentHash } = await loadModule();
+    const h = contentHash({ a: "b" });
+    expect(h).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("embedTexts", () => {
+  it("posts to batchEmbedContents with correct shape", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          embeddings: [
+            { values: [0.1, 0.2, 0.3] },
+            { values: [0.4, 0.5, 0.6] },
+          ],
+        }),
+    });
+
+    const { embedTexts } = await loadModule();
+    const vecs = await embedTexts("test-key", ["hello", "world"], "gemini-embedding-001");
+
+    expect(vecs).toEqual([
+      [0.1, 0.2, 0.3],
+      [0.4, 0.5, 0.6],
+    ]);
+
+    const call = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const url: string = call[0];
+    const init = call[1] as RequestInit;
+    expect(url).toContain(
+      "/v1beta/models/gemini-embedding-001:batchEmbedContents",
+    );
+    expect(url).toContain("key=test-key");
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body as string);
+    expect(body).toEqual({
+      requests: [
+        { model: "models/gemini-embedding-001", content: { parts: [{ text: "hello" }] } },
+        { model: "models/gemini-embedding-001", content: { parts: [{ text: "world" }] } },
+      ],
+    });
+  });
+
+  it("returns empty array for empty input without calling fetch", async () => {
+    const { embedTexts } = await loadModule();
+    const vecs = await embedTexts("test-key", []);
+    expect(vecs).toEqual([]);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("throws on non-retryable HTTP error (e.g. 400)", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: () => Promise.resolve("bad request"),
+    });
+
+    const { embedTexts } = await loadModule();
+    await expect(embedTexts("test-key", ["x"])).rejects.toThrow(/Gemini API error 400/);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when embeddings count differs from input count", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ embeddings: [{ values: [0.1] }] }),
+    });
+
+    const { embedTexts } = await loadModule();
+    await expect(embedTexts("test-key", ["a", "b"])).rejects.toThrow(
+      /returned 1 embeddings for 2 inputs/,
+    );
+  });
+
+  it("throws when any embedding is empty", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ embeddings: [{ values: [] }] }),
+    });
+
+    const { embedTexts } = await loadModule();
+    await expect(embedTexts("test-key", ["a"])).rejects.toThrow(/empty embedding/);
+  });
+});

--- a/tests/unit/rag-score-schema.test.ts
+++ b/tests/unit/rag-score-schema.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import {
+  RagScoreRequestSchema,
+  RAG_SCORE_DOCUMENTS_MAX,
+} from "../../src/schemas.js";
+
+const validBrandId = "550e8400-e29b-41d4-a716-446655440000";
+
+function makeDocs(n: number) {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `doc-${i}`,
+    text: `body ${i}`,
+  }));
+}
+
+describe("RagScoreRequestSchema", () => {
+  it("accepts a minimal valid request", () => {
+    const result = RagScoreRequestSchema.safeParse({
+      brandId: validBrandId,
+      documents: [{ id: "a", text: "hello" }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts an optional query override", () => {
+    const result = RagScoreRequestSchema.safeParse({
+      brandId: validBrandId,
+      documents: [{ id: "a", text: "hello" }],
+      query: "B2B SaaS pricing experiments",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.query).toBe("B2B SaaS pricing experiments");
+    }
+  });
+
+  it("rejects empty documents array", () => {
+    const result = RagScoreRequestSchema.safeParse({
+      brandId: validBrandId,
+      documents: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it(`rejects documents.length > ${RAG_SCORE_DOCUMENTS_MAX}`, () => {
+    const result = RagScoreRequestSchema.safeParse({
+      brandId: validBrandId,
+      documents: makeDocs(RAG_SCORE_DOCUMENTS_MAX + 1),
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(JSON.stringify(result.error.issues)).toMatch(/at most/);
+    }
+  });
+
+  it(`accepts documents.length == ${RAG_SCORE_DOCUMENTS_MAX} (boundary)`, () => {
+    const result = RagScoreRequestSchema.safeParse({
+      brandId: validBrandId,
+      documents: makeDocs(RAG_SCORE_DOCUMENTS_MAX),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects non-uuid brandId", () => {
+    const result = RagScoreRequestSchema.safeParse({
+      brandId: "not-a-uuid",
+      documents: [{ id: "a", text: "hello" }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty document.text", () => {
+    const result = RagScoreRequestSchema.safeParse({
+      brandId: validBrandId,
+      documents: [{ id: "a", text: "" }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty document.id", () => {
+    const result = RagScoreRequestSchema.safeParse({
+      brandId: validBrandId,
+      documents: [{ id: "", text: "hello" }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects unknown top-level fields (strict)", () => {
+    const result = RagScoreRequestSchema.safeParse({
+      brandId: validBrandId,
+      documents: [{ id: "a", text: "hello" }],
+      sneaky: true,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects unknown document fields (strict)", () => {
+    const result = RagScoreRequestSchema.safeParse({
+      brandId: validBrandId,
+      documents: [{ id: "a", text: "hello", extra: 1 }],
+    });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a RAG-style scoring endpoint so consumers can rank N text documents against a brand's profile using semantic similarity, instead of paying for an LLM call per document.

- **Endpoint:** `POST /orgs/rag/score` — body `{ documents: { id, text }[], brandId, query? }` → returns `{ results: [{ id, score }] }` sorted desc.
- **Consumer:** [journalists-quotes-service](https://github.com/shamanic-technologies/journalists-quotes-service) — needs to score 50–200 quote requests per loop run against each brand to pick the best outreach match.
- **Cost rationale:** at ~50–200 requests per loop, Gemini embeddings (~$0.00013 / 1k tokens) blow an LLM-per-request scorer out of the water on cost and latency. The brand-profile embedding is cached so repeat loops within the same brand context cost ~zero on the brand side.

### Pipeline

1. Resolve brand context via brand-service (`industry`, `expertise`, `target_audience`, `voice`) — `x-brand-id` set from body.
2. Synthesize a brand-profile query string from the resolved fields (or use `query` override).
3. Compute the brand-profile embedding via Gemini `gemini-embedding-001`. Cached in new `brand_profile_embeddings` table keyed by `(orgId, brandId, contentHash)` where `contentHash` = sha256 of canonical sorted-key JSON of the resolved fields. Any field change → new hash → re-embed.
4. Batch-embed every `documents[i].text` in a single Gemini call.
5. Cosine similarity, clamped negatives → 0, sorted desc.

### What's in scope

- New endpoint + Zod schema + OpenAPI registration.
- New `src/lib/embeddings.ts` (cosine, contentHash, batch + single Gemini embed with retry).
- New table + migration `0014_add_brand_profile_embeddings.sql`.
- `BrandError` class so 404 from brand-service surfaces as 404 to caller.
- Standard run tracking: own run created, `parent_run_id` linked, `x-run-id` overwritten on the brand-service call.
- README section, env var docs, OpenAPI regenerated.

### What's NOT in scope (per orchestrator brief)

- pgvector / vector DB — JSONB column + in-memory cosine is fine at current volumes (≤100 docs / call).
- Document-side embedding cache (every call recomputes doc vectors).
- Cross-org caching.
- journalists-quotes-service consumer wiring (already stubbed in that repo).

### Tests

| File | Coverage |
|---|---|
| `tests/unit/embeddings.test.ts` | cosine, contentHash determinism / order-independence / change-detection, batchEmbedContents request shape, error paths |
| `tests/unit/rag-score-schema.test.ts` | request validation, cap of 100, uuid brandId, strict mode |
| `tests/integration/rag-score.test.ts` | handler happy path (sort + id preservation + run tracking + brand-service header forwarding); cache hit on second call; cache invalidation when brand context changes; documents > cap → 400; brand 404 → 404 |

All 552 tests pass locally (unit + integration via local Postgres). CI runs integration against a Neon PR branch.

## Test plan
- [ ] CI green (`npm run test:unit`, `npm run test:integration` on Neon branch).
- [ ] OpenAPI lints OK — `/orgs/rag/score` path present (`grep "/orgs/rag/score" openapi.json` returns 1 match).
- [ ] After deploy: manual `curl` against staging with valid headers + 5 documents + a real brandId → score ordering matches intuition.
- [ ] After deploy: second curl with same brandId → response shows `"cacheHit": true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)