### PR TITLE
hotfix: Drop output_config from Anthropic /complete (additionalProperties: true rejected)

### DIFF
--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -1081,25 +1081,17 @@ export function createAnthropicClient({ apiKey, systemPrompt }: AnthropicOptions
         userContent = message;
       }
 
+      // JSON-mode correctness is enforced by JSON_RESPONSE_SYSTEM_SUFFIX
+      // (system-prompt nudge) + downstream parseModelJson/jsonrepair pipeline.
+      // We do NOT pass `output_config` here: Anthropic rejects a permissive
+      // schema (additionalProperties: true, no properties) with 400, and we
+      // have no caller-supplied strict schema.
       const params = {
         model: effectiveModel,
         max_tokens: MAX_TOKENS,
         system: systemPrompt,
         messages: [{ role: "user", content: userContent }],
         ...(options?.temperature != null ? { temperature: options.temperature } : {}),
-        ...(options?.responseFormat === "json"
-          ? {
-              output_config: {
-                format: {
-                  type: "json_schema" as const,
-                  schema: {
-                    type: "object",
-                    additionalProperties: true,
-                  },
-                },
-              },
-            }
-          : {}),
       };
 
       const timeoutMs = ANTHROPIC_TIMEOUT_MS[effectiveModel] ?? DEFAULT_ANTHROPIC_TIMEOUT_MS;

--- a/tests/unit/anthropic-output-config.test.ts
+++ b/tests/unit/anthropic-output-config.test.ts
@@ -1,13 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 /**
- * Tests that createAnthropicClient().complete() passes output_config
- * with json_schema when responseFormat: "json" is requested, ensuring
- * Anthropic's constrained decoding produces valid JSON (no fences, no
- * malformed output).
+ * Anthropic rejects `output_config.format.schema` when the schema is a
+ * permissive object (`additionalProperties: true`, no `properties`), with:
+ *   400 invalid_request_error — "For 'object' type, 'additionalProperties: true'
+ *   is not supported. Please set 'additionalProperties' to false"
+ *
+ * We have no caller-supplied schema for the generic JSON-mode use case, so
+ * complete() must NOT pass `output_config` at all. JSON correctness is enforced
+ * by the system-prompt suffix (JSON_RESPONSE_SYSTEM_SUFFIX) + the downstream
+ * parseModelJson / jsonrepair / LLM-repair pipeline.
  */
 
-// Capture the params passed to client.messages.stream
 let capturedParams: Record<string, unknown> | undefined;
 
 vi.mock("@anthropic-ai/sdk", () => {
@@ -23,6 +27,7 @@ vi.mock("@anthropic-ai/sdk", () => {
             finalMessage: async () => ({
               content: [{ type: "text", text: '{"ok":true}' }],
               usage: { input_tokens: 10, output_tokens: 5 },
+              stop_reason: "end_turn",
             }),
           };
         },
@@ -31,7 +36,6 @@ vi.mock("@anthropic-ai/sdk", () => {
   };
 });
 
-// Import after mock is set up
 const { createAnthropicClient } = await import("../../src/lib/anthropic.js");
 
 describe("anthropic complete() output_config", () => {
@@ -39,20 +43,12 @@ describe("anthropic complete() output_config", () => {
     capturedParams = undefined;
   });
 
-  it("passes output_config with json_schema when responseFormat is json", async () => {
+  it("does NOT pass output_config when responseFormat is json", async () => {
     const claude = createAnthropicClient({ apiKey: "test-key", systemPrompt: "You are helpful." });
     await claude.complete("Return JSON", { responseFormat: "json" });
 
     expect(capturedParams).toBeDefined();
-    expect(capturedParams!.output_config).toEqual({
-      format: {
-        type: "json_schema",
-        schema: {
-          type: "object",
-          additionalProperties: true,
-        },
-      },
-    });
+    expect(capturedParams!.output_config).toBeUndefined();
   });
 
   it("does NOT pass output_config when responseFormat is omitted", async () => {


### PR DESCRIPTION
Automated by release.sh