### PR TITLE
hotfix: Fix 404 cascade: rename billing-service credits/authorize → customer_balance/authorize

### DIFF
--- a/src/lib/billing-client.ts
+++ b/src/lib/billing-client.ts
@@ -68,7 +68,7 @@ export async function authorizeCredits(
     }
   }
 
-  const res = await fetch(`${BILLING_SERVICE_URL}/v1/credits/authorize`, {
+  const res = await fetch(`${BILLING_SERVICE_URL}/v1/customer_balance/authorize`, {
     method: "POST",
     headers,
     body: JSON.stringify({ items, description }),
@@ -77,7 +77,7 @@ export async function authorizeCredits(
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new BillingError(
-      `[billing-client] POST /v1/credits/authorize returned ${res.status}: ${text}`,
+      `[billing-client] POST /v1/customer_balance/authorize returned ${res.status}: ${text}`,
       res.status,
       text,
     );

--- a/tests/unit/billing-client.test.ts
+++ b/tests/unit/billing-client.test.ts
@@ -39,7 +39,7 @@ describe("authorizeCredits", () => {
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://billing.test.local/v1/credits/authorize",
+      "https://billing.test.local/v1/customer_balance/authorize",
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({
@@ -211,7 +211,7 @@ describe("authorizeCredits", () => {
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://billing.mcpfactory.org/v1/credits/authorize",
+      "https://billing.mcpfactory.org/v1/customer_balance/authorize",
       expect.anything(),
     );
   });


### PR DESCRIPTION
Automated by release.sh