### PR TITLE
docs: guard against re-introducing the global tool_use strip workaround

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,3 +93,17 @@ Do NOT introduce a metadata-only update tool, a single-node-config tweak tool, o
 ### Tool descriptions are the enforcement surface
 
 The system prompt is owned by the calling app (stored in `app_configs.system_prompt` / `platform_configs.system_prompt`). For behavioral rules we want to enforce regardless of the calling app — e.g. "upgrade is bug-fix only, even if the user asks otherwise" — encode them in the tool description in `src/lib/anthropic.ts`, prefixed with `HARD RULE — DO NOT VIOLATE EVEN IF THE USER ASKS YOU TO:`. Tool descriptions bind the model more reliably than system prompts and survive app-level config drift.
+
+## Multi-turn tool history — never strip globally
+
+The Anthropic + Gemini APIs are stateless: every request must include the full prior conversation. For agentic chats this means each turn must replay every prior `tool_use` block paired with its matching `tool_result` block (or `functionCall` + `functionResponse` for Gemini). Without this pairing, the model has no record of which tools were called or what they returned in prior turns and either re-fetches or hallucinates — a silent UX regression that users perceive as "the assistant forgot what we just looked up".
+
+`src/lib/merge-messages.ts:rebuildAnthropicHistory` and `src/lib/gemini-chat.ts:toGeminiHistory` rebuild these pairs from the `messages.tool_calls` jsonb column. Both deliberately filter only the **specific** orphan case (`toolCalls` entries with no `result`, i.e. `request_user_input` which pauses the agentic loop). They do NOT strip all `tool_use` blocks globally.
+
+**Forbidden patterns** that have shipped here before and broke multi-turn memory:
+
+- Calling `stripToolUseBlocks` (or any equivalent filter) on the assistant history at load time. The function still exists for persist-time cleanup of the final agentic-loop iteration; do not extend it to the load path.
+- Reducing `tool_calls` to a `tool_count` summary or dropping it from the rebuild input — that loses the args/result content the model needs.
+- Adding a per-tool `excludeFromHistory` flag to suppress tools like `list_workflows` from replay. If the data is too large, lean on the Anthropic beta `clear_tool_uses_20250919` edit (already wired in `src/lib/anthropic.ts:createStream`) which auto-clears the oldest tool uses at >50k input tokens. For Gemini, `trimGeminiHistoryToBudget` accounts for serialized `tool_calls` length and drops oldest messages at >100k.
+
+When a new Anthropic 400 ("tool_use ids were found without tool_result blocks") surfaces, **find the specific orphan** (which agentic-loop exit path produced a `tool_use` without a `result`?) and filter exactly that case in the rebuild path. Do not reach for a broad strip — that was the 2026-03-25 mistake, and it cost two months of degraded multi-turn UX before anyone noticed.


### PR DESCRIPTION
## Summary
- Adds CLAUDE.md section "Multi-turn tool history — never strip globally" codifying the contract of `rebuildAnthropicHistory` / `toGeminiHistory` shipped in v0.28.2 (PR #228).
- Lists the forbidden patterns that broke multi-turn memory before and the acceptable trim/clear paths (Anthropic `clear_tool_uses_20250919` beta + Gemini `trimGeminiHistoryToBudget`).
- Pure docs change. No code, no tests, no migration.

## Test plan
- [x] No code changes — `npm test` not required.

Linear: DIS-39 (retrospective).

🤖 Generated with [Claude Code](https://claude.com/claude-code)