### PR TITLE
fix: use streaming transport for Anthropic /complete (hotfix)

### DIFF
--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -1081,7 +1081,7 @@ export function createAnthropicClient({ apiKey, systemPrompt }: AnthropicOptions
         userContent = message;
       }
 
-      const params: Anthropic.MessageCreateParamsNonStreaming = {
+      const params = {
         model: effectiveModel,
         max_tokens: MAX_TOKENS,
         system: systemPrompt,
@@ -1103,7 +1103,14 @@ export function createAnthropicClient({ apiKey, systemPrompt }: AnthropicOptions
       };
 
       const timeoutMs = ANTHROPIC_TIMEOUT_MS[effectiveModel] ?? DEFAULT_ANTHROPIC_TIMEOUT_MS;
-      const response = await client.messages.create(params, { timeout: timeoutMs });
+      // Use streaming transport. Anthropic SDK rejects non-streaming requests
+      // when max_tokens implies >10 min runtime ("Streaming is required..."),
+      // so we stream under the hood and assemble the final Message.
+      const stream = client.messages.stream(
+        params as unknown as Anthropic.MessageStreamParams,
+        { timeout: timeoutMs },
+      );
+      const response = await stream.finalMessage();
 
       if (response.stop_reason === "max_tokens") {
         console.warn(

--- a/tests/unit/anthropic-output-config.test.ts
+++ b/tests/unit/anthropic-output-config.test.ts
@@ -7,22 +7,24 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
  * malformed output).
  */
 
-// Capture the params passed to client.messages.create
+// Capture the params passed to client.messages.stream
 let capturedParams: Record<string, unknown> | undefined;
 
 vi.mock("@anthropic-ai/sdk", () => {
   return {
     default: class MockAnthropic {
       messages = {
-        create: async (params: Record<string, unknown>) => {
+        create: () => {
+          throw new Error("create not implemented in mock — complete() must use stream");
+        },
+        stream: (params: Record<string, unknown>) => {
           capturedParams = params;
           return {
-            content: [{ type: "text", text: '{"ok":true}' }],
-            usage: { input_tokens: 10, output_tokens: 5 },
+            finalMessage: async () => ({
+              content: [{ type: "text", text: '{"ok":true}' }],
+              usage: { input_tokens: 10, output_tokens: 5 },
+            }),
           };
-        },
-        stream: () => {
-          throw new Error("stream not implemented in mock");
         },
       };
     },

--- a/tests/unit/anthropic-streaming-required.test.ts
+++ b/tests/unit/anthropic-streaming-required.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from "vitest";
+
+/**
+ * Regression: Anthropic SDK rejects non-streaming requests when max_tokens
+ * implies >10 min latency with `AnthropicError: Streaming is required for
+ * operations that may take longer than 10 minutes`.
+ *
+ * complete() must use messages.stream().finalMessage() under the hood so it
+ * never trips that pre-flight check.
+ */
+
+vi.mock("@anthropic-ai/sdk", () => {
+  return {
+    default: class MockAnthropic {
+      messages = {
+        create: async () => {
+          throw new Error(
+            "Streaming is required for operations that may take longer than 10 minutes.",
+          );
+        },
+        stream: () => ({
+          finalMessage: async () => ({
+            stop_reason: "end_turn",
+            content: [{ type: "text", text: "streamed ok" }],
+            usage: { input_tokens: 10, output_tokens: 5 },
+          }),
+        }),
+      };
+    },
+  };
+});
+
+const { createAnthropicClient } = await import("../../src/lib/anthropic.js");
+
+describe("anthropic complete() must use streaming transport", () => {
+  it("resolves successfully even when messages.create would throw 'Streaming is required'", async () => {
+    const claude = createAnthropicClient({ apiKey: "test-key", systemPrompt: "test" });
+    const result = await claude.complete("Hello");
+
+    expect(result.content).toBe("streamed ok");
+    expect(result.tokensInput).toBe(10);
+    expect(result.tokensOutput).toBe(5);
+  });
+});

--- a/tests/unit/anthropic-thinking.test.ts
+++ b/tests/unit/anthropic-thinking.test.ts
@@ -1,18 +1,20 @@
 import { describe, it, expect, vi } from "vitest";
 
-let lastCreateParams: Record<string, unknown>;
-let mockCreateResponse: Record<string, unknown>;
+let lastStreamParams: Record<string, unknown>;
+let mockFinalMessage: Record<string, unknown>;
 
 vi.mock("@anthropic-ai/sdk", () => {
   return {
     default: class MockAnthropic {
       messages = {
-        create: async (params: Record<string, unknown>) => {
-          lastCreateParams = params;
-          return mockCreateResponse;
+        create: () => {
+          throw new Error("create not implemented in mock — complete() must use stream");
         },
-        stream: () => {
-          throw new Error("stream not implemented in mock");
+        stream: (params: Record<string, unknown>) => {
+          lastStreamParams = params;
+          return {
+            finalMessage: async () => mockFinalMessage,
+          };
         },
       };
     },
@@ -25,7 +27,7 @@ describe("anthropic complete() options", () => {
   const claude = createAnthropicClient({ apiKey: "test-key", systemPrompt: "You are helpful." });
 
   it("does NOT send thinking config (thinking removed from API)", async () => {
-    mockCreateResponse = {
+    mockFinalMessage = {
       stop_reason: "end_turn",
       content: [{ type: "text", text: "result" }],
       usage: { input_tokens: 10, output_tokens: 5 },
@@ -33,11 +35,11 @@ describe("anthropic complete() options", () => {
 
     await claude.complete("Simple task");
 
-    expect(lastCreateParams.thinking).toBeUndefined();
+    expect(lastStreamParams.thinking).toBeUndefined();
   });
 
   it("preserves caller temperature", async () => {
-    mockCreateResponse = {
+    mockFinalMessage = {
       stop_reason: "end_turn",
       content: [{ type: "text", text: "result" }],
       usage: { input_tokens: 10, output_tokens: 5 },
@@ -45,11 +47,11 @@ describe("anthropic complete() options", () => {
 
     await claude.complete("Simple task", { temperature: 0.3 });
 
-    expect(lastCreateParams.temperature).toBe(0.3);
+    expect(lastStreamParams.temperature).toBe(0.3);
   });
 
   it("does not send temperature when omitted", async () => {
-    mockCreateResponse = {
+    mockFinalMessage = {
       stop_reason: "end_turn",
       content: [{ type: "text", text: "result" }],
       usage: { input_tokens: 10, output_tokens: 5 },
@@ -57,6 +59,6 @@ describe("anthropic complete() options", () => {
 
     await claude.complete("Simple task");
 
-    expect(lastCreateParams.temperature).toBeUndefined();
+    expect(lastStreamParams.temperature).toBeUndefined();
   });
 });

--- a/tests/unit/anthropic-timeout.test.ts
+++ b/tests/unit/anthropic-timeout.test.ts
@@ -11,16 +11,18 @@ vi.mock("@anthropic-ai/sdk", () => {
   return {
     default: class MockAnthropic {
       messages = {
-        create: async (_params: Record<string, unknown>, options?: Record<string, unknown>) => {
+        create: () => {
+          throw new Error("create not implemented in mock — complete() must use stream");
+        },
+        stream: (_params: Record<string, unknown>, options?: Record<string, unknown>) => {
           capturedRequestOptions = options;
           return {
-            content: [{ type: "text", text: "ok" }],
-            usage: { input_tokens: 10, output_tokens: 5 },
-            stop_reason: "end_turn",
+            finalMessage: async () => ({
+              content: [{ type: "text", text: "ok" }],
+              usage: { input_tokens: 10, output_tokens: 5 },
+              stop_reason: "end_turn",
+            }),
           };
-        },
-        stream: () => {
-          throw new Error("stream not implemented in mock");
         },
       };
     },

--- a/tests/unit/anthropic-truncation.test.ts
+++ b/tests/unit/anthropic-truncation.test.ts
@@ -5,16 +5,18 @@ import { describe, it, expect, vi } from "vitest";
  * stop_reason: "max_tokens" — it should never throw, regardless of responseFormat.
  */
 
-let mockCreateResponse: Record<string, unknown>;
+let mockFinalMessage: Record<string, unknown>;
 
 vi.mock("@anthropic-ai/sdk", () => {
   return {
     default: class MockAnthropic {
       messages = {
-        create: async () => mockCreateResponse,
-        stream: () => {
-          throw new Error("stream not implemented in mock");
+        create: () => {
+          throw new Error("create not implemented in mock — complete() must use stream");
         },
+        stream: () => ({
+          finalMessage: async () => mockFinalMessage,
+        }),
       };
     },
   };
@@ -24,7 +26,7 @@ const { createAnthropicClient } = await import("../../src/lib/anthropic.js");
 
 describe("anthropic complete() truncation detection", () => {
   it("returns partial content when stop_reason is max_tokens with responseFormat json", async () => {
-    mockCreateResponse = {
+    mockFinalMessage = {
       stop_reason: "max_tokens",
       content: [{ type: "text", text: '{"partial": "dat' }],
       usage: { input_tokens: 100, output_tokens: 16000 },
@@ -39,7 +41,7 @@ describe("anthropic complete() truncation detection", () => {
   });
 
   it("returns partial content when stop_reason is max_tokens without responseFormat json", async () => {
-    mockCreateResponse = {
+    mockFinalMessage = {
       stop_reason: "max_tokens",
       content: [{ type: "text", text: "some long text that got cut off" }],
       usage: { input_tokens: 100, output_tokens: 16000 },
@@ -52,7 +54,7 @@ describe("anthropic complete() truncation detection", () => {
   });
 
   it("does NOT throw when stop_reason is end_turn with responseFormat json", async () => {
-    mockCreateResponse = {
+    mockFinalMessage = {
       stop_reason: "end_turn",
       content: [{ type: "text", text: '{"complete": true}' }],
       usage: { input_tokens: 50, output_tokens: 20 },


### PR DESCRIPTION
## Summary

- Production fix: `chat-service` `/complete` calls to Anthropic were failing with `AnthropicError: Streaming is required for operations that may take longer than 10 minutes`, returning 502 to callers. Root cause: the Anthropic SDK now pre-flights `messages.create()` against `max_tokens`; with `max_tokens: 64_000` it refuses the non-streaming path.
- Switch `complete()` to `client.messages.stream(...).finalMessage()`. Same params, same returned `Message` shape, same timeout / `output_config` / image / `stop_reason` semantics.
- Pure transport change. No API contract change. No new state.

## Impact

Unblocks ai-visibility-score-service extraction step (and every other service calling `/complete` with `provider: "anthropic"`).

## Test plan

- [x] New regression test `tests/unit/anthropic-streaming-required.test.ts`: mocks `messages.create` to throw the exact SDK error and verifies `complete()` still resolves via `stream().finalMessage()`.
- [x] Updated 4 existing test mocks (`anthropic-timeout`, `anthropic-output-config`, `anthropic-truncation`, `anthropic-thinking`) to capture from `stream` instead of `create`. All assert the same params / options / response handling.
- [x] Full suite: 561/561 passing locally.
- [x] `npm run build` clean (tsc + openapi regen).
- [ ] Post-deploy: tail Railway logs for `chat-service` (production) for 10 min → zero new "Streaming is required" errors.
- [ ] Cross-service: trigger `ai-visibility-score-service` POST `/orgs/visibility-score-runs` → run no longer 502s at extraction step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)