### PR TITLE
feat: split workflow tools into create / upgrade / fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ Before using `/chat`, register a config for each chat mode your app needs. Each 
   "systemPrompt": "You are an AI assistant that helps users understand and modify their outreach workflows...",
   "allowedTools": [
     "request_user_input",
-    "update_workflow",
+    "create_workflow",
+    "upgrade_workflow",
+    "fork_workflow",
     "validate_workflow",
     "get_workflow_details",
-    "generate_workflow",
     "get_workflow_required_providers",
     "list_workflows",
-    "update_workflow_node_config",
     "get_prompt_template",
     "update_prompt_template",
     "list_services",
@@ -438,8 +438,8 @@ data: {"type":"token","content":" suggest..."}
 ### 4. Tool calls (optional)
 If the AI invokes a built-in tool:
 ```
-data: {"type":"tool_call","id":"tc_550e8400-e29b-41d4-a716-446655440000","name":"update_workflow","args":{"workflowId":"..."}}
-data: {"type":"tool_result","id":"tc_550e8400-e29b-41d4-a716-446655440000","name":"update_workflow","result":{...}}
+data: {"type":"tool_call","id":"tc_550e8400-e29b-41d4-a716-446655440000","name":"fork_workflow","args":{"workflowId":"...","dag":{...}}}
+data: {"type":"tool_result","id":"tc_550e8400-e29b-41d4-a716-446655440000","name":"fork_workflow","result":{...}}
 ```
 - `id` — unique identifier matching a `tool_call` to its `tool_result`
 - `name` — the tool name
@@ -454,14 +454,21 @@ The tools available in each chat session are determined by the `allowedTools` ar
 
 **Workflow tools:**
 
+The three workflow write tools are intent-specific. The frontend's system prompt should make clear which intent applies:
+
+| Tool | Intent | Endpoint |
+|---|---|---|
+| `create_workflow` | Brand-new workflow from natural language. No existing workflow being modified. Starts a new dynasty. | `POST /v1/workflows/create` |
+| `upgrade_workflow` | Re-generate the DAG of an existing workflow within its dynasty. **Hard rule: bug fixes or metadata clarifications only.** Substantive changes must use `fork_workflow`. | `POST /v1/workflows/upgrade` |
+| `fork_workflow` | Substantive change to an existing workflow. Submits a new DAG to `PUT /v1/workflows/:id`; the workflow-service creates a new dynasty when the DAG signature differs. Same-signature submissions return `_action: "updated"` (no-op). | `PUT /v1/workflows/:id` |
+
+Read-only and supporting workflow tools:
+
 | Tool | Description |
 |---|---|
-| `get_workflow_details` | Fetches full workflow details (DAG, metadata, status) via workflow-service `GET /workflows/{id}` |
-| `generate_workflow` | Generates a new workflow from natural language via workflow-service `POST /workflows/generate` |
-| `get_workflow_required_providers` | Returns BYOK providers needed to execute a workflow via `GET /workflows/{id}/required-providers` |
+| `get_workflow_details` | Fetches full workflow details (DAG, metadata, status) via `GET /workflows/{id}` |
+| `get_workflow_required_providers` | Returns BYOK providers needed to execute a workflow via `GET /workflows/{id}/key-status` |
 | `list_workflows` | Lists workflows via `GET /workflows` with optional filters |
-| `update_workflow` | Updates a workflow's metadata or DAG. DAG changes trigger a fork (new workflow). Metadata-only changes update in-place. |
-| `update_workflow_node_config` | Updates a specific node's config in a workflow's DAG. May fork if DAG changes. |
 | `validate_workflow` | Validates a workflow's DAG structure |
 | `get_prompt_template` | Retrieves a stored prompt template by type |
 | `update_prompt_template` | Creates a new version of an existing prompt template (auto-versions) |
@@ -701,7 +708,7 @@ src/
     key-client.ts      # Key-service client: resolveKey (decrypt), listOrgKeys, getKeySource, listKeySources, checkProviderRequirements
     api-registry-client.ts # API Registry client: listServices, listServiceEndpoints, callApi (progressive disclosure)
     runs-client.ts     # RunsService HTTP client for run tracking and cost reporting
-    workflow-client.ts              # Workflow-service client for update_workflow and validate_workflow built-in tools
+    workflow-client.ts              # Workflow-service client for create/upgrade/fork/validate built-in tools
     content-generation-client.ts    # Content-generation service client for get_prompt_template built-in tool
     features-client.ts              # Features-service client (create, update/fork, list, get, inputs, prefill, stats)
 scripts/

--- a/openapi.json
+++ b/openapi.json
@@ -108,7 +108,7 @@
           "name": {
             "type": "string",
             "description": "The tool name being invoked",
-            "example": "update_workflow"
+            "example": "fork_workflow"
           },
           "args": {
             "type": "object",
@@ -145,7 +145,7 @@
           "name": {
             "type": "string",
             "description": "The tool name that produced this result",
-            "example": "update_workflow"
+            "example": "fork_workflow"
           },
           "result": {
             "nullable": true,
@@ -429,10 +429,12 @@
               "minLength": 1
             },
             "minItems": 1,
-            "description": "List of tool names the LLM is allowed to use in this chat mode. Only these tools will be provided to the model and executable server-side. Available tools: request_user_input, update_workflow, validate_workflow, get_workflow_details, generate_workflow, get_workflow_required_providers, list_workflows, update_workflow_node_config, get_prompt_template, update_prompt_template, list_services, list_service_endpoints, list_org_keys, get_key_source, list_key_sources, check_provider_requirements, create_feature, update_feature, list_features, get_feature, get_feature_inputs, prefill_feature, get_feature_stats, update_campaign_fields, extract_brand_fields, browse_url",
+            "description": "List of tool names the LLM is allowed to use in this chat mode. Only these tools will be provided to the model and executable server-side. Available tools: request_user_input, create_workflow, upgrade_workflow, fork_workflow, validate_workflow, get_workflow_details, get_workflow_required_providers, list_workflows, get_prompt_template, update_prompt_template, list_services, list_service_endpoints, list_org_keys, get_key_source, list_key_sources, check_provider_requirements, create_feature, update_feature, list_features, get_feature, get_feature_inputs, prefill_feature, get_feature_stats, update_campaign_fields, extract_brand_fields, browse_url",
             "example": [
               "request_user_input",
-              "update_workflow",
+              "create_workflow",
+              "upgrade_workflow",
+              "fork_workflow",
               "validate_workflow",
               "get_workflow_details",
               "list_workflows"
@@ -540,7 +542,9 @@
             "description": "List of tool names the LLM is allowed to use. Same semantics as in PUT /config.",
             "example": [
               "request_user_input",
-              "update_workflow",
+              "create_workflow",
+              "upgrade_workflow",
+              "fork_workflow",
               "validate_workflow",
               "get_workflow_details",
               "list_workflows"
@@ -1145,7 +1149,7 @@
           "App Config"
         ],
         "summary": "Register or update app configuration",
-        "description": "Idempotent upsert of app configuration scoped by (orgId, key). Each key represents a chat mode (e.g. 'workflow', 'feature', 'press-kit'). The config defines the system prompt and which tools the LLM can use in that mode. Call on every cold start.\n\n**Example — workflow chat config:**\n```json\n{ \"key\": \"workflow\", \"systemPrompt\": \"You help users understand and modify workflows...\", \"allowedTools\": [\"request_user_input\", \"update_workflow\", \"validate_workflow\", \"get_workflow_details\", \"list_workflows\", \"update_workflow_node_config\", \"get_prompt_template\", \"update_prompt_template\", \"list_org_keys\", \"get_key_source\", \"list_key_sources\", \"check_provider_requirements\", \"list_services\", \"list_service_endpoints\", \"generate_workflow\", \"get_workflow_required_providers\"] }\n```\n\n**Example — feature chat config:**\n```json\n{ \"key\": \"feature\", \"systemPrompt\": \"You help users design and manage features...\", \"allowedTools\": [\"request_user_input\", \"create_feature\", \"update_feature\", \"list_features\", \"get_feature\", \"get_feature_inputs\", \"prefill_feature\", \"get_feature_stats\"] }\n```",
+        "description": "Idempotent upsert of app configuration scoped by (orgId, key). Each key represents a chat mode (e.g. 'workflow', 'feature', 'press-kit'). The config defines the system prompt and which tools the LLM can use in that mode. Call on every cold start.\n\n**Example — workflow chat config:**\n```json\n{ \"key\": \"workflow\", \"systemPrompt\": \"You help users understand and modify workflows...\", \"allowedTools\": [\"request_user_input\", \"create_workflow\", \"upgrade_workflow\", \"fork_workflow\", \"validate_workflow\", \"get_workflow_details\", \"list_workflows\", \"get_prompt_template\", \"update_prompt_template\", \"list_org_keys\", \"get_key_source\", \"list_key_sources\", \"check_provider_requirements\", \"list_services\", \"list_service_endpoints\", \"get_workflow_required_providers\"] }\n```\n\n**Example — feature chat config:**\n```json\n{ \"key\": \"feature\", \"systemPrompt\": \"You help users design and manage features...\", \"allowedTools\": [\"request_user_input\", \"create_feature\", \"update_feature\", \"list_features\", \"get_feature\", \"get_feature_inputs\", \"prefill_feature\", \"get_feature_stats\"] }\n```",
         "parameters": [
           {
             "schema": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,9 +22,10 @@ import {
 import type { Provider, ModelAlias } from "./lib/anthropic.js";
 import { isGeminiModel, completeWithGemini } from "./lib/gemini.js";
 import {
-  updateWorkflow,
+  createWorkflow,
+  upgradeWorkflow,
+  forkWorkflow,
   validateWorkflow,
-  updateWorkflowNodeConfig,
   getWorkflow,
   getWorkflowRequiredProviders,
   listWorkflows,
@@ -1431,8 +1432,12 @@ app.post("/chat", requireAuth, async (req, res) => {
         return { name: call.name, result };
       }
 
-      // Built-in workflow tools
-      if (call.name === "update_workflow" || call.name === "validate_workflow") {
+      // Built-in workflow write tools: create / upgrade / fork
+      if (
+        call.name === "create_workflow" ||
+        call.name === "upgrade_workflow" ||
+        call.name === "fork_workflow"
+      ) {
         const wfParams = {
           orgId,
           userId,
@@ -1442,57 +1447,81 @@ app.post("/chat", requireAuth, async (req, res) => {
         const args = (call.args as Record<string, unknown>) || {};
         let result: unknown;
 
-        if (call.name === "update_workflow") {
-          const { workflowId: rawWorkflowId, ...updateBody } = args;
+        if (call.name === "create_workflow") {
+          result = await createWorkflow(
+            args as unknown as import("./lib/workflow-client.js").CreateWorkflowBody,
+            wfParams,
+          );
+        } else if (call.name === "upgrade_workflow") {
+          result = await upgradeWorkflow(
+            args as unknown as import("./lib/workflow-client.js").UpgradeWorkflowBody,
+            wfParams,
+          );
+        } else {
+          // fork_workflow
+          const { workflowId: rawWorkflowId, dag } = args;
           // Redirect to the already-forked workflow if the LLM tries to
-          // update the same source workflow again in this turn.
-          const effectiveWorkflowId = forkedWorkflowMap.get(rawWorkflowId as string) ?? rawWorkflowId as string;
+          // fork the same source workflow again in this turn.
+          const effectiveWorkflowId =
+            forkedWorkflowMap.get(rawWorkflowId as string) ?? (rawWorkflowId as string);
           const wasRedirected = effectiveWorkflowId !== (rawWorkflowId as string);
           if (wasRedirected) {
             console.log(
-              `[chat] Redirecting update_workflow from already-forked source "${rawWorkflowId}" → "${effectiveWorkflowId}"`,
+              `[chat] Redirecting fork_workflow from already-forked source "${rawWorkflowId}" → "${effectiveWorkflowId}"`,
             );
           }
           try {
-            const updateResult = await updateWorkflow(
+            const forkResult = await forkWorkflow(
               effectiveWorkflowId,
-              updateBody as import("./lib/workflow-client.js").UpdateWorkflowBody,
+              { dag: dag as import("./lib/workflow-client.js").DAG },
               wfParams,
             );
-            if (updateResult.outcome === "forked") {
-              const forkedFrom = updateResult.workflow._forkedFromName || rawWorkflowId;
-              // Record the fork so subsequent calls target the fork, not the original
-              forkedWorkflowMap.set(rawWorkflowId as string, updateResult.workflow.id);
+            if (forkResult.outcome === "forked") {
+              const forkedFrom = forkResult.workflow._forkedFromName || rawWorkflowId;
+              forkedWorkflowMap.set(rawWorkflowId as string, forkResult.workflow.id);
               result = {
-                ...updateResult.workflow,
-                _note: `This is a NEW workflow forked from "${forkedFrom}". Tell the user: "Your customized workflow is ready: ${updateResult.workflow.name || updateResult.workflow.signatureName || updateResult.workflow.id}. Use this name for future campaigns."`,
+                ...forkResult.workflow,
+                _note: `This is a NEW workflow forked from "${forkedFrom}". Tell the user: "Your customized workflow is ready: ${forkResult.workflow.name || forkResult.workflow.signatureName || forkResult.workflow.id}. Use this name for future campaigns."`,
               };
             } else {
-              result = updateResult.workflow;
+              result = {
+                ...forkResult.workflow,
+                _note:
+                  "No fork created — the submitted DAG has the same signature as the source workflow. The workflow is unchanged.",
+              };
             }
           } catch (err: unknown) {
-            // 409 on a redirected call means the forked workflow already has
-            // the same DAG — treat as a no-op and return the current state.
-            const is409 = err instanceof Error && err.message.includes("signature already exists");
+            const is409 =
+              err instanceof Error && err.message.includes("signature already exists");
             if (is409) {
               console.log(
-                `[chat] update_workflow 409 on "${effectiveWorkflowId}" — workflow already has this DAG, returning current state`,
+                `[chat] fork_workflow 409 on "${effectiveWorkflowId}" — another workflow already has this DAG, returning current state`,
               );
               const current = await getWorkflow(effectiveWorkflowId, wfParams);
               result = {
                 ...current,
-                _note: "No changes needed — this workflow already has the requested configuration.",
+                _note: "No changes needed — a workflow with this DAG already exists.",
               };
             } else {
               throw err;
             }
           }
-        } else {
-          result = await validateWorkflow(
-            args.workflowId as string,
-            wfParams,
-          );
         }
+
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
+      // Built-in workflow validate tool
+      if (call.name === "validate_workflow") {
+        const wfParams = {
+          orgId,
+          userId,
+          runId: runId!,
+          trackingHeaders: Object.keys(trackingHeaders).length > 0 ? trackingHeaders as Record<string, string> : undefined,
+        };
+        const args = (call.args as Record<string, unknown>) || {};
+        const result = await validateWorkflow(args.workflowId as string, wfParams);
 
         toolCalls.push({ name: call.name, args, result });
         return { name: call.name, result };
@@ -1537,68 +1566,6 @@ app.post("/chat", requireAuth, async (req, res) => {
             trackingHeaders: Object.keys(trackingHeaders).length > 0 ? trackingHeaders as Record<string, string> : undefined,
           },
         );
-
-        toolCalls.push({ name: call.name, args, result });
-        return { name: call.name, result };
-      }
-
-      // Built-in workflow node config update tool
-      if (call.name === "update_workflow_node_config") {
-        const args = (call.args as Record<string, unknown>) || {};
-        const rawWorkflowId = args.workflowId as string;
-        // Redirect to the already-forked workflow if applicable
-        const effectiveWorkflowId = forkedWorkflowMap.get(rawWorkflowId) ?? rawWorkflowId;
-        if (effectiveWorkflowId !== rawWorkflowId) {
-          console.log(
-            `[chat] Redirecting update_workflow_node_config from already-forked source "${rawWorkflowId}" → "${effectiveWorkflowId}"`,
-          );
-        }
-
-        let result: unknown;
-        try {
-          const updateResult = await updateWorkflowNodeConfig(
-            effectiveWorkflowId,
-            args.nodeId as string,
-            args.configUpdates as Record<string, unknown>,
-            {
-              orgId,
-              userId,
-              runId: runId!,
-              trackingHeaders: Object.keys(trackingHeaders).length > 0 ? trackingHeaders as Record<string, string> : undefined,
-            },
-          );
-
-          if (updateResult.outcome === "forked") {
-            const forkedFrom = updateResult.workflow._forkedFromName || "the original";
-            // Record the fork so subsequent calls target the fork
-            forkedWorkflowMap.set(rawWorkflowId, updateResult.workflow.id);
-            result = {
-              ...updateResult.workflow,
-              _note: `This is a NEW workflow forked from "${forkedFrom}". Tell the user: "Your customized workflow is ready: ${updateResult.workflow.name || updateResult.workflow.signatureName || updateResult.workflow.id}. Use this name for future campaigns."`,
-            };
-          } else {
-            result = updateResult.workflow;
-          }
-        } catch (err: unknown) {
-          const is409 = err instanceof Error && err.message.includes("signature already exists");
-          if (is409) {
-            console.log(
-              `[chat] update_workflow_node_config 409 on "${effectiveWorkflowId}" — workflow already has this DAG, returning current state`,
-            );
-            const current = await getWorkflow(effectiveWorkflowId, {
-              orgId,
-              userId,
-              runId: runId!,
-              trackingHeaders: Object.keys(trackingHeaders).length > 0 ? trackingHeaders as Record<string, string> : undefined,
-            });
-            result = {
-              ...current,
-              _note: "No changes needed — this workflow already has the requested configuration.",
-            };
-          } else {
-            throw err;
-          }
-        }
 
         toolCalls.push({ name: call.name, args, result });
         return { name: call.name, result };

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -120,38 +120,109 @@ export const REQUEST_USER_INPUT_TOOL: Anthropic.Tool = {
   },
 };
 
-export const UPDATE_WORKFLOW_TOOL: Anthropic.Tool = {
-  name: "update_workflow",
+export const CREATE_WORKFLOW_TOOL: Anthropic.Tool = {
+  name: "create_workflow",
   description:
-    "Update a workflow's metadata (name, description, tags) and/or its DAG structure. Use this to directly modify a workflow when the user asks — do not use input_request to confirm values you already know. For structural changes (adding/removing nodes or edges), pass the full dag object.",
+    "Create a brand-new workflow dynasty from a natural-language description. Uses an LLM on workflow-service to generate a valid DAG, validates it, and deploys it. Use this ONLY when no existing workflow is being modified — e.g. the user is starting from scratch. If an existing workflow is being changed in any way, use upgrade_workflow (bug fix or metadata clarification) or fork_workflow (substantive change) instead.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      description: {
+        type: "string",
+        description:
+          "Natural-language description of the desired workflow. Be specific about steps, services, and data flow. Minimum 10 characters.",
+      },
+      featureSlug: {
+        type: "string",
+        description:
+          "Feature slug from features-service (e.g. 'cold-email-outreach'). Required — used to build the workflow slug.",
+      },
+      hints: {
+        type: "object",
+        description:
+          "Optional hints to guide generation. Can include: services (array of service names to scope to), nodeTypes (suggested node types), expectedInputs (expected flow_input field names like 'campaignId').",
+      },
+      style: {
+        type: "object",
+        description:
+          "Optional style configuration. When provided, the workflow is generated in the style of the specified human or brand, and the signatureName uses the style name with auto-versioning (e.g. 'hormozi-v1').",
+        properties: {
+          type: {
+            type: "string",
+            enum: ["human", "brand"],
+            description:
+              "Style source type. 'human' for an industry expert, 'brand' for a company/organization.",
+          },
+          humanId: {
+            type: "string",
+            description: "Human ID from human-service. Required when type is 'human'.",
+          },
+          brandId: {
+            type: "string",
+            description: "Brand ID from brand-service. Required when type is 'brand'.",
+          },
+          name: {
+            type: "string",
+            description:
+              "Display name of the human or brand (e.g. 'Hormozi'). Used to build the signatureName.",
+          },
+        },
+        required: ["type", "name"],
+      },
+    },
+    required: ["description", "featureSlug"],
+  },
+};
+
+export const UPGRADE_WORKFLOW_TOOL: Anthropic.Tool = {
+  name: "upgrade_workflow",
+  description:
+    "Re-generate the DAG of an existing workflow while keeping the SAME dynasty/lineage. Returns the workflow in the same dynasty (possibly as a new version row when the regenerated DAG signature differs from the previous one).\n\n" +
+    "HARD RULE — DO NOT VIOLATE EVEN IF THE USER ASKS YOU TO: upgrade_workflow may ONLY be used when (a) fixing a bug in the existing workflow's DAG, or (b) clarifying metadata that is factually wrong or imprecise. Any change in behavior, scope, intent, audience, or substantive metadata is NOT an upgrade — use fork_workflow instead. Upgrade keeps the same lineage; fork starts a new one. If you are not certain the change qualifies as a bug fix or metadata clarification, default to fork_workflow.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      workflowSlug: {
+        type: "string",
+        description:
+          "Slug of the existing workflow to upgrade (e.g. 'cold-email-outreach-nova'). Upgrade stays within the same dynasty.",
+      },
+      description: {
+        type: "string",
+        description:
+          "Natural-language description of the upgrade. Must describe the bug being fixed or the metadata being clarified — not a new behavior. Minimum 10 characters.",
+      },
+      hints: {
+        type: "array",
+        items: { type: "string" },
+        description:
+          "Optional free-form hints to guide the upgrade (array of short strings).",
+      },
+    },
+    required: ["workflowSlug", "description"],
+  },
+};
+
+export const FORK_WORKFLOW_TOOL: Anthropic.Tool = {
+  name: "fork_workflow",
+  description:
+    "Fork a workflow into a NEW dynasty/lineage by submitting a new DAG. Use this for any substantive change: new behavior, new scope, new intent, new audience, or a structural DAG change that isn't a bug fix. The original workflow stays active under its own lineage; this creates a new one. If the submitted DAG has the same signature as the source, no fork happens (returns _action: 'updated') — that's expected, not an error.\n\n" +
+    "Always call get_workflow_details first to read the current DAG, modify it, and pass the COMPLETE updated DAG — partial DAGs are not supported.",
   input_schema: {
     type: "object" as const,
     properties: {
       workflowId: {
         type: "string",
         description:
-          "UUID of the workflow to update. If available in context, use it directly — do NOT ask the user for it.",
-      },
-      name: {
-        type: "string",
-        description: "New workflow name (optional)",
-      },
-      description: {
-        type: "string",
-        description: "New workflow description (optional)",
-      },
-      tags: {
-        type: "array",
-        items: { type: "string" },
-        description: "New tags for the workflow (optional)",
+          "UUID of the source workflow to fork from. If available in context, use it directly — do NOT ask the user for it.",
       },
       dag: {
         type: "object",
         description:
-          "Full DAG definition with nodes and edges. Use for structural changes like adding/removing nodes or edges. Must include the complete DAG — partial updates are not supported. Use get_workflow_details first to read the current DAG, then modify and pass the full result.",
+          "Full DAG definition with nodes and edges. Must include the complete DAG — partial updates are not supported. Use get_workflow_details first to read the current DAG, then modify and pass the full result.",
       },
     },
-    required: ["workflowId"],
+    required: ["workflowId", "dag"],
   },
 };
 
@@ -214,33 +285,6 @@ export const UPDATE_PROMPT_TEMPLATE_TOOL: Anthropic.Tool = {
       },
     },
     required: ["sourceType", "prompt", "variables"],
-  },
-};
-
-export const UPDATE_WORKFLOW_NODE_CONFIG_TOOL: Anthropic.Tool = {
-  name: "update_workflow_node_config",
-  description:
-    "Update the static config of a specific node in a workflow's DAG. Fetches the current DAG, merges your config changes into the target node, and saves. Use this to change node parameters like prompt type, target URL, call-to-action, etc.",
-  input_schema: {
-    type: "object" as const,
-    properties: {
-      workflowId: {
-        type: "string",
-        description:
-          "UUID of the workflow to update. If available in context, use it directly.",
-      },
-      nodeId: {
-        type: "string",
-        description:
-          "ID of the node to update (e.g. 'email-generate', 'email-send')",
-      },
-      configUpdates: {
-        type: "object",
-        description:
-          'Key-value pairs to merge into the node\'s config. Only specified keys are changed; others are preserved. Example: {"body": {"type": "cold-email-v3"}}',
-      },
-    },
-    required: ["workflowId", "nodeId", "configUpdates"],
   },
 };
 
@@ -346,7 +390,7 @@ export const CHECK_PROVIDER_REQUIREMENTS_TOOL: Anthropic.Tool = {
 export const GET_WORKFLOW_DETAILS_TOOL: Anthropic.Tool = {
   name: "get_workflow_details",
   description:
-    "Fetch the full details of a workflow including its DAG, metadata, and status. Use this to inspect the current state of a workflow, especially after making changes via update_workflow or update_workflow_node_config.",
+    "Fetch the full details of a workflow including its DAG, metadata, and status. Use this to inspect the current state of a workflow, especially before calling fork_workflow (to read the current DAG before modifying it).",
   input_schema: {
     type: "object" as const,
     properties: {
@@ -357,58 +401,6 @@ export const GET_WORKFLOW_DETAILS_TOOL: Anthropic.Tool = {
       },
     },
     required: ["workflowId"],
-  },
-};
-
-export const GENERATE_WORKFLOW_TOOL: Anthropic.Tool = {
-  name: "generate_workflow",
-  description:
-    "Generate a new workflow from a natural language description. Uses an LLM to create a valid DAG, validates it, and deploys it automatically. Use this when the user wants to create a brand new workflow from scratch.",
-  input_schema: {
-    type: "object" as const,
-    properties: {
-      description: {
-        type: "string",
-        description:
-          "Natural language description of the desired workflow. Be specific about the steps, services, and data flow. Minimum 10 characters.",
-      },
-      featureSlug: {
-        type: "string",
-        description:
-          "Feature slug from features-service (e.g. 'cold-email-outreach'). Required — used to build the workflow slug.",
-      },
-      hints: {
-        type: "object",
-        description:
-          "Optional hints to guide generation. Can include: services (array of service names to scope to), nodeTypes (suggested node types), expectedInputs (expected flow_input field names like 'campaignId').",
-      },
-      style: {
-        type: "object",
-        description:
-          "Optional style configuration. When provided, the workflow is generated in the style of the specified human or brand, and the signatureName uses the style name with auto-versioning (e.g. 'hormozi-v1').",
-        properties: {
-          type: {
-            type: "string",
-            enum: ["human", "brand"],
-            description: "Style source type. 'human' for an industry expert, 'brand' for a company/organization.",
-          },
-          humanId: {
-            type: "string",
-            description: "Human ID from human-service. Required when type is 'human'.",
-          },
-          brandId: {
-            type: "string",
-            description: "Brand ID from brand-service. Required when type is 'brand'.",
-          },
-          name: {
-            type: "string",
-            description: "Display name of the human or brand (e.g. 'Hormozi'). Used to build the signatureName.",
-          },
-        },
-        required: ["type", "name"],
-      },
-    },
-    required: ["description", "featureSlug"],
   },
 };
 
@@ -892,13 +884,13 @@ export const BROWSE_URL_TOOL: Anthropic.Tool = {
 
 export const TOOL_REGISTRY: Record<string, Anthropic.Tool> = {
   request_user_input: REQUEST_USER_INPUT_TOOL,
-  update_workflow: UPDATE_WORKFLOW_TOOL,
+  create_workflow: CREATE_WORKFLOW_TOOL,
+  upgrade_workflow: UPGRADE_WORKFLOW_TOOL,
+  fork_workflow: FORK_WORKFLOW_TOOL,
   validate_workflow: VALIDATE_WORKFLOW_TOOL,
   get_prompt_template: GET_PROMPT_TEMPLATE_TOOL,
   update_prompt_template: UPDATE_PROMPT_TEMPLATE_TOOL,
-  update_workflow_node_config: UPDATE_WORKFLOW_NODE_CONFIG_TOOL,
   get_workflow_details: GET_WORKFLOW_DETAILS_TOOL,
-  generate_workflow: GENERATE_WORKFLOW_TOOL,
   get_workflow_required_providers: GET_WORKFLOW_REQUIRED_PROVIDERS_TOOL,
   list_workflows: LIST_WORKFLOWS_TOOL,
   list_services: LIST_SERVICES_TOOL,

--- a/src/lib/tool-errors.ts
+++ b/src/lib/tool-errors.ts
@@ -37,13 +37,12 @@ function parseStatusCode(msg: string): number | null {
 }
 
 const TOOL_HINTS: Record<string, string> = {
-  update_workflow:
-    "For targeted node changes, prefer update_workflow_node_config instead. " +
-    "If you need to send a full DAG, call get_workflow_details first to get the current DAG, " +
-    "then modify only the parts you need and pass the complete result.",
-  update_workflow_node_config:
-    "Pass workflowId (UUID), nodeId (e.g. 'email-generate'), and configUpdates (object with keys to merge). " +
-    "Only keys in configUpdates are changed; the rest is preserved.",
+  create_workflow:
+    "Pass description (natural language, min 10 chars), featureSlug (e.g. 'cold-email-outreach'), optional hints ({services, nodeTypes, expectedInputs}), optional style ({type, name, humanId?, brandId?}). Use only for NEW workflows from scratch.",
+  upgrade_workflow:
+    "Pass workflowSlug (existing workflow slug) and description (NL describing the bug fix or metadata clarification, min 10 chars). HARD RULE: upgrade is for bug fixes or metadata clarifications only — for substantive changes, use fork_workflow instead.",
+  fork_workflow:
+    "Pass workflowId (UUID) and dag (complete DAG with nodes and edges). Call get_workflow_details first to read the current DAG, modify it, then pass the full result. Partial DAGs are not supported.",
   get_workflow_details:
     "Pass workflowId as a UUID string. If it's in context, use it directly.",
   validate_workflow:

--- a/src/lib/workflow-client.ts
+++ b/src/lib/workflow-client.ts
@@ -59,9 +59,9 @@ export interface WorkflowMutationResponse extends WorkflowResponse {
   _forkedFromName?: string;
 }
 
-export interface UpdateWorkflowResult {
+export interface ForkWorkflowResult {
   workflow: WorkflowMutationResponse;
-  /** "updated" = in-place 200, "forked" = new workflow 201 */
+  /** "updated" = signature unchanged (no-op), "forked" = new workflow created */
   outcome: "updated" | "forked";
 }
 
@@ -91,11 +91,8 @@ export async function getWorkflow(
   return (await res.json()) as WorkflowResponse;
 }
 
-export interface UpdateWorkflowBody {
-  name?: string;
-  description?: string;
-  tags?: string[];
-  dag?: DAG;
+export interface ForkWorkflowBody {
+  dag: DAG;
 }
 
 /**
@@ -116,12 +113,17 @@ function sanitizeDag(dag: DAG): DAG {
   };
 }
 
-export async function updateWorkflow(
+/**
+ * Fork a workflow by submitting a new DAG to PUT /v1/workflows/:id.
+ * Workflow-service creates a new dynasty when the DAG signature differs from
+ * the source. Same-signature submissions return _action: "updated" (no-op).
+ */
+export async function forkWorkflow(
   workflowId: string,
-  body: UpdateWorkflowBody,
+  body: ForkWorkflowBody,
   params: WorkflowCallParams,
-): Promise<UpdateWorkflowResult> {
-  const sanitized = body.dag ? { ...body, dag: sanitizeDag(body.dag) } : body;
+): Promise<ForkWorkflowResult> {
+  const sanitized = { dag: sanitizeDag(body.dag) };
   const res = await apiServiceFetch(
     `/v1/workflows/${encodeURIComponent(workflowId)}`,
     "PUT",
@@ -148,32 +150,7 @@ export async function updateWorkflow(
   return { workflow, outcome };
 }
 
-export async function updateWorkflowNodeConfig(
-  workflowId: string,
-  nodeId: string,
-  configUpdates: Record<string, unknown>,
-  params: WorkflowCallParams,
-): Promise<UpdateWorkflowResult> {
-  const workflow = await getWorkflow(workflowId, params);
-
-  if (!workflow.dag) {
-    throw new Error(`[workflow-client] Workflow ${workflowId} has no DAG`);
-  }
-
-  const nodeIndex = workflow.dag.nodes.findIndex((n) => n.id === nodeId);
-  if (nodeIndex === -1) {
-    throw new Error(
-      `[workflow-client] Node "${nodeId}" not found in workflow ${workflowId}. Available nodes: ${workflow.dag.nodes.map((n) => n.id).join(", ")}`,
-    );
-  }
-
-  const node = workflow.dag.nodes[nodeIndex];
-  node.config = { ...node.config, ...configUpdates };
-
-  return updateWorkflow(workflowId, { dag: workflow.dag }, params);
-}
-
-export interface GenerateWorkflowBody {
+export interface CreateWorkflowBody {
   description: string;
   featureSlug: string;
   hints?: {
@@ -189,16 +166,47 @@ export interface GenerateWorkflowBody {
   };
 }
 
-export async function generateWorkflow(
-  body: GenerateWorkflowBody,
+/**
+ * Create a new workflow dynasty from a natural-language description.
+ * Returns the generated workflow with its DAG. workflow-service deploys it.
+ */
+export async function createWorkflow(
+  body: CreateWorkflowBody,
   params: WorkflowCallParams,
 ): Promise<unknown> {
-  const res = await apiServiceFetch("/v1/workflows/generate", "POST", params, body);
+  const res = await apiServiceFetch("/v1/workflows/create", "POST", params, body);
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `[workflow-client] POST /v1/workflows/generate returned ${res.status}: ${text}`,
+      `[workflow-client] POST /v1/workflows/create returned ${res.status}: ${text}`,
+    );
+  }
+
+  return await res.json();
+}
+
+export interface UpgradeWorkflowBody {
+  workflowSlug: string;
+  description: string;
+  hints?: string[];
+}
+
+/**
+ * Upgrade an existing workflow within its dynasty. The description should
+ * describe a bug fix or a metadata clarification — not a substantive change
+ * (use forkWorkflow for that).
+ */
+export async function upgradeWorkflow(
+  body: UpgradeWorkflowBody,
+  params: WorkflowCallParams,
+): Promise<unknown> {
+  const res = await apiServiceFetch("/v1/workflows/upgrade", "POST", params, body);
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `[workflow-client] POST /v1/workflows/upgrade returned ${res.status}: ${text}`,
     );
   }
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -114,9 +114,9 @@ export const AppConfigRequestSchema = z
       description:
         "List of tool names the LLM is allowed to use in this chat mode. " +
         "Only these tools will be provided to the model and executable server-side. " +
-        "Available tools: request_user_input, update_workflow, validate_workflow, " +
-        "get_workflow_details, generate_workflow, get_workflow_required_providers, list_workflows, " +
-        "update_workflow_node_config, get_prompt_template, update_prompt_template, " +
+        "Available tools: request_user_input, create_workflow, upgrade_workflow, fork_workflow, " +
+        "validate_workflow, get_workflow_details, get_workflow_required_providers, list_workflows, " +
+        "get_prompt_template, update_prompt_template, " +
         "list_services, list_service_endpoints, " +
         "list_org_keys, get_key_source, list_key_sources, check_provider_requirements, " +
         "create_feature, update_feature, list_features, get_feature, get_feature_inputs, " +
@@ -124,7 +124,9 @@ export const AppConfigRequestSchema = z
         "update_campaign_fields, extract_brand_fields, browse_url",
       example: [
         "request_user_input",
-        "update_workflow",
+        "create_workflow",
+        "upgrade_workflow",
+        "fork_workflow",
         "validate_workflow",
         "get_workflow_details",
         "list_workflows",
@@ -194,7 +196,7 @@ registry.registerPath({
     "**Example — workflow chat config:**\n" +
     "```json\n" +
     '{ "key": "workflow", "systemPrompt": "You help users understand and modify workflows...", ' +
-    '"allowedTools": ["request_user_input", "update_workflow", "validate_workflow", "get_workflow_details", "list_workflows", "update_workflow_node_config", "get_prompt_template", "update_prompt_template", "list_org_keys", "get_key_source", "list_key_sources", "check_provider_requirements", "list_services", "list_service_endpoints", "generate_workflow", "get_workflow_required_providers"] }\n' +
+    '"allowedTools": ["request_user_input", "create_workflow", "upgrade_workflow", "fork_workflow", "validate_workflow", "get_workflow_details", "list_workflows", "get_prompt_template", "update_prompt_template", "list_org_keys", "get_key_source", "list_key_sources", "check_provider_requirements", "list_services", "list_service_endpoints", "get_workflow_required_providers"] }\n' +
     "```\n\n" +
     "**Example — feature chat config:**\n" +
     "```json\n" +
@@ -261,7 +263,9 @@ export const PlatformConfigRequestSchema = z
         "List of tool names the LLM is allowed to use. Same semantics as in PUT /config.",
       example: [
         "request_user_input",
-        "update_workflow",
+        "create_workflow",
+        "upgrade_workflow",
+        "fork_workflow",
         "validate_workflow",
         "get_workflow_details",
         "list_workflows",
@@ -715,7 +719,7 @@ const SSEToolCallEventSchema = z
     }),
     name: z.string().openapi({
       description: "The tool name being invoked",
-      example: "update_workflow",
+      example: "fork_workflow",
     }),
     args: z.record(z.string(), z.unknown()).openapi({
       description: "Input arguments passed to the tool, as a JSON object",
@@ -734,7 +738,7 @@ const SSEToolResultEventSchema = z
     }),
     name: z.string().openapi({
       description: "The tool name that produced this result",
-      example: "update_workflow",
+      example: "fork_workflow",
     }),
     result: z.unknown().openapi({
       description: "The tool output — can be a string or a JSON object",

--- a/tests/unit/anthropic.test.ts
+++ b/tests/unit/anthropic.test.ts
@@ -34,7 +34,9 @@ import {
   SUPPORTED_MODELS,
   costPrefixForModel,
   REQUEST_USER_INPUT_TOOL,
-  UPDATE_WORKFLOW_TOOL,
+  CREATE_WORKFLOW_TOOL,
+  UPGRADE_WORKFLOW_TOOL,
+  FORK_WORKFLOW_TOOL,
   VALIDATE_WORKFLOW_TOOL,
   CREATE_FEATURE_TOOL,
   UPDATE_FEATURE_TOOL,
@@ -467,23 +469,55 @@ describe("REQUEST_USER_INPUT_TOOL", () => {
   });
 });
 
-describe("UPDATE_WORKFLOW_TOOL", () => {
-  it("has correct name and required workflowId parameter", () => {
-    expect(UPDATE_WORKFLOW_TOOL.name).toBe("update_workflow");
-    const schema = UPDATE_WORKFLOW_TOOL.input_schema as {
+describe("CREATE_WORKFLOW_TOOL", () => {
+  it("has correct name and required description + featureSlug", () => {
+    expect(CREATE_WORKFLOW_TOOL.name).toBe("create_workflow");
+    const schema = CREATE_WORKFLOW_TOOL.input_schema as {
+      properties: Record<string, unknown>;
+      required: string[];
+    };
+    expect(schema.properties).toHaveProperty("description");
+    expect(schema.properties).toHaveProperty("featureSlug");
+    expect(schema.properties).toHaveProperty("hints");
+    expect(schema.properties).toHaveProperty("style");
+    expect(schema.required).toEqual(
+      expect.arrayContaining(["description", "featureSlug"]),
+    );
+  });
+});
+
+describe("UPGRADE_WORKFLOW_TOOL", () => {
+  it("has correct name and required workflowSlug + description", () => {
+    expect(UPGRADE_WORKFLOW_TOOL.name).toBe("upgrade_workflow");
+    const schema = UPGRADE_WORKFLOW_TOOL.input_schema as {
+      properties: Record<string, unknown>;
+      required: string[];
+    };
+    expect(schema.properties).toHaveProperty("workflowSlug");
+    expect(schema.properties).toHaveProperty("description");
+    expect(schema.required).toEqual(
+      expect.arrayContaining(["workflowSlug", "description"]),
+    );
+  });
+
+  it("description carries the HARD RULE for bug-fix/metadata-clarification scope", () => {
+    expect(UPGRADE_WORKFLOW_TOOL.description).toContain("HARD RULE");
+    expect(UPGRADE_WORKFLOW_TOOL.description).toMatch(/bug.?fix/i);
+    expect(UPGRADE_WORKFLOW_TOOL.description).toContain("fork_workflow");
+  });
+});
+
+describe("FORK_WORKFLOW_TOOL", () => {
+  it("has correct name and required workflowId + dag", () => {
+    expect(FORK_WORKFLOW_TOOL.name).toBe("fork_workflow");
+    const schema = FORK_WORKFLOW_TOOL.input_schema as {
       properties: Record<string, unknown>;
       required: string[];
     };
     expect(schema.properties).toHaveProperty("workflowId");
-    expect(schema.properties).toHaveProperty("name");
-    expect(schema.properties).toHaveProperty("description");
-    expect(schema.properties).toHaveProperty("tags");
-    expect(schema.required).toEqual(["workflowId"]);
-  });
-
-  it("description instructs to use context workflowId directly", () => {
-    expect(UPDATE_WORKFLOW_TOOL.description).toContain(
-      "do not use input_request",
+    expect(schema.properties).toHaveProperty("dag");
+    expect(schema.required).toEqual(
+      expect.arrayContaining(["workflowId", "dag"]),
     );
   });
 });
@@ -503,13 +537,13 @@ describe("VALIDATE_WORKFLOW_TOOL", () => {
 describe("TOOL_REGISTRY", () => {
   it("contains all expected tools", () => {
     expect(AVAILABLE_TOOL_NAMES).toContain("request_user_input");
-    expect(AVAILABLE_TOOL_NAMES).toContain("update_workflow");
+    expect(AVAILABLE_TOOL_NAMES).toContain("create_workflow");
+    expect(AVAILABLE_TOOL_NAMES).toContain("upgrade_workflow");
+    expect(AVAILABLE_TOOL_NAMES).toContain("fork_workflow");
     expect(AVAILABLE_TOOL_NAMES).toContain("validate_workflow");
     expect(AVAILABLE_TOOL_NAMES).toContain("get_prompt_template");
     expect(AVAILABLE_TOOL_NAMES).toContain("update_prompt_template");
-    expect(AVAILABLE_TOOL_NAMES).toContain("update_workflow_node_config");
     expect(AVAILABLE_TOOL_NAMES).toContain("get_workflow_details");
-    expect(AVAILABLE_TOOL_NAMES).toContain("generate_workflow");
     expect(AVAILABLE_TOOL_NAMES).toContain("get_workflow_required_providers");
     expect(AVAILABLE_TOOL_NAMES).toContain("list_workflows");
     expect(AVAILABLE_TOOL_NAMES).toContain("list_services");

--- a/tests/unit/fork-dedup.test.ts
+++ b/tests/unit/fork-dedup.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 /**
  * Regression test for duplicate fork bug.
  *
- * When the LLM calls update_workflow multiple times with the same workflowId
+ * When the LLM calls fork_workflow multiple times with the same workflowId
  * in a single chat turn, the first call may trigger a fork (201). Subsequent
  * calls must target the already-forked workflow ID, NOT the original — otherwise
  * each call creates a new fork from the same parent.
@@ -89,8 +89,8 @@ describe("fork deduplication (forkedWorkflowMap)", () => {
     expect(dedup.resolveWorkflowId("wf-C")).toBe("wf-C"); // untouched
   });
 
-  it("prevents duplicate forks when LLM calls update_workflow 4 times on same source", async () => {
-    const { updateWorkflow } = await loadModule();
+  it("prevents duplicate forks when LLM calls fork_workflow 4 times on same source", async () => {
+    const { forkWorkflow } = await loadModule();
     const dedup = createForkDedup();
 
     let forkCount = 0;
@@ -126,13 +126,13 @@ describe("fork deduplication (forkedWorkflowMap)", () => {
 
     const params = { orgId: "org-1", userId: "user-1", runId: "run-1" };
 
-    // Simulate 4 LLM tool calls to update_workflow with the same source workflowId
+    // Simulate 4 LLM tool calls to fork_workflow with the same source workflowId
     const results = [];
     for (let i = 0; i < 4; i++) {
       const effectiveId = dedup.resolveWorkflowId("wf-original");
-      const result = await updateWorkflow(
+      const result = await forkWorkflow(
         effectiveId,
-        { description: `change ${i}` },
+        { dag: { nodes: [{ id: `s${i}`, type: "http.call" }], edges: [] } },
         params,
       );
       if (result.outcome === "forked") {
@@ -158,14 +158,14 @@ describe("fork deduplication (forkedWorkflowMap)", () => {
     expect(forkedCalls).toHaveLength(3);
   });
 
-  it("handles 409 gracefully when redirected update has same DAG signature", async () => {
+  it("handles 409 gracefully when redirected fork has same DAG signature", async () => {
     /**
-     * Regression: after a fork, the LLM may call update_workflow again with
+     * Regression: after a fork, the LLM may call fork_workflow again with
      * the same DAG. Workflow-service returns 409 "signature already exists".
      * The handler should catch this and return the current workflow state
      * instead of propagating the error (which causes the LLM to retry).
      */
-    const { updateWorkflow, getWorkflow } = await loadModule();
+    const { forkWorkflow } = await loadModule();
     const dedup = createForkDedup();
 
     // First call: fork
@@ -182,7 +182,7 @@ describe("fork deduplication (forkedWorkflowMap)", () => {
     });
 
     const params = { orgId: "org-1", userId: "user-1", runId: "run-1" };
-    const result1 = await updateWorkflow("wf-original", { dag: { nodes: [{ id: "s1", type: "http.call" }], edges: [] } }, params);
+    const result1 = await forkWorkflow("wf-original", { dag: { nodes: [{ id: "s1", type: "http.call" }], edges: [] } }, params);
     expect(result1.outcome).toBe("forked");
     dedup.recordFork("wf-original", result1.workflow.id);
 
@@ -201,11 +201,11 @@ describe("fork deduplication (forkedWorkflowMap)", () => {
     const effectiveId = dedup.resolveWorkflowId("wf-original");
     expect(effectiveId).toBe("wf-forked");
 
-    // The 409 should throw from updateWorkflow — the handler in index.ts
+    // The 409 should throw from forkWorkflow — the handler in index.ts
     // catches it and calls getWorkflow instead. Here we verify the error
     // message contains "signature already exists" so the handler can match it.
     await expect(
-      updateWorkflow(effectiveId, { dag: { nodes: [{ id: "s1", type: "http.call" }], edges: [] } }, params),
+      forkWorkflow(effectiveId, { dag: { nodes: [{ id: "s1", type: "http.call" }], edges: [] } }, params),
     ).rejects.toThrow(/signature already exists/);
   });
 });

--- a/tests/unit/tool-errors.test.ts
+++ b/tests/unit/tool-errors.test.ts
@@ -5,12 +5,12 @@ describe("formatToolError", () => {
   it("parses Zod validation errors into field-level messages", () => {
     const raw = `[workflow-client] PUT /workflows/wf-1 returned 400: {"error":"Validation error","details":{"issues":[{"code":"invalid_type","expected":"object","received":"null","path":["dag","nodes",0,"config"],"message":"Expected object, received null"},{"code":"invalid_type","expected":"object","received":"null","path":["dag","nodes",0,"inputMapping"],"message":"Expected object, received null"}],"name":"ZodError"}}`;
 
-    const result = formatToolError("update_workflow", raw);
+    const result = formatToolError("fork_workflow", raw);
 
     expect(result.error).toContain("dag.nodes.0.config: Expected object, received null");
     expect(result.error).toContain("dag.nodes.0.inputMapping: Expected object, received null");
-    expect(result.suggestion).toContain("update_workflow_node_config");
-    expect(result.tool).toBe("update_workflow");
+    expect(result.suggestion).toContain("get_workflow_details");
+    expect(result.tool).toBe("fork_workflow");
   });
 
   it("truncates when more than 5 Zod issues", () => {
@@ -23,7 +23,7 @@ describe("formatToolError", () => {
     }));
     const raw = `returned 400: {"error":"Validation error","details":{"issues":${JSON.stringify(issues)},"name":"ZodError"}}`;
 
-    const result = formatToolError("update_workflow", raw);
+    const result = formatToolError("fork_workflow", raw);
     expect(result.error).toContain("and 3 more");
   });
 
@@ -45,7 +45,7 @@ describe("formatToolError", () => {
 
   it("handles missing API key errors", () => {
     const raw = "[workflow-client] WORKFLOW_SERVICE_API_KEY is required";
-    const result = formatToolError("update_workflow", raw);
+    const result = formatToolError("fork_workflow", raw);
 
     expect(result.error).toContain("is required");
     expect(result.suggestion).toContain("server configuration");
@@ -53,17 +53,17 @@ describe("formatToolError", () => {
 
   it("handles generic 400 errors without Zod details", () => {
     const raw = "[workflow-client] PUT /workflows/wf-1 returned 400: Bad request body";
-    const result = formatToolError("update_workflow", raw);
+    const result = formatToolError("fork_workflow", raw);
 
     expect(result.error).toContain("Bad request");
-    expect(result.suggestion).toContain("update_workflow_node_config");
+    expect(result.suggestion).toContain("get_workflow_details");
   });
 
-  it("includes tool-specific hints for update_workflow_node_config", () => {
-    const raw = "[workflow-client] Node \"bad-node\" not found in workflow wf-1";
-    const result = formatToolError("update_workflow_node_config", raw);
+  it("includes tool-specific hints for upgrade_workflow", () => {
+    const raw = "returned 400: invalid description";
+    const result = formatToolError("upgrade_workflow", raw);
 
-    expect(result.suggestion).toContain("nodeId");
+    expect(result.suggestion).toMatch(/bug.?fix|metadata/i);
   });
 
   it("includes tool-specific hints for update_prompt_template", () => {

--- a/tests/unit/tool-registry.test.ts
+++ b/tests/unit/tool-registry.test.ts
@@ -4,13 +4,18 @@ import { TOOL_REGISTRY, AVAILABLE_TOOL_NAMES, resolveToolSet } from "../../src/l
 describe("TOOL_REGISTRY", () => {
   it("contains all expected tools", () => {
     expect(AVAILABLE_TOOL_NAMES).toContain("request_user_input");
-    expect(AVAILABLE_TOOL_NAMES).toContain("update_workflow");
+    expect(AVAILABLE_TOOL_NAMES).toContain("create_workflow");
+    expect(AVAILABLE_TOOL_NAMES).toContain("upgrade_workflow");
+    expect(AVAILABLE_TOOL_NAMES).toContain("fork_workflow");
     expect(AVAILABLE_TOOL_NAMES).toContain("create_feature");
     expect(AVAILABLE_TOOL_NAMES).toContain("list_services");
     expect(AVAILABLE_TOOL_NAMES).toContain("update_campaign_fields");
     expect(AVAILABLE_TOOL_NAMES).toContain("extract_brand_fields");
     expect(AVAILABLE_TOOL_NAMES).toContain("browse_url");
     expect(AVAILABLE_TOOL_NAMES).not.toContain("extract_brand_text");
+    expect(AVAILABLE_TOOL_NAMES).not.toContain("update_workflow");
+    expect(AVAILABLE_TOOL_NAMES).not.toContain("update_workflow_node_config");
+    expect(AVAILABLE_TOOL_NAMES).not.toContain("generate_workflow");
   });
 
   it("does NOT contain call_api (removed for security)", () => {
@@ -27,10 +32,10 @@ describe("TOOL_REGISTRY", () => {
 
 describe("resolveToolSet", () => {
   it("resolves known tools to their definitions", () => {
-    const tools = resolveToolSet(["request_user_input", "update_workflow"]);
+    const tools = resolveToolSet(["request_user_input", "fork_workflow"]);
     expect(tools).toHaveLength(2);
     expect(tools[0].name).toBe("request_user_input");
-    expect(tools[1].name).toBe("update_workflow");
+    expect(tools[1].name).toBe("fork_workflow");
   });
 
   it("skips unknown tool names", () => {

--- a/tests/unit/workflow-client.test.ts
+++ b/tests/unit/workflow-client.test.ts
@@ -18,24 +18,33 @@ async function loadModule() {
   return import("../../src/lib/workflow-client.js");
 }
 
-describe("updateWorkflow", () => {
-  it("sends PUT with correct URL, headers, and body via api-service", async () => {
+describe("createWorkflow", () => {
+  it("sends POST /v1/workflows/create with body and identity headers", async () => {
+    const mockResponse = {
+      workflow: { id: "wf-new", name: "cold-email-outreach-nova", action: "created" },
+      dag: { nodes: [{ id: "step-1", type: "http.call" }], edges: [] },
+      generatedDescription: "Cold email workflow",
+    };
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ id: "wf-123", description: "Updated" }),
+      status: 201,
+      json: () => Promise.resolve(mockResponse),
     });
 
-    const { updateWorkflow } = await loadModule();
-    const result = await updateWorkflow(
-      "wf-123",
-      { description: "Updated description" },
+    const { createWorkflow } = await loadModule();
+    const result = await createWorkflow(
+      {
+        description: "Fetch a lead, generate a cold email, and send it",
+        featureSlug: "cold-email-outreach",
+        hints: { services: ["lead", "content-generation"] },
+      },
       { orgId: "org-1", userId: "user-1", runId: "run-1" },
     );
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://api.test.local/v1/workflows/wf-123",
+      "https://api.test.local/v1/workflows/create",
       expect.objectContaining({
-        method: "PUT",
+        method: "POST",
         headers: expect.objectContaining({
           "Content-Type": "application/json",
           "X-API-Key": "test-api-svc-key",
@@ -43,126 +52,191 @@ describe("updateWorkflow", () => {
           "x-user-id": "user-1",
           "x-run-id": "run-1",
         }),
-        body: JSON.stringify({ description: "Updated description" }),
       }),
     );
-    expect(result).toEqual({
-      workflow: { id: "wf-123", description: "Updated" },
-      outcome: "updated",
+    const sentBody = JSON.parse(
+      (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body,
+    );
+    expect(sentBody.description).toContain("cold email");
+    expect(sentBody.featureSlug).toBe("cold-email-outreach");
+    expect(sentBody.hints.services).toEqual(["lead", "content-generation"]);
+    expect(result).toEqual(mockResponse);
+  });
+
+  it("passes optional style configuration through", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ workflow: { id: "wf-1" } }),
+    });
+
+    const { createWorkflow } = await loadModule();
+    await createWorkflow(
+      {
+        description: "Workflow inspired by an expert",
+        featureSlug: "cold-email",
+        style: { type: "human", humanId: "hum-1", name: "Hormozi" },
+      },
+      { orgId: "o", userId: "u", runId: "r" },
+    );
+
+    const sentBody = JSON.parse(
+      (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body,
+    );
+    expect(sentBody.style).toEqual({
+      type: "human",
+      humanId: "hum-1",
+      name: "Hormozi",
     });
   });
 
-  it("returns outcome 'forked' on HTTP 201", async () => {
+  it("throws on non-OK response with status and body in message", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 422,
+      text: () => Promise.resolve("Could not generate a valid DAG"),
+    });
+
+    const { createWorkflow } = await loadModule();
+    await expect(
+      createWorkflow(
+        { description: "vague workflow request", featureSlug: "test" },
+        { orgId: "o", userId: "u", runId: "r" },
+      ),
+    ).rejects.toThrow(/returned 422.*Could not generate a valid DAG/);
+  });
+});
+
+describe("upgradeWorkflow", () => {
+  it("sends POST /v1/workflows/upgrade with workflowSlug + description", async () => {
+    const mockResponse = {
+      workflow: {
+        id: "wf-v2",
+        name: "cold-email-outreach-nova",
+        action: "updated",
+      },
+      dag: { nodes: [], edges: [] },
+      generatedDescription: "Upgraded workflow",
+    };
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(mockResponse),
+    });
+
+    const { upgradeWorkflow } = await loadModule();
+    const result = await upgradeWorkflow(
+      {
+        workflowSlug: "cold-email-outreach-nova",
+        description: "Bug fix: the email-send step was missing the to address mapping",
+      },
+      { orgId: "org-1", userId: "user-1", runId: "run-1" },
+    );
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.test.local/v1/workflows/upgrade",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "X-API-Key": "test-api-svc-key",
+          "x-org-id": "org-1",
+        }),
+      }),
+    );
+    const sentBody = JSON.parse(
+      (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body,
+    );
+    expect(sentBody.workflowSlug).toBe("cold-email-outreach-nova");
+    expect(sentBody.description).toContain("Bug fix");
+    expect(result).toEqual(mockResponse);
+  });
+
+  it("throws on non-OK response", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve("Workflow slug not found"),
+    });
+
+    const { upgradeWorkflow } = await loadModule();
+    await expect(
+      upgradeWorkflow(
+        { workflowSlug: "missing", description: "fix something" },
+        { orgId: "o", userId: "u", runId: "r" },
+      ),
+    ).rejects.toThrow(/returned 404.*Workflow slug not found/);
+  });
+
+  it("forwards tracking headers", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ workflow: { id: "wf-1" } }),
+    });
+
+    const { upgradeWorkflow } = await loadModule();
+    await upgradeWorkflow(
+      { workflowSlug: "s", description: "description text" },
+      {
+        orgId: "o",
+        userId: "u",
+        runId: "r",
+        trackingHeaders: { "x-campaign-id": "camp-1" },
+      },
+    );
+
+    const callHeaders = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
+      .headers;
+    expect(callHeaders["x-campaign-id"]).toBe("camp-1");
+  });
+});
+
+describe("forkWorkflow", () => {
+  it("sends PUT /v1/workflows/:id with DAG body via api-service", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       status: 201,
-      json: () => Promise.resolve({ id: "wf-new", name: "sales-email-v2", creationType: "fork", createdFromWorkflow: "wf-123", signatureName: "sales-email-v2", _action: "forked", _forkedFromName: "sales-email-v1" }),
+      json: () =>
+        Promise.resolve({
+          id: "wf-new",
+          name: "sales-email-v2",
+          creationType: "fork",
+          createdFromWorkflow: "wf-123",
+          signatureName: "sales-email-v2",
+          _action: "forked",
+          _forkedFromName: "sales-email-v1",
+        }),
     });
 
-    const { updateWorkflow } = await loadModule();
-    const result = await updateWorkflow(
+    const { forkWorkflow } = await loadModule();
+    const result = await forkWorkflow(
       "wf-123",
       { dag: { nodes: [{ id: "step-1", type: "http.call" }], edges: [] } },
       { orgId: "org-1", userId: "user-1", runId: "run-1" },
     );
 
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.test.local/v1/workflows/wf-123",
+      expect.objectContaining({ method: "PUT" }),
+    );
     expect(result.outcome).toBe("forked");
     expect(result.workflow.id).toBe("wf-new");
     expect(result.workflow.creationType).toBe("fork");
-    expect(result.workflow.createdFromWorkflow).toBe("wf-123");
-    expect(result.workflow.signatureName).toBe("sales-email-v2");
-    expect(result.workflow._action).toBe("forked");
-    expect(result.workflow._forkedFromName).toBe("sales-email-v1");
   });
 
-  it("uses _action from response body over status code", async () => {
+  it("returns outcome 'updated' when signature is identical (no fork)", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       status: 200,
       json: () => Promise.resolve({ id: "wf-1", _action: "updated" }),
     });
 
-    const { updateWorkflow } = await loadModule();
-    const result = await updateWorkflow(
+    const { forkWorkflow } = await loadModule();
+    const result = await forkWorkflow(
       "wf-1",
-      { description: "test" },
+      { dag: { nodes: [{ id: "step-1", type: "http.call" }], edges: [] } },
       { orgId: "o", userId: "u", runId: "r" },
     );
 
     expect(result.outcome).toBe("updated");
-    expect(result.workflow._action).toBe("updated");
-  });
-
-  it("throws with existing workflow info on HTTP 409", async () => {
-    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ok: false,
-      status: 409,
-      json: () => Promise.resolve({ existingWorkflowId: "wf-existing", existingWorkflowSlug: "sales-email-v2" }),
-    });
-
-    const { updateWorkflow } = await loadModule();
-    await expect(
-      updateWorkflow(
-        "wf-123",
-        { dag: { nodes: [{ id: "step-1", type: "http.call" }], edges: [] } },
-        { orgId: "org-1", userId: "user-1", runId: "run-1" },
-      ),
-    ).rejects.toThrow(/sales-email-v2.*wf-existing/);
-  });
-
-  it("always sends identity headers", async () => {
-    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ id: "wf-123" }),
-    });
-
-    const { updateWorkflow } = await loadModule();
-    await updateWorkflow(
-      "wf-123",
-      { name: "test" },
-      { orgId: "org-1", userId: "user-1", runId: "run-1" },
-    );
-
-    const callHeaders = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].headers;
-    expect(callHeaders["x-run-id"]).toBe("run-1");
-    expect(callHeaders["x-org-id"]).toBe("org-1");
-    expect(callHeaders["x-user-id"]).toBe("user-1");
-    expect(callHeaders["X-API-Key"]).toBe("test-api-svc-key");
-  });
-
-  it("forwards tracking headers", async () => {
-    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ id: "wf-123" }),
-    });
-
-    const { updateWorkflow } = await loadModule();
-    await updateWorkflow(
-      "wf-123",
-      { name: "new-name" },
-      {
-        orgId: "org-1",
-        userId: "user-1",
-        runId: "run-1",
-        trackingHeaders: { "x-campaign-id": "camp-1" },
-      },
-    );
-
-    const callHeaders = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].headers;
-    expect(callHeaders["x-campaign-id"]).toBe("camp-1");
-  });
-
-  it("throws on HTTP error", async () => {
-    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ok: false,
-      status: 404,
-      text: () => Promise.resolve("Not found"),
-    });
-
-    const { updateWorkflow } = await loadModule();
-    await expect(
-      updateWorkflow("wf-bad", { description: "x" }, { orgId: "o", userId: "u", runId: "r" }),
-    ).rejects.toThrow(/returned 404/);
   });
 
   it("strips null config and inputMapping from DAG nodes before sending", async () => {
@@ -171,15 +245,26 @@ describe("updateWorkflow", () => {
       json: () => Promise.resolve({ id: "wf-1" }),
     });
 
-    const { updateWorkflow } = await loadModule();
-    await updateWorkflow(
+    const { forkWorkflow } = await loadModule();
+    await forkWorkflow(
       "wf-1",
       {
         dag: {
           nodes: [
-            { id: "step-1", type: "http.call", config: null as unknown as Record<string, unknown>, inputMapping: null as unknown as Record<string, string>, retries: 0 },
+            {
+              id: "step-1",
+              type: "http.call",
+              config: null as unknown as Record<string, unknown>,
+              inputMapping: null as unknown as Record<string, string>,
+              retries: 0,
+            },
             { id: "step-2", type: "condition" },
-            { id: "step-3", type: "http.call", config: { path: "/send" }, inputMapping: { "body.to": "$ref:step-1.output.email" } },
+            {
+              id: "step-3",
+              type: "http.call",
+              config: { path: "/send" },
+              inputMapping: { "body.to": "$ref:step-1.output.email" },
+            },
           ],
           edges: [{ from: "step-1", to: "step-2" }],
         },
@@ -187,58 +272,100 @@ describe("updateWorkflow", () => {
       { orgId: "o", userId: "u", runId: "r" },
     );
 
-    const sentBody = JSON.parse((fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
-    expect(sentBody.dag.nodes[0]).toEqual({ id: "step-1", type: "http.call", retries: 0 });
+    const sentBody = JSON.parse(
+      (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body,
+    );
+    expect(sentBody.dag.nodes[0]).toEqual({
+      id: "step-1",
+      type: "http.call",
+      retries: 0,
+    });
     expect(sentBody.dag.nodes[0].config).toBeUndefined();
     expect(sentBody.dag.nodes[0].inputMapping).toBeUndefined();
-    expect(sentBody.dag.nodes[1]).toEqual({ id: "step-2", type: "condition" });
     expect(sentBody.dag.nodes[2].config).toEqual({ path: "/send" });
-    expect(sentBody.dag.nodes[2].inputMapping).toEqual({ "body.to": "$ref:step-1.output.email" });
   });
 
-  it("preserves condition field on DAG edges when sending", async () => {
+  it("preserves condition field on DAG edges", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ id: "wf-1", _action: "updated" }),
     });
 
-    const { updateWorkflow } = await loadModule();
-    await updateWorkflow(
+    const { forkWorkflow } = await loadModule();
+    await forkWorkflow(
       "wf-1",
       {
         dag: {
           nodes: [
             { id: "check", type: "condition" },
-            { id: "yes-branch", type: "http.call", config: { path: "/yes" } },
-            { id: "no-branch", type: "http.call", config: { path: "/no" } },
-            { id: "always", type: "http.call", config: { path: "/done" } },
+            { id: "yes", type: "http.call", config: { path: "/yes" } },
           ],
           edges: [
-            { from: "check", to: "yes-branch", condition: "results.check.found == true" },
-            { from: "check", to: "no-branch", condition: "results.check.found == false" },
-            { from: "check", to: "always" },
-            { from: "yes-branch", to: "always" },
+            { from: "check", to: "yes", condition: "results.check.found == true" },
           ],
         },
       },
       { orgId: "o", userId: "u", runId: "r" },
     );
 
-    const sentBody = JSON.parse((fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
-    expect(sentBody.dag.edges).toEqual([
-      { from: "check", to: "yes-branch", condition: "results.check.found == true" },
-      { from: "check", to: "no-branch", condition: "results.check.found == false" },
-      { from: "check", to: "always" },
-      { from: "yes-branch", to: "always" },
-    ]);
+    const sentBody = JSON.parse(
+      (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body,
+    );
+    expect(sentBody.dag.edges[0]).toEqual({
+      from: "check",
+      to: "yes",
+      condition: "results.check.found == true",
+    });
+  });
+
+  it("throws with existing workflow info on HTTP 409", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: () =>
+        Promise.resolve({
+          existingWorkflowId: "wf-existing",
+          existingWorkflowSlug: "sales-email-v2",
+        }),
+    });
+
+    const { forkWorkflow } = await loadModule();
+    await expect(
+      forkWorkflow(
+        "wf-123",
+        { dag: { nodes: [{ id: "step-1", type: "http.call" }], edges: [] } },
+        { orgId: "org-1", userId: "user-1", runId: "run-1" },
+      ),
+    ).rejects.toThrow(/sales-email-v2.*wf-existing/);
+  });
+
+  it("throws on other HTTP errors", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("Internal error"),
+    });
+
+    const { forkWorkflow } = await loadModule();
+    await expect(
+      forkWorkflow(
+        "wf-bad",
+        { dag: { nodes: [], edges: [] } },
+        { orgId: "o", userId: "u", runId: "r" },
+      ),
+    ).rejects.toThrow(/returned 500/);
   });
 
   it("throws when ADMIN_DISTRIBUTE_API_KEY is not set", async () => {
     delete process.env.ADMIN_DISTRIBUTE_API_KEY;
 
-    const { updateWorkflow } = await loadModule();
+    const { forkWorkflow } = await loadModule();
     await expect(
-      updateWorkflow("wf-1", { description: "x" }, { orgId: "o", userId: "u", runId: "r" }),
+      forkWorkflow(
+        "wf-1",
+        { dag: { nodes: [], edges: [] } },
+        { orgId: "o", userId: "u", runId: "r" },
+      ),
     ).rejects.toThrow(/ADMIN_DISTRIBUTE_API_KEY is required/);
 
     expect(fetch).not.toHaveBeenCalled();
@@ -313,7 +440,11 @@ describe("getWorkflow", () => {
     });
 
     const { getWorkflow } = await loadModule();
-    const result = await getWorkflow("wf-1", { orgId: "org-1", userId: "user-1", runId: "run-1" });
+    const result = await getWorkflow("wf-1", {
+      orgId: "org-1",
+      userId: "user-1",
+      runId: "run-1",
+    });
 
     expect(fetch).toHaveBeenCalledWith(
       "https://api.test.local/v1/workflows/wf-1",
@@ -339,190 +470,6 @@ describe("getWorkflow", () => {
     await expect(
       getWorkflow("wf-bad", { orgId: "o", userId: "u", runId: "r" }),
     ).rejects.toThrow(/returned 404/);
-  });
-});
-
-describe("updateWorkflowNodeConfig", () => {
-  it("fetches workflow, merges config, and PUTs the updated DAG", async () => {
-    const existingWorkflow = {
-      id: "wf-1",
-      dag: {
-        nodes: [
-          { id: "email-generate", type: "http.call", config: { body: { type: "cold-email" }, path: "/generate", method: "POST", service: "content-generation" } },
-          { id: "email-send", type: "http.call", config: { path: "/send", method: "POST", service: "email-gateway" } },
-        ],
-        edges: [{ from: "email-generate", to: "email-send" }],
-      },
-    };
-
-    const updatedWorkflow = { ...existingWorkflow, updatedAt: "2026-03-18T00:00:00Z" };
-
-    (fetch as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(existingWorkflow) })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(updatedWorkflow) });
-
-    const { updateWorkflowNodeConfig } = await loadModule();
-    const result = await updateWorkflowNodeConfig(
-      "wf-1",
-      "email-generate",
-      { body: { type: "cold-email-v3" } },
-      { orgId: "org-1", userId: "user-1", runId: "run-1" },
-    );
-
-    expect((fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe("https://api.test.local/v1/workflows/wf-1");
-    expect((fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].method).toBe("GET");
-
-    const putBody = JSON.parse((fetch as ReturnType<typeof vi.fn>).mock.calls[1][1].body);
-    expect(putBody.dag.nodes[0].config.body.type).toBe("cold-email-v3");
-    expect(putBody.dag.nodes[0].config.path).toBe("/generate");
-    expect(putBody.dag.nodes[0].config.service).toBe("content-generation");
-    expect(putBody.dag.nodes[1].id).toBe("email-send");
-
-    expect(result).toEqual({ workflow: updatedWorkflow, outcome: "updated" });
-  });
-
-  it("returns forked outcome when node config change triggers a fork", async () => {
-    const existingWorkflow = {
-      id: "wf-1",
-      dag: {
-        nodes: [{ id: "step-1", type: "http.call", config: { path: "/old" } }],
-        edges: [],
-      },
-    };
-
-    const forkedWorkflow = { id: "wf-forked", name: "wf-1-custom", creationType: "fork", createdFromWorkflow: "wf-1", dag: existingWorkflow.dag };
-
-    (fetch as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(existingWorkflow) })
-      .mockResolvedValueOnce({ ok: true, status: 201, json: () => Promise.resolve(forkedWorkflow) });
-
-    const { updateWorkflowNodeConfig } = await loadModule();
-    const result = await updateWorkflowNodeConfig(
-      "wf-1",
-      "step-1",
-      { path: "/new" },
-      { orgId: "org-1", userId: "user-1", runId: "run-1" },
-    );
-
-    expect(result.outcome).toBe("forked");
-    expect(result.workflow.id).toBe("wf-forked");
-    expect(result.workflow.creationType).toBe("fork");
-    expect(result.workflow.createdFromWorkflow).toBe("wf-1");
-  });
-
-  it("throws when node is not found in DAG", async () => {
-    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({
-        id: "wf-1",
-        dag: { nodes: [{ id: "step-1", type: "http.call" }], edges: [] },
-      }),
-    });
-
-    const { updateWorkflowNodeConfig } = await loadModule();
-    await expect(
-      updateWorkflowNodeConfig(
-        "wf-1",
-        "nonexistent-node",
-        { body: { type: "v2" } },
-        { orgId: "o", userId: "u", runId: "r" },
-      ),
-    ).rejects.toThrow(/Node "nonexistent-node" not found/);
-  });
-
-  it("throws when workflow has no DAG", async () => {
-    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ id: "wf-1", dag: null }),
-    });
-
-    const { updateWorkflowNodeConfig } = await loadModule();
-    await expect(
-      updateWorkflowNodeConfig(
-        "wf-1",
-        "step-1",
-        { body: {} },
-        { orgId: "o", userId: "u", runId: "r" },
-      ),
-    ).rejects.toThrow(/has no DAG/);
-  });
-});
-
-describe("generateWorkflow", () => {
-  it("sends POST /v1/workflows/generate via api-service", async () => {
-    const mockResponse = {
-      workflow: { id: "wf-new", name: "sales-email-cold-outreach-nova" },
-      dag: { nodes: [{ id: "step-1", type: "http.call" }], edges: [] },
-      category: "sales",
-      channel: "email",
-      audienceType: "cold-outreach",
-      generatedDescription: "A cold email workflow",
-    };
-
-    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve(mockResponse),
-    });
-
-    const { generateWorkflow } = await loadModule();
-    const result = await generateWorkflow(
-      {
-        description: "Create a cold email workflow that fetches a lead, generates an email, and sends it",
-        featureSlug: "cold-email",
-        hints: { services: ["lead", "content-generation", "email-gateway"] },
-      },
-      { orgId: "org-1", userId: "user-1", runId: "run-1" },
-    );
-
-    expect(fetch).toHaveBeenCalledWith(
-      "https://api.test.local/v1/workflows/generate",
-      expect.objectContaining({
-        method: "POST",
-        headers: expect.objectContaining({
-          "X-API-Key": "test-api-svc-key",
-          "x-org-id": "org-1",
-        }),
-      }),
-    );
-
-    const body = JSON.parse((fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
-    expect(body.description).toContain("cold email workflow");
-    expect(body.hints.services).toContain("lead");
-
-    expect(result).toEqual(mockResponse);
-  });
-
-  it("throws on HTTP error", async () => {
-    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ok: false,
-      status: 422,
-      text: () => Promise.resolve("Invalid DAG"),
-    });
-
-    const { generateWorkflow } = await loadModule();
-    await expect(
-      generateWorkflow(
-        { description: "bad workflow", featureSlug: "test" },
-        { orgId: "o", userId: "u", runId: "r" },
-      ),
-    ).rejects.toThrow(/returned 422/);
-  });
-
-  it("works without hints", async () => {
-    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ workflow: { id: "wf-1" } }),
-    });
-
-    const { generateWorkflow } = await loadModule();
-    await generateWorkflow(
-      { description: "Simple workflow that sends an email", featureSlug: "email" },
-      { orgId: "o", userId: "u", runId: "r" },
-    );
-
-    const body = JSON.parse((fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
-    expect(body.description).toBe("Simple workflow that sends an email");
-    expect(body.hints).toBeUndefined();
   });
 });
 
@@ -563,7 +510,11 @@ describe("getWorkflowRequiredProviders", () => {
 
     const { getWorkflowRequiredProviders } = await loadModule();
     await expect(
-      getWorkflowRequiredProviders("wf-bad", { orgId: "o", userId: "u", runId: "r" }),
+      getWorkflowRequiredProviders("wf-bad", {
+        orgId: "o",
+        userId: "u",
+        runId: "r",
+      }),
     ).rejects.toThrow(/returned 404/);
   });
 });
@@ -578,7 +529,13 @@ describe("listWorkflows", () => {
 
     const { listWorkflows } = await loadModule();
     const result = await listWorkflows(
-      { category: "sales", channel: "email", tag: "cold", featureSlug: "cold-email-outreach", status: "active" },
+      {
+        category: "sales",
+        channel: "email",
+        tag: "cold",
+        featureSlug: "cold-email-outreach",
+        status: "active",
+      },
       { orgId: "org-1", userId: "user-1", runId: "run-1" },
     );
 

--- a/tests/unit/workflow-tools-registry.test.ts
+++ b/tests/unit/workflow-tools-registry.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import {
+  TOOL_REGISTRY,
+  AVAILABLE_TOOL_NAMES,
+} from "../../src/lib/anthropic.js";
+
+describe("workflow tool registry", () => {
+  it("exposes create_workflow, upgrade_workflow, fork_workflow", () => {
+    expect(TOOL_REGISTRY).toHaveProperty("create_workflow");
+    expect(TOOL_REGISTRY).toHaveProperty("upgrade_workflow");
+    expect(TOOL_REGISTRY).toHaveProperty("fork_workflow");
+    expect(AVAILABLE_TOOL_NAMES).toContain("create_workflow");
+    expect(AVAILABLE_TOOL_NAMES).toContain("upgrade_workflow");
+    expect(AVAILABLE_TOOL_NAMES).toContain("fork_workflow");
+  });
+
+  it("does NOT expose the old update_workflow, update_workflow_node_config, generate_workflow tools", () => {
+    expect(TOOL_REGISTRY).not.toHaveProperty("update_workflow");
+    expect(TOOL_REGISTRY).not.toHaveProperty("update_workflow_node_config");
+    expect(TOOL_REGISTRY).not.toHaveProperty("generate_workflow");
+    expect(AVAILABLE_TOOL_NAMES).not.toContain("update_workflow");
+    expect(AVAILABLE_TOOL_NAMES).not.toContain("update_workflow_node_config");
+    expect(AVAILABLE_TOOL_NAMES).not.toContain("generate_workflow");
+  });
+
+  it("create_workflow requires description and featureSlug", () => {
+    const tool = TOOL_REGISTRY.create_workflow;
+    expect(tool.name).toBe("create_workflow");
+    const schema = tool.input_schema as {
+      properties: Record<string, unknown>;
+      required: string[];
+    };
+    expect(schema.required).toEqual(
+      expect.arrayContaining(["description", "featureSlug"]),
+    );
+    expect(schema.properties).toHaveProperty("description");
+    expect(schema.properties).toHaveProperty("featureSlug");
+    expect(schema.properties).toHaveProperty("hints");
+    expect(schema.properties).toHaveProperty("style");
+  });
+
+  it("upgrade_workflow requires workflowSlug and description, includes HARD RULE in description", () => {
+    const tool = TOOL_REGISTRY.upgrade_workflow;
+    expect(tool.name).toBe("upgrade_workflow");
+    const schema = tool.input_schema as {
+      properties: Record<string, unknown>;
+      required: string[];
+    };
+    expect(schema.required).toEqual(
+      expect.arrayContaining(["workflowSlug", "description"]),
+    );
+    expect(tool.description).toMatch(/HARD RULE/);
+    expect(tool.description?.toLowerCase()).toMatch(/bug.?fix/);
+    expect(tool.description?.toLowerCase()).toMatch(/metadata/);
+    expect(tool.description?.toLowerCase()).toMatch(/fork_workflow/);
+  });
+
+  it("fork_workflow requires workflowId and dag, mentions new lineage in description", () => {
+    const tool = TOOL_REGISTRY.fork_workflow;
+    expect(tool.name).toBe("fork_workflow");
+    const schema = tool.input_schema as {
+      properties: Record<string, unknown>;
+      required: string[];
+    };
+    expect(schema.required).toEqual(
+      expect.arrayContaining(["workflowId", "dag"]),
+    );
+    expect(tool.description?.toLowerCase()).toMatch(/lineage|new.?dynasty|fork/);
+  });
+});


### PR DESCRIPTION
## Summary

Expose three intent-specific workflow tools so the frontend agent can call the right one per situation (matches the recent workflow-service endpoint split):

- **`create_workflow`** → `POST /v1/workflows/create` — brand-new workflow / new dynasty from NL.
- **`upgrade_workflow`** → `POST /v1/workflows/upgrade` — regenerate the DAG of an existing workflow, **keeping the same dynasty/lineage**. Tool description includes a **HARD RULE**: upgrade is for bug fixes or metadata clarifications only. Any substantive change must use `fork_workflow`.
- **`fork_workflow`** → `PUT /v1/workflows/:id` with a new DAG — creates a new dynasty when the DAG signature differs from the source. Same-signature submissions return `_action: "updated"` (no-op, surfaced honestly in the tool result).

## Removed tools

- `update_workflow` — polymorphic PUT (metadata + DAG + fork) was confusing; metadata "tweak" path no longer reachable via tools.
- `update_workflow_node_config` — single-node tweak. Bypassed the fork/upgrade decision. Model now uses `fork_workflow` with the full DAG (or `upgrade_workflow` for bug fixes).
- `generate_workflow` — pointed at `POST /v1/workflows/generate`, which workflow-service / api-service no longer expose (renamed to `/create`). Was effectively broken.

## Other changes

- `workflow-client.ts`: new `createWorkflow()` and `upgradeWorkflow()` client functions; `updateWorkflow()` → `forkWorkflow()` with body narrowed to `{ dag }`; removed `generateWorkflow()` and `updateWorkflowNodeConfig()`.
- `executeTool()` dispatch updated; per-turn `forkedWorkflowMap` redirect logic preserved on `fork_workflow`.
- `tool-errors.ts` hints updated.
- `schemas.ts` allowedTools docs/examples refreshed; tool name example in SSE events → `fork_workflow`.
- README tool inventory rewritten with the three-tool intent matrix.
- Regenerated `openapi.json`.

## Test plan

- [x] `npm run build` (TS + openapi gen) — green
- [x] `npm run test:unit` — 553 tests passing (was 548)
- [ ] Manual: dev server, trigger each of the three tools through chat, verify the right workflow-service endpoint is hit (logs)
- [ ] Frontend follow-up: update any prompts that referenced `update_workflow` / `generate_workflow` / `update_workflow_node_config` to use the new tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)