### PR TITLE
hotfix: Persist tool_use+tool_result pairs across turns so multi-turn agentic chat memory survives

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,15 @@ data: {"type":"tool_result","id":"tc_550e8400-e29b-41d4-a716-446655440000","name
 
 After a tool result, more `token` events follow with the AI's continuation.
 
+#### Tool memory across turns
+
+Tool calls and their results are persisted on the assistant message (in the `tool_calls` jsonb column) and replayed to the provider on every subsequent turn:
+
+- **Anthropic**: prior `tool_use` blocks + matching `tool_result` blocks are rebuilt from `tool_calls` and re-injected into the conversation history. Tool-use ids are synthesized deterministically per (message-index, tool-index) — the live agentic loop uses real Anthropic ids; only cross-turn reconstruction uses synthetic ids. Tool calls without a `result` (e.g. paused on `request_user_input`) are filtered out.
+- **Gemini**: prior `functionCall` + `functionResponse` parts are rebuilt and re-injected, merging into the existing user/model turn flow. Gemini 3 `id` fields are captured during the live loop and threaded through `functionResponse`.
+
+Anthropic's beta `clear_tool_uses_20250919` context-management edit auto-clears the oldest tool-use blocks once the input crosses 50k tokens, so multi-turn agentic conversations stay within budget without manual trimming. For Gemini, `trimGeminiHistoryToBudget` drops oldest messages (now accounting for serialized `tool_calls` length) once the heuristic estimate crosses 100k tokens.
+
 ### Available Tools
 
 The tools available in each chat session are determined by the `allowedTools` array in the config. The LLM only sees and can call tools that are listed. Unknown or unlisted tools are rejected.

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,12 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const openapiPath = join(__dirname, "..", "openapi.json");
 
-import { mergeConsecutiveMessages, stripToolUseBlocks } from "./lib/merge-messages.js";
+import {
+  mergeConsecutiveMessages,
+  rebuildAnthropicHistory,
+  stripToolUseBlocks,
+  type RebuildableMessage,
+} from "./lib/merge-messages.js";
 import { streamGeminiChat, type ToolDefinition } from "./lib/gemini-chat.js";
 import { SESSION_NOT_FOUND_EVENT } from "./lib/session-errors.js";
 import { buildContextUsageEvent } from "./lib/context-usage.js";
@@ -1671,6 +1676,7 @@ app.post("/chat", requireAuth, async (req, res) => {
         .map((m) => ({
           role: m.role as "user" | "assistant",
           content: m.content as string,
+          toolCalls: m.toolCalls,
         }));
 
       const geminiResult = await streamGeminiChat({
@@ -1698,25 +1704,16 @@ app.post("/chat", requireAuth, async (req, res) => {
     } else {
     // --- Anthropic streaming path ---
 
-    // Build Anthropic message history — use contentBlocks if available (preserves compaction blocks)
-    const rawHistory: Anthropic.MessageParam[] = history
-      .filter((m) => m.role !== "tool")
-      .map((m) => {
-        if (m.role === "assistant" && m.contentBlocks) {
-          const blocks = stripToolUseBlocks(
-            m.contentBlocks as Anthropic.ContentBlockParam[],
-          );
-          return {
-            role: "assistant" as const,
-            content: blocks.length > 0 ? blocks : (m.content as string),
-          };
-        }
-        return {
-          role: m.role as "user" | "assistant",
-          content: m.content as string | Anthropic.ContentBlockParam[],
-        };
-      });
-    const anthropicHistory = mergeConsecutiveMessages(rawHistory);
+    // Build Anthropic message history — restore tool_use + tool_result pairs
+    // from `toolCalls` jsonb so multi-turn agentic memory survives across turns.
+    const rebuildable: RebuildableMessage[] = history.map((m) => ({
+      role: m.role as RebuildableMessage["role"],
+      content: m.content as string,
+      toolCalls: m.toolCalls,
+    }));
+    const anthropicHistory = mergeConsecutiveMessages(
+      rebuildAnthropicHistory(rebuildable),
+    );
 
     const turnMessages: Anthropic.MessageParam[] = [
       ...anthropicHistory,

--- a/src/lib/gemini-chat.ts
+++ b/src/lib/gemini-chat.ts
@@ -50,10 +50,10 @@ interface GeminiFunctionDeclaration {
 /** Gemini message part types. */
 interface GeminiTextPart { text: string }
 interface GeminiFunctionCallPart {
-  functionCall: { name: string; args: Record<string, unknown> };
+  functionCall: { name: string; args: Record<string, unknown>; id?: string };
 }
 interface GeminiFunctionResponsePart {
-  functionResponse: { name: string; response: unknown };
+  functionResponse: { name: string; response: unknown; id?: string };
 }
 type GeminiPart = GeminiTextPart | GeminiFunctionCallPart | GeminiFunctionResponsePart;
 
@@ -61,6 +61,17 @@ interface GeminiMessage {
   role: "user" | "model";
   parts: GeminiPart[];
 }
+
+/** History entry shape consumed by toGeminiHistory. */
+export type GeminiHistoryInput = Array<{
+  role: "user" | "assistant";
+  content: string;
+  toolCalls?: Array<{
+    name: string;
+    args: Record<string, unknown>;
+    result?: unknown;
+  }> | null;
+}>;
 
 /** SSE event sender (same signature as index.ts sendSSE). */
 type SendSSE = (res: ExpressResponse, data: unknown) => void;
@@ -79,7 +90,7 @@ export interface StreamGeminiChatOptions {
   apiKey: string;
   model: string;
   systemPrompt: string;
-  history: Array<{ role: "user" | "assistant"; content: string }>;
+  history: GeminiHistoryInput;
   userMessage: string;
   tools: ToolDefinition[];
   res: ExpressResponse;
@@ -115,21 +126,62 @@ export function toGeminiFunctionDeclarations(
   }));
 }
 
-/** Convert DB message history to Gemini format. */
-function toGeminiHistory(
-  history: Array<{ role: "user" | "assistant"; content: string }>,
-): GeminiMessage[] {
+/**
+ * Convert DB message history to Gemini format.
+ *
+ * Rebuilds `functionCall` + `functionResponse` pairs from the `toolCalls`
+ * jsonb column so multi-turn agentic memory survives across turns. Without
+ * this, the model has no record of which tools were called or what they
+ * returned in prior turns and either re-fetches or hallucinates.
+ *
+ * Tool calls without a `result` are filtered out (e.g. `request_user_input`
+ * which pauses the agentic loop) so we never emit a `functionCall` with no
+ * matching `functionResponse`.
+ */
+export function toGeminiHistory(history: GeminiHistoryInput): GeminiMessage[] {
   const result: GeminiMessage[] = [];
-  for (const msg of history) {
-    const geminiRole = msg.role === "assistant" ? "model" : "user";
-    // Merge consecutive same-role messages (Gemini requires alternating roles)
+
+  const pushOrMerge = (role: "user" | "model", parts: GeminiPart[]) => {
+    if (parts.length === 0) return;
     const prev = result[result.length - 1];
-    if (prev && prev.role === geminiRole) {
-      prev.parts.push({ text: msg.content });
+    if (prev && prev.role === role) {
+      prev.parts.push(...parts);
     } else {
-      result.push({ role: geminiRole, parts: [{ text: msg.content }] });
+      result.push({ role, parts });
+    }
+  };
+
+  for (const msg of history) {
+    if (msg.role === "user") {
+      pushOrMerge("user", [{ text: msg.content }]);
+      continue;
+    }
+
+    const text = msg.content ?? "";
+    const validToolCalls = (msg.toolCalls ?? []).filter(
+      (tc) => tc.result !== undefined,
+    );
+
+    const modelParts: GeminiPart[] = [];
+    if (text.length > 0) {
+      modelParts.push({ text });
+    }
+    for (const tc of validToolCalls) {
+      modelParts.push({ functionCall: { name: tc.name, args: tc.args } });
+    }
+
+    if (modelParts.length === 0) continue;
+
+    pushOrMerge("model", modelParts);
+
+    if (validToolCalls.length > 0) {
+      const responseParts: GeminiPart[] = validToolCalls.map((tc) => ({
+        functionResponse: { name: tc.name, response: tc.result },
+      }));
+      pushOrMerge("user", responseParts);
     }
   }
+
   return result;
 }
 
@@ -143,7 +195,7 @@ interface GeminiStreamChunk {
       parts?: Array<{
         text?: string;
         thought?: boolean;
-        functionCall?: { name: string; args: Record<string, unknown> };
+        functionCall?: { name: string; args: Record<string, unknown>; id?: string };
       }>;
     };
     finishReason?: string;
@@ -253,7 +305,7 @@ export async function streamGeminiChat(
     const decoder = new TextDecoder();
     let sseBuffer = "";
     let inThinking = false;
-    const functionCalls: Array<{ name: string; args: Record<string, unknown> }> = [];
+    const functionCalls: Array<{ name: string; args: Record<string, unknown>; id?: string }> = [];
     let chunkTokensInput = 0;
     let chunkTokensOutput = 0;
 
@@ -320,6 +372,7 @@ export async function streamGeminiChat(
               functionCalls.push({
                 name: part.functionCall.name,
                 args: part.functionCall.args ?? {},
+                ...(part.functionCall.id ? { id: part.functionCall.id } : {}),
               });
             }
           }
@@ -345,7 +398,13 @@ export async function streamGeminiChat(
     const responseParts: GeminiPart[] = [];
 
     for (const fc of functionCalls) {
-      modelParts.push({ functionCall: fc });
+      modelParts.push({
+        functionCall: {
+          name: fc.name,
+          args: fc.args,
+          ...(fc.id ? { id: fc.id } : {}),
+        },
+      });
 
       const toolCallId = `tc_${crypto.randomUUID()}`;
       if (fc.name !== "request_user_input") {
@@ -377,6 +436,7 @@ export async function streamGeminiChat(
             functionResponse: {
               name: fc.name,
               response: { error: "Unknown tool" },
+              ...(fc.id ? { id: fc.id } : {}),
             },
           });
           continue;
@@ -388,6 +448,7 @@ export async function streamGeminiChat(
           functionResponse: {
             name: fc.name,
             response: toolResult.result,
+            ...(fc.id ? { id: fc.id } : {}),
           },
         });
       } catch (toolErr: unknown) {
@@ -399,6 +460,7 @@ export async function streamGeminiChat(
           functionResponse: {
             name: fc.name,
             response: errorResult,
+            ...(fc.id ? { id: fc.id } : {}),
           },
         });
       }

--- a/src/lib/gemini-trim.ts
+++ b/src/lib/gemini-trim.ts
@@ -17,6 +17,11 @@ const MIN_KEEP_MESSAGES = 2;
 export interface HistoryMessage {
   role: "user" | "assistant";
   content: string;
+  toolCalls?: Array<{
+    name: string;
+    args: Record<string, unknown>;
+    result?: unknown;
+  }> | null;
 }
 
 export interface TrimResult {
@@ -27,7 +32,12 @@ export interface TrimResult {
 
 function estimateTokens(messages: HistoryMessage[]): number {
   let chars = 0;
-  for (const m of messages) chars += m.content.length;
+  for (const m of messages) {
+    chars += m.content.length;
+    if (m.toolCalls && m.toolCalls.length > 0) {
+      chars += JSON.stringify(m.toolCalls).length;
+    }
+  }
   return Math.ceil(chars / CHARS_PER_TOKEN);
 }
 
@@ -39,7 +49,6 @@ export function trimGeminiHistoryToBudget(
     return { history, trimmed: false, estimatedInputTokens: initialTokens };
   }
 
-  // Drop oldest messages until under target, but never fewer than MIN_KEEP_MESSAGES.
   let working = history.slice();
   while (
     working.length > MIN_KEEP_MESSAGES &&

--- a/src/lib/merge-messages.ts
+++ b/src/lib/merge-messages.ts
@@ -28,13 +28,96 @@ export function mergeConsecutiveMessages(
 
 /**
  * Strip tool_use blocks from content blocks.
- * Tool calls are ephemeral within a single request's agentic loop — their
- * matching tool_result messages are never persisted. Including orphaned
- * tool_use blocks in history causes Anthropic to reject the request with
- * "tool_use ids were found without tool_result blocks immediately after".
+ * Used at persist time to clean orphan tool_use blocks from the last
+ * agentic-loop iteration when the loop exits via `request_user_input`
+ * (the tool_result is never produced because the loop pauses for input).
  */
 export function stripToolUseBlocks(
   blocks: Anthropic.ContentBlockParam[],
 ): Anthropic.ContentBlockParam[] {
   return blocks.filter((b) => b.type !== "tool_use");
+}
+
+/**
+ * DB message shape consumed by rebuildAnthropicHistory.
+ */
+export interface RebuildableMessage {
+  role: "user" | "assistant" | "tool";
+  content: string;
+  toolCalls?: Array<{
+    name: string;
+    args: Record<string, unknown>;
+    result?: unknown;
+  }> | null;
+}
+
+/**
+ * Rebuild Anthropic message history from DB records, restoring tool_use +
+ * tool_result pairs from the `toolCalls` jsonb column.
+ *
+ * Anthropic Messages API is stateless: every request must include the full
+ * prior conversation, and multi-turn tool use requires the assistant's
+ * `tool_use` blocks to be paired with matching `tool_result` blocks in a
+ * synthetic user message immediately after. Without this pairing, Claude
+ * has no memory of which tools were called or what they returned in prior
+ * turns — it either re-fetches or hallucinates.
+ *
+ * Tool calls without a `result` (e.g. `request_user_input` which pauses the
+ * agentic loop) are filtered out — they would create orphan `tool_use` ids
+ * and trigger "tool_use ids were found without tool_result blocks" 400s.
+ *
+ * tool_use ids are synthesized deterministically per (message-index, tool-index).
+ * The live agentic loop uses the real Anthropic-provided ids; only cross-turn
+ * reconstruction uses synthetic ids, which is fine because each request is
+ * self-contained.
+ */
+export function rebuildAnthropicHistory(
+  messages: RebuildableMessage[],
+): Anthropic.MessageParam[] {
+  const result: Anthropic.MessageParam[] = [];
+
+  for (let i = 0; i < messages.length; i++) {
+    const m = messages[i];
+    if (m.role === "tool") continue;
+
+    if (m.role === "user") {
+      result.push({ role: "user", content: m.content });
+      continue;
+    }
+
+    const text = m.content ?? "";
+    const validToolCalls = (m.toolCalls ?? []).filter(
+      (tc) => tc.result !== undefined,
+    );
+
+    const assistantBlocks: Anthropic.ContentBlockParam[] = [];
+    if (text.length > 0) {
+      assistantBlocks.push({ type: "text", text });
+    }
+    for (let j = 0; j < validToolCalls.length; j++) {
+      const tc = validToolCalls[j];
+      assistantBlocks.push({
+        type: "tool_use",
+        id: `toolu_${i}_${j}`,
+        name: tc.name,
+        input: tc.args,
+      });
+    }
+
+    if (assistantBlocks.length === 0) continue;
+
+    result.push({ role: "assistant", content: assistantBlocks });
+
+    if (validToolCalls.length > 0) {
+      const toolResultBlocks: Anthropic.ToolResultBlockParam[] =
+        validToolCalls.map((tc, j) => ({
+          type: "tool_result",
+          tool_use_id: `toolu_${i}_${j}`,
+          content: JSON.stringify(tc.result),
+        }));
+      result.push({ role: "user", content: toolResultBlocks });
+    }
+  }
+
+  return result;
 }

--- a/tests/unit/gemini-history.test.ts
+++ b/tests/unit/gemini-history.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  toGeminiHistory,
+  type GeminiHistoryInput,
+} from "../../src/lib/gemini-chat.js";
+
+describe("toGeminiHistory", () => {
+  it("returns empty for empty input", () => {
+    expect(toGeminiHistory([])).toEqual([]);
+  });
+
+  it("passes through plain user/assistant text turns", () => {
+    const msgs: GeminiHistoryInput = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "thanks" },
+    ];
+    const result = toGeminiHistory(msgs);
+    expect(result).toEqual([
+      { role: "user", parts: [{ text: "hello" }] },
+      { role: "model", parts: [{ text: "hi" }] },
+      { role: "user", parts: [{ text: "thanks" }] },
+    ]);
+  });
+
+  it("merges consecutive same-role messages", () => {
+    const msgs: GeminiHistoryInput = [
+      { role: "user", content: "a" },
+      { role: "user", content: "b" },
+      { role: "assistant", content: "ok" },
+    ];
+    const result = toGeminiHistory(msgs);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      role: "user",
+      parts: [{ text: "a" }, { text: "b" }],
+    });
+    expect(result[1]).toEqual({ role: "model", parts: [{ text: "ok" }] });
+  });
+
+  it("rebuilds functionCall + functionResponse pairs from toolCalls", () => {
+    const msgs: GeminiHistoryInput = [
+      { role: "user", content: "fetch X" },
+      {
+        role: "assistant",
+        content: "Looking it up.",
+        toolCalls: [
+          { name: "get_x", args: { id: "abc" }, result: { value: 42 } },
+        ],
+      },
+    ];
+    const result = toGeminiHistory(msgs);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ role: "user", parts: [{ text: "fetch X" }] });
+
+    expect(result[1].role).toBe("model");
+    expect(result[1].parts).toHaveLength(2);
+    expect(result[1].parts[0]).toEqual({ text: "Looking it up." });
+    expect(result[1].parts[1]).toEqual({
+      functionCall: { name: "get_x", args: { id: "abc" } },
+    });
+
+    expect(result[2].role).toBe("user");
+    expect(result[2].parts).toEqual([
+      { functionResponse: { name: "get_x", response: { value: 42 } } },
+    ]);
+  });
+
+  it("emits functionCall-only model message when text is empty", () => {
+    const msgs: GeminiHistoryInput = [
+      { role: "user", content: "go" },
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [{ name: "tool_x", args: {}, result: { ok: true } }],
+      },
+    ];
+    const result = toGeminiHistory(msgs);
+    expect(result).toHaveLength(3);
+    expect(result[1].role).toBe("model");
+    expect(result[1].parts).toHaveLength(1);
+    expect(result[1].parts[0]).toEqual({
+      functionCall: { name: "tool_x", args: {} },
+    });
+  });
+
+  it("filters toolCalls entries without a result", () => {
+    const msgs: GeminiHistoryInput = [
+      { role: "user", content: "go" },
+      {
+        role: "assistant",
+        content: "Working.",
+        toolCalls: [
+          { name: "tool_ok", args: {}, result: { ok: true } },
+          { name: "tool_orphan", args: {} },
+        ],
+      },
+    ];
+    const result = toGeminiHistory(msgs);
+    const modelParts = result[1].parts;
+    expect(modelParts).toHaveLength(2);
+    expect(modelParts[1]).toEqual({
+      functionCall: { name: "tool_ok", args: {} },
+    });
+
+    const responseParts = result[2].parts;
+    expect(responseParts).toHaveLength(1);
+  });
+
+  it("skips assistant messages with no text and no toolCalls", () => {
+    const msgs: GeminiHistoryInput = [
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "" },
+      { role: "user", content: "still there?" },
+    ];
+    const result = toGeminiHistory(msgs);
+    expect(result).toEqual([
+      { role: "user", parts: [{ text: "hi" }, { text: "still there?" }] },
+    ]);
+  });
+
+  it("merges synthetic functionResponse user with a following plain user message", () => {
+    const msgs: GeminiHistoryInput = [
+      { role: "user", content: "first" },
+      {
+        role: "assistant",
+        content: "calling",
+        toolCalls: [{ name: "tool_y", args: {}, result: "r" }],
+      },
+      { role: "user", content: "follow up" },
+    ];
+    const result = toGeminiHistory(msgs);
+    expect(result).toHaveLength(3);
+    expect(result[0].role).toBe("user");
+    expect(result[1].role).toBe("model");
+    expect(result[2].role).toBe("user");
+    expect(result[2].parts).toHaveLength(2);
+    expect(result[2].parts[0]).toEqual({
+      functionResponse: { name: "tool_y", response: "r" },
+    });
+    expect(result[2].parts[1]).toEqual({ text: "follow up" });
+  });
+
+  it("preserves multiple turns with tool calls in order (merging consecutive user roles)", () => {
+    const msgs: GeminiHistoryInput = [
+      { role: "user", content: "turn 1" },
+      {
+        role: "assistant",
+        content: "r1",
+        toolCalls: [{ name: "t1", args: {}, result: "v1" }],
+      },
+      { role: "user", content: "turn 2" },
+      {
+        role: "assistant",
+        content: "r2",
+        toolCalls: [{ name: "t2", args: {}, result: "v2" }],
+      },
+    ];
+    const result = toGeminiHistory(msgs);
+    // synthetic functionResponse user from turn 1 merges with real "turn 2" user
+    expect(result).toHaveLength(5);
+    expect(result[0].role).toBe("user");
+    expect(result[1].role).toBe("model");
+    expect(result[2].role).toBe("user"); // merged: [fr:t1, text:turn2]
+    expect(result[3].role).toBe("model");
+    expect(result[4].role).toBe("user"); // synthetic functionResponse t2
+
+    expect(result[2].parts).toHaveLength(2);
+    expect(result[2].parts[0]).toEqual({
+      functionResponse: { name: "t1", response: "v1" },
+    });
+    expect(result[2].parts[1]).toEqual({ text: "turn 2" });
+
+    expect(result[1].parts.find((p) => "functionCall" in p)).toEqual({
+      functionCall: { name: "t1", args: {} },
+    });
+    expect(result[3].parts.find((p) => "functionCall" in p)).toEqual({
+      functionCall: { name: "t2", args: {} },
+    });
+  });
+});

--- a/tests/unit/merge-messages.test.ts
+++ b/tests/unit/merge-messages.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from "vitest";
 import type Anthropic from "@anthropic-ai/sdk";
 
-import { mergeConsecutiveMessages } from "../../src/lib/merge-messages.js";
+import {
+  mergeConsecutiveMessages,
+  rebuildAnthropicHistory,
+  type RebuildableMessage,
+} from "../../src/lib/merge-messages.js";
 
 describe("mergeConsecutiveMessages", () => {
   it("passes through alternating messages unchanged", () => {
@@ -85,5 +89,187 @@ describe("mergeConsecutiveMessages", () => {
     const original = JSON.parse(JSON.stringify(msgs));
     mergeConsecutiveMessages(msgs);
     expect(msgs).toEqual(original);
+  });
+});
+
+describe("rebuildAnthropicHistory", () => {
+  it("returns empty for empty input", () => {
+    expect(rebuildAnthropicHistory([])).toEqual([]);
+  });
+
+  it("passes through plain user/assistant text turns", () => {
+    const msgs: RebuildableMessage[] = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi", toolCalls: null },
+      { role: "user", content: "how are you" },
+    ];
+    const result = rebuildAnthropicHistory(msgs);
+    expect(result).toEqual([
+      { role: "user", content: "hello" },
+      { role: "assistant", content: [{ type: "text", text: "hi" }] },
+      { role: "user", content: "how are you" },
+    ]);
+  });
+
+  it("rebuilds tool_use + tool_result pairs from toolCalls", () => {
+    const msgs: RebuildableMessage[] = [
+      { role: "user", content: "fetch workflow abc" },
+      {
+        role: "assistant",
+        content: "Looking it up.",
+        toolCalls: [
+          {
+            name: "get_workflow_details",
+            args: { workflowId: "abc" },
+            result: { id: "abc", name: "Test workflow" },
+          },
+        ],
+      },
+    ];
+    const result = rebuildAnthropicHistory(msgs);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ role: "user", content: "fetch workflow abc" });
+
+    expect(result[1].role).toBe("assistant");
+    const assistantBlocks = result[1].content as Anthropic.ContentBlockParam[];
+    expect(assistantBlocks).toHaveLength(2);
+    expect(assistantBlocks[0]).toEqual({ type: "text", text: "Looking it up." });
+    expect(assistantBlocks[1]).toMatchObject({
+      type: "tool_use",
+      name: "get_workflow_details",
+      input: { workflowId: "abc" },
+    });
+    const toolUseId = (assistantBlocks[1] as Anthropic.ToolUseBlockParam).id;
+    expect(toolUseId).toMatch(/^toolu_/);
+
+    expect(result[2].role).toBe("user");
+    const userBlocks = result[2].content as Anthropic.ToolResultBlockParam[];
+    expect(userBlocks).toHaveLength(1);
+    expect(userBlocks[0]).toEqual({
+      type: "tool_result",
+      tool_use_id: toolUseId,
+      content: JSON.stringify({ id: "abc", name: "Test workflow" }),
+    });
+  });
+
+  it("pairs multiple toolCalls in a single assistant message", () => {
+    const msgs: RebuildableMessage[] = [
+      { role: "user", content: "do two things" },
+      {
+        role: "assistant",
+        content: "On it.",
+        toolCalls: [
+          { name: "tool_a", args: { x: 1 }, result: { ok: true } },
+          { name: "tool_b", args: { y: 2 }, result: { ok: false } },
+        ],
+      },
+    ];
+    const result = rebuildAnthropicHistory(msgs);
+    expect(result).toHaveLength(3);
+
+    const assistantBlocks = result[1].content as Anthropic.ContentBlockParam[];
+    expect(assistantBlocks).toHaveLength(3);
+    const id0 = (assistantBlocks[1] as Anthropic.ToolUseBlockParam).id;
+    const id1 = (assistantBlocks[2] as Anthropic.ToolUseBlockParam).id;
+    expect(id0).not.toBe(id1);
+
+    const userBlocks = result[2].content as Anthropic.ToolResultBlockParam[];
+    expect(userBlocks).toHaveLength(2);
+    expect(userBlocks[0].tool_use_id).toBe(id0);
+    expect(userBlocks[1].tool_use_id).toBe(id1);
+  });
+
+  it("emits tool_use-only assistant message when text content is empty", () => {
+    const msgs: RebuildableMessage[] = [
+      { role: "user", content: "just call the tool" },
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [{ name: "tool_x", args: {}, result: { ok: true } }],
+      },
+    ];
+    const result = rebuildAnthropicHistory(msgs);
+    expect(result).toHaveLength(3);
+    const assistantBlocks = result[1].content as Anthropic.ContentBlockParam[];
+    expect(assistantBlocks).toHaveLength(1);
+    expect(assistantBlocks[0].type).toBe("tool_use");
+  });
+
+  it("skips assistant messages with no text and no toolCalls", () => {
+    const msgs: RebuildableMessage[] = [
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "", toolCalls: null },
+      { role: "user", content: "still there?" },
+    ];
+    const result = rebuildAnthropicHistory(msgs);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ role: "user", content: "hi" });
+    expect(result[1]).toEqual({ role: "user", content: "still there?" });
+  });
+
+  it("filters toolCalls entries without a result (orphan tool calls)", () => {
+    const msgs: RebuildableMessage[] = [
+      { role: "user", content: "go" },
+      {
+        role: "assistant",
+        content: "Working.",
+        toolCalls: [
+          { name: "tool_ok", args: {}, result: { ok: true } },
+          { name: "tool_orphan", args: {} },
+        ],
+      },
+    ];
+    const result = rebuildAnthropicHistory(msgs);
+    const assistantBlocks = result[1].content as Anthropic.ContentBlockParam[];
+    expect(assistantBlocks).toHaveLength(2);
+    expect((assistantBlocks[1] as Anthropic.ToolUseBlockParam).name).toBe("tool_ok");
+
+    const userBlocks = result[2].content as Anthropic.ToolResultBlockParam[];
+    expect(userBlocks).toHaveLength(1);
+  });
+
+  it("skips role='tool' messages", () => {
+    const msgs: RebuildableMessage[] = [
+      { role: "user", content: "hi" },
+      { role: "tool", content: "some tool dump" },
+      { role: "assistant", content: "hello", toolCalls: null },
+    ];
+    const result = rebuildAnthropicHistory(msgs);
+    expect(result).toHaveLength(2);
+    expect(result[0].role).toBe("user");
+    expect(result[1].role).toBe("assistant");
+  });
+
+  it("preserves order across multiple agentic turns", () => {
+    const msgs: RebuildableMessage[] = [
+      { role: "user", content: "turn 1" },
+      {
+        role: "assistant",
+        content: "result 1",
+        toolCalls: [{ name: "t1", args: {}, result: "r1" }],
+      },
+      { role: "user", content: "turn 2" },
+      {
+        role: "assistant",
+        content: "result 2",
+        toolCalls: [{ name: "t2", args: {}, result: "r2" }],
+      },
+    ];
+    const result = rebuildAnthropicHistory(msgs);
+    expect(result).toHaveLength(6);
+    expect(result[0]).toEqual({ role: "user", content: "turn 1" });
+    expect(result[1].role).toBe("assistant");
+    expect(result[2].role).toBe("user"); // synthetic tool_result
+    expect(result[3]).toEqual({ role: "user", content: "turn 2" });
+    expect(result[4].role).toBe("assistant");
+    expect(result[5].role).toBe("user"); // synthetic tool_result
+
+    const ids0 = (result[1].content as Anthropic.ContentBlockParam[])
+      .filter((b) => b.type === "tool_use")
+      .map((b) => (b as Anthropic.ToolUseBlockParam).id);
+    const ids1 = (result[4].content as Anthropic.ContentBlockParam[])
+      .filter((b) => b.type === "tool_use")
+      .map((b) => (b as Anthropic.ToolUseBlockParam).id);
+    expect(ids0[0]).not.toBe(ids1[0]);
   });
 });


### PR DESCRIPTION
Automated by release.sh