### PR TITLE
hotfix: fix(rag-score): pass brandIds in body, consume new extract-fields response shape

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -565,12 +565,16 @@ app.post("/orgs/rag/score", requireAuth, async (req, res) => {
     // Resolve brand context. Pass own runId so brand-service sees us as the parent.
     let brandResults;
     try {
-      brandResults = await extractBrandFields(RAG_BRAND_FIELDS, {
-        orgId,
-        userId,
-        runId,
-        trackingHeaders,
-      });
+      brandResults = await extractBrandFields(
+        RAG_BRAND_FIELDS,
+        [brandId],
+        {
+          orgId,
+          userId,
+          runId,
+          trackingHeaders,
+        },
+      );
     } catch (err) {
       if (err instanceof BrandError && err.status === 404) {
         return res.status(404).json({
@@ -580,13 +584,13 @@ app.post("/orgs/rag/score", requireAuth, async (req, res) => {
       throw err;
     }
 
-    // Flatten results into a {key: stringValue} map. Skip null/empty values.
+    // Flatten consolidated `value` per field into a {key: stringValue} map. Skip null/empty values.
     const fieldValues: Record<string, string> = {};
-    for (const r of brandResults.results) {
-      if (r.value == null) continue;
-      const str = typeof r.value === "string" ? r.value : JSON.stringify(r.value);
+    for (const [key, entry] of Object.entries(brandResults.fields)) {
+      if (entry.value == null) continue;
+      const str = typeof entry.value === "string" ? entry.value : JSON.stringify(entry.value);
       if (str.trim().length === 0) continue;
-      fieldValues[r.key] = str;
+      fieldValues[key] = str;
     }
 
     const queryText = queryOverride ?? buildBrandProfileQuery(fieldValues);
@@ -1070,9 +1074,12 @@ app.post("/chat", requireAuth, async (req, res) => {
   try {
     // Get or create session (scoped by org + user + app)
     let currentSessionId = sessionId;
-    const brandIds = workflowTracking.brandId
-      ? workflowTracking.brandId.split(",").map(s => s.trim()).filter(Boolean)
-      : null;
+    // Resolve brand UUIDs for this turn. Header CSV first, fall back to context.brandId.
+    const brandIds: string[] = workflowTracking.brandId
+      ? workflowTracking.brandId.split(",").map((s) => s.trim()).filter(Boolean)
+      : typeof context?.brandId === "string" && context.brandId
+        ? [context.brandId]
+        : [];
     if (!currentSessionId) {
       const [session] = await db
         .insert(sessions)
@@ -1081,7 +1088,7 @@ app.post("/chat", requireAuth, async (req, res) => {
           userId,
           parentRunId,
           campaignId: workflowTracking.campaignId ?? null,
-          brandIds,
+          brandIds: brandIds.length > 0 ? brandIds : null,
           workflowSlug: workflowTracking.workflowSlug ?? null,
           featureSlug: workflowTracking.featureSlug ?? null,
         })
@@ -1572,7 +1579,12 @@ app.post("/chat", requireAuth, async (req, res) => {
 
       if (call.name === "prefill_feature") {
         const args = (call.args as Record<string, unknown>) || {};
-        const result = await prefillFeature(args.slug as string, featureCallParams);
+        if (brandIds.length === 0) {
+          throw new Error(
+            "[chat] prefill_feature requires brandIds — provide x-brand-id header or context.brandId",
+          );
+        }
+        const result = await prefillFeature(args.slug as string, brandIds, featureCallParams);
         toolCalls.push({ name: call.name, args, result });
         return { name: call.name, result };
       }
@@ -1603,8 +1615,14 @@ app.post("/chat", requireAuth, async (req, res) => {
 
       if (call.name === "extract_brand_fields") {
         const args = (call.args as Record<string, unknown>) || {};
+        if (brandIds.length === 0) {
+          throw new Error(
+            "[chat] extract_brand_fields requires brandIds — provide x-brand-id header or context.brandId",
+          );
+        }
         const result = await extractBrandFields(
           args.fields as Array<{ key: string; description: string }>,
+          brandIds,
           featureCallParams,
         );
         toolCalls.push({ name: call.name, args, result });

--- a/src/lib/brand-client.ts
+++ b/src/lib/brand-client.ts
@@ -13,7 +13,9 @@ export class BrandError extends Error {
 }
 
 // ---------------------------------------------------------------------------
-// POST /brands/extract-fields  (reads x-brand-id from forwarded headers)
+// POST /v1/brands/extract-fields
+// Body: { brandIds: string[] (non-empty), fields: [{key, description}] }
+// Response: { brands: [...], fields: { [key]: { value, byBrand: { [domain]: {...} } } } }
 // ---------------------------------------------------------------------------
 
 export interface ExtractFieldDef {
@@ -21,8 +23,7 @@ export interface ExtractFieldDef {
   description: string;
 }
 
-export interface ExtractFieldResult {
-  key: string;
+export interface ExtractFieldByBrand {
   value: unknown;
   cached: boolean;
   extractedAt: string;
@@ -30,20 +31,33 @@ export interface ExtractFieldResult {
   sourceUrls: string[] | null;
 }
 
-export interface ExtractFieldsResponse {
+export interface ExtractFieldEntry {
+  value: unknown;
+  byBrand: Record<string, ExtractFieldByBrand>;
+}
+
+export interface ExtractBrandMeta {
   brandId: string;
-  results: ExtractFieldResult[];
+  domain: string;
+  name: string;
+  brandUrl: string | null;
+}
+
+export interface ExtractFieldsResponse {
+  brands: ExtractBrandMeta[];
+  fields: Record<string, ExtractFieldEntry>;
 }
 
 export async function extractBrandFields(
   fields: ExtractFieldDef[],
+  brandIds: string[],
   params: BrandCallParams,
 ): Promise<ExtractFieldsResponse> {
   const res = await apiServiceFetch(
     `/v1/brands/extract-fields`,
     "POST",
     params,
-    { fields },
+    { brandIds, fields },
   );
 
   if (!res.ok) {

--- a/src/lib/features-client.ts
+++ b/src/lib/features-client.ts
@@ -217,12 +217,14 @@ export interface PrefillTextResponse {
 
 export async function prefillFeature(
   slug: string,
+  brandIds: string[],
   params: FeaturesCallParams,
 ): Promise<PrefillTextResponse> {
   const res = await apiServiceFetch(
     `/v1/features/${encodeURIComponent(slug)}/prefill`,
     "POST",
     params,
+    { brandIds },
   );
 
   if (!res.ok) {

--- a/tests/integration/rag-score.test.ts
+++ b/tests/integration/rag-score.test.ts
@@ -113,18 +113,34 @@ function mockBrandExtract(
       if (capture && init?.body) {
         capture.body = JSON.parse(init.body as string);
       }
+      const domain = "fake-brand.example";
+      const fieldsObj: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(fields)) {
+        fieldsObj[key] = {
+          value,
+          byBrand: {
+            [domain]: {
+              value,
+              cached: false,
+              extractedAt: new Date().toISOString(),
+              expiresAt: null,
+              sourceUrls: null,
+            },
+          },
+        };
+      }
       return {
         ok: true,
         body: {
-          brandId: "fake-brand",
-          results: Object.entries(fields).map(([key, value]) => ({
-            key,
-            value,
-            cached: false,
-            extractedAt: new Date().toISOString(),
-            expiresAt: null,
-            sourceUrls: null,
-          })),
+          brands: [
+            {
+              brandId: "fake-brand",
+              domain,
+              name: "Fake Brand",
+              brandUrl: `https://${domain}`,
+            },
+          ],
+          fields: fieldsObj,
         },
       };
     },
@@ -293,6 +309,11 @@ describe("POST /orgs/rag/score", { timeout: 30_000 }, () => {
     // brand-service got our own runId (not the parent), and our own brandId in headers
     expect(brandCapture.headers?.["x-run-id"]).toBe(ownRunId);
     expect(brandCapture.headers?.["x-brand-id"]).toBe(brandId);
+    // Outbound body to api-service must include brandIds (non-empty array) — regression for rag-score 502
+    expect(brandCapture.body).toMatchObject({
+      brandIds: [brandId],
+      fields: expect.any(Array),
+    });
     // runs-service create was called with the parent runId from the request
     expect(runsCapture.headers?.["x-run-id"]).toBe(parentRunId);
 

--- a/tests/unit/brand-client.test.ts
+++ b/tests/unit/brand-client.test.ts
@@ -24,24 +24,40 @@ const baseParams = {
   runId: "run-1",
 };
 
-describe("extractBrandFields", () => {
-  it("calls POST /v1/brands/extract-fields via api-service (no brandId in path)", async () => {
-    const mockResponse = {
-      brandId: "brand-123",
-      results: [
-        { key: "industry", value: "SaaS", cached: false, extractedAt: "2026-01-01T00:00:00Z", expiresAt: "2026-01-31T00:00:00Z", sourceUrls: ["https://example.com"] },
-      ],
-    };
+function newShapeMockResponse(brandId: string, domain: string) {
+  return {
+    brands: [
+      { brandId, domain, name: "Test Brand", brandUrl: `https://${domain}` },
+    ],
+    fields: {
+      industry: {
+        value: "SaaS",
+        byBrand: {
+          [domain]: {
+            value: "SaaS",
+            cached: false,
+            extractedAt: "2026-01-01T00:00:00Z",
+            expiresAt: "2026-01-31T00:00:00Z",
+            sourceUrls: [`https://${domain}/about`],
+          },
+        },
+      },
+    },
+  };
+}
 
+describe("extractBrandFields", () => {
+  it("sends brandIds and fields in request body to POST /v1/brands/extract-fields", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve(mockResponse),
+      json: () => Promise.resolve(newShapeMockResponse("brand-123", "acme.com")),
     });
 
     const { extractBrandFields } = await loadModule();
     const result = await extractBrandFields(
       [{ key: "industry", description: "The brand's primary industry" }],
-      { ...baseParams, trackingHeaders: { "x-brand-id": "brand-123" } },
+      ["brand-123"],
+      baseParams,
     );
 
     expect(fetch).toHaveBeenCalledWith(
@@ -52,45 +68,75 @@ describe("extractBrandFields", () => {
           "x-org-id": "org-1",
           "x-user-id": "user-1",
           "x-run-id": "run-1",
-          "x-brand-id": "brand-123",
         }),
         body: JSON.stringify({
+          brandIds: ["brand-123"],
           fields: [{ key: "industry", description: "The brand's primary industry" }],
         }),
       }),
     );
 
-    expect(result.brandId).toBe("brand-123");
-    expect(result.results).toHaveLength(1);
-    expect(result.results[0].key).toBe("industry");
-    expect(result.results[0].value).toBe("SaaS");
+    expect(result.brands).toHaveLength(1);
+    expect(result.brands[0].brandId).toBe("brand-123");
+    expect(result.fields.industry.value).toBe("SaaS");
+    expect(result.fields.industry.byBrand["acme.com"].cached).toBe(false);
   });
 
-  it("throws on non-OK response", async () => {
+  it("sends multiple brandIds in body", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ brands: [], fields: {} }),
+    });
+
+    const { extractBrandFields } = await loadModule();
+    await extractBrandFields(
+      [{ key: "x", description: "y" }],
+      ["b-1", "b-2", "b-3"],
+      baseParams,
+    );
+
+    const sentBody = JSON.parse(
+      (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body,
+    );
+    expect(sentBody.brandIds).toEqual(["b-1", "b-2", "b-3"]);
+    expect(sentBody.fields).toEqual([{ key: "x", description: "y" }]);
+  });
+
+  it("throws BrandError on non-OK response", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: false,
       status: 404,
       text: () => Promise.resolve("Brand not found"),
     });
 
-    const { extractBrandFields } = await loadModule();
+    const { extractBrandFields, BrandError } = await loadModule();
 
-    await expect(
-      extractBrandFields([{ key: "x", description: "y" }], baseParams),
-    ).rejects.toThrow("[brand-client] extract-fields failed (404)");
+    const err = await extractBrandFields(
+      [{ key: "x", description: "y" }],
+      ["brand-1"],
+      baseParams,
+    ).catch((e) => e);
+
+    expect(err).toBeInstanceOf(BrandError);
+    expect(err.status).toBe(404);
+    expect(err.message).toMatch(/extract-fields failed \(404\)/);
   });
 
-  it("forwards tracking headers including multi-brand CSV x-brand-id", async () => {
+  it("forwards tracking headers", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ brandId: "b-1", results: [] }),
+      json: () => Promise.resolve({ brands: [], fields: {} }),
     });
 
     const { extractBrandFields } = await loadModule();
-    await extractBrandFields([{ key: "x", description: "y" }], {
-      ...baseParams,
-      trackingHeaders: { "x-campaign-id": "camp-1", "x-brand-id": "b-1,b-2,b-3" },
-    });
+    await extractBrandFields(
+      [{ key: "x", description: "y" }],
+      ["b-1", "b-2", "b-3"],
+      {
+        ...baseParams,
+        trackingHeaders: { "x-campaign-id": "camp-1", "x-brand-id": "b-1,b-2,b-3" },
+      },
+    );
 
     expect(fetch).toHaveBeenCalledWith(
       expect.any(String),
@@ -103,4 +149,3 @@ describe("extractBrandFields", () => {
     );
   });
 });
-

--- a/tests/unit/features-client.test.ts
+++ b/tests/unit/features-client.test.ts
@@ -405,7 +405,7 @@ describe("getFeatureInputs", () => {
 });
 
 describe("prefillFeature", () => {
-  it("sends POST /v1/features/:slug/prefill via api-service", async () => {
+  it("sends POST /v1/features/:slug/prefill with brandIds in body", async () => {
     const mockResponse = {
       slug: "cold-email-outreach",
       brandId: "brand-1",
@@ -418,7 +418,7 @@ describe("prefillFeature", () => {
     });
 
     const { prefillFeature } = await loadModule();
-    const result = await prefillFeature("cold-email-outreach", {
+    const result = await prefillFeature("cold-email-outreach", ["brand-1"], {
       orgId: "org-1",
       userId: "user-1",
       runId: "run-1",
@@ -428,8 +428,33 @@ describe("prefillFeature", () => {
       "https://api.test.local/v1/features/cold-email-outreach/prefill",
       expect.objectContaining({ method: "POST" }),
     );
+
+    const sentBody = JSON.parse(
+      (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body,
+    );
+    expect(sentBody).toEqual({ brandIds: ["brand-1"] });
+
     expect(result.prefilled.targetCompanyUrl).toBe("https://acme.com");
     expect(result.format).toBe("text");
+  });
+
+  it("sends multiple brandIds in body", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ slug: "s", brandId: "b1", format: "text", prefilled: {} }),
+    });
+
+    const { prefillFeature } = await loadModule();
+    await prefillFeature("s", ["brand-1", "brand-2"], {
+      orgId: "o",
+      userId: "u",
+      runId: "r",
+    });
+
+    const sentBody = JSON.parse(
+      (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body,
+    );
+    expect(sentBody.brandIds).toEqual(["brand-1", "brand-2"]);
   });
 
   it("throws on HTTP error", async () => {
@@ -441,7 +466,7 @@ describe("prefillFeature", () => {
 
     const { prefillFeature } = await loadModule();
     await expect(
-      prefillFeature("cold-email-outreach", { orgId: "o", userId: "u", runId: "r" }),
+      prefillFeature("cold-email-outreach", ["brand-1"], { orgId: "o", userId: "u", runId: "r" }),
     ).rejects.toThrow(/returned 400/);
   });
 });


### PR DESCRIPTION
Automated by release.sh