### PR TITLE
fix(gemini): swap flash-lite to graduated stable id (preview sunset)

### DIFF
--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -38,7 +38,7 @@ const MODEL_MAP: Record<string, Record<string, ResolvedModel>> = {
     opus: { apiModelId: "claude-opus-4-6", costPrefix: "anthropic-opus-4.6", provider: "anthropic" },
   },
   google: {
-    "flash-lite": { apiModelId: "gemini-3.1-flash-lite-preview", costPrefix: "google-flash-lite-3.1", provider: "google" },
+    "flash-lite": { apiModelId: "gemini-3.1-flash-lite", costPrefix: "google-flash-lite-3.1", provider: "google" },
     "flash": { apiModelId: "gemini-3-flash-preview", costPrefix: "google-flash-3", provider: "google" },
     "pro": { apiModelId: "gemini-3.1-pro-preview", costPrefix: "google-pro-3.1", provider: "google" },
   },
@@ -70,7 +70,7 @@ export const SUPPORTED_MODELS: Record<string, string> = {
   "claude-sonnet-4-6": "anthropic-sonnet-4.6",
   "claude-haiku-4-5": "anthropic-haiku-4.5",
   "claude-opus-4-6": "anthropic-opus-4.6",
-  "gemini-3.1-flash-lite-preview": "google-flash-lite-3.1",
+  "gemini-3.1-flash-lite": "google-flash-lite-3.1",
   "gemini-3-flash-preview": "google-flash-3",
   "gemini-3.1-pro-preview": "google-pro-3.1",
   "gemini-2.5-pro": "google-pro-2.5",

--- a/src/lib/gemini-chat.ts
+++ b/src/lib/gemini-chat.ts
@@ -13,7 +13,7 @@ const GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta";
 const GEMINI_TIMEOUT_MS: Record<string, number> = {
   "gemini-3.1-pro-preview": 15 * 60_000,
   "gemini-3-flash-preview": 10 * 60_000,
-  "gemini-3.1-flash-lite-preview": 5 * 60_000,
+  "gemini-3.1-flash-lite": 5 * 60_000,
   "gemini-2.5-pro": 15 * 60_000,
   "gemini-2.5-flash": 10 * 60_000,
 };

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -1,12 +1,12 @@
 // ---------------------------------------------------------------------------
 // Gemini REST API client — lightweight, no SDK dependency
-// Used by POST /complete for vision tasks (gemini-3.1-flash-lite-preview)
+// Used by POST /complete for vision tasks (gemini-3.1-flash-lite)
 // ---------------------------------------------------------------------------
 
 const GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta";
 
 export const GEMINI_MODELS: Record<string, string> = {
-  "gemini-3.1-flash-lite-preview": "google-flash-lite-3.1",
+  "gemini-3.1-flash-lite": "google-flash-lite-3.1",
   "gemini-3-flash-preview": "google-flash-3",
   "gemini-3.1-pro-preview": "google-pro-3.1",
   "gemini-2.5-pro": "google-pro-2.5",
@@ -17,7 +17,7 @@ export const GEMINI_MODELS: Record<string, string> = {
 const GEMINI_TIMEOUT_MS: Record<string, number> = {
   "gemini-3.1-pro-preview": 15 * 60_000,       // 15 min — Pro
   "gemini-3-flash-preview": 10 * 60_000,        // 10 min — Flash
-  "gemini-3.1-flash-lite-preview": 5 * 60_000,  //  5 min — Flash Lite
+  "gemini-3.1-flash-lite": 5 * 60_000,          //  5 min — Flash Lite
   "gemini-2.5-pro": 15 * 60_000,                // 15 min — 2.5 Pro
   "gemini-2.5-flash": 10 * 60_000,              // 10 min — 2.5 Flash
 };
@@ -27,7 +27,7 @@ const DEFAULT_GEMINI_TIMEOUT_MS = 10 * 60_000;  // 10 min fallback
 const GEMINI_FALLBACK_MODEL: Record<string, string> = {
   "gemini-3.1-pro-preview": "gemini-2.5-pro",
   "gemini-3-flash-preview": "gemini-2.5-flash",
-  "gemini-3.1-flash-lite-preview": "gemini-2.5-flash",
+  "gemini-3.1-flash-lite": "gemini-2.5-flash",
 };
 
 /** HTTP status codes that warrant a retry. */

--- a/tests/unit/complete-passthrough.test.ts
+++ b/tests/unit/complete-passthrough.test.ts
@@ -95,7 +95,7 @@ describe("Gemini completeWithGemini() — caller systemPrompt is forwarded byte-
           json: async () => ({
             candidates: [{ content: { parts: [{ text: '{"ok":true}' }] }, finishReason: "STOP" }],
             usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5 },
-            modelVersion: "gemini-3.1-flash-lite-preview",
+            modelVersion: "gemini-3.1-flash-lite",
           }),
           headers: new Headers(),
         } as unknown as Response;
@@ -106,7 +106,7 @@ describe("Gemini completeWithGemini() — caller systemPrompt is forwarded byte-
   it("forwards systemPrompt unchanged for jsonMode requests", async () => {
     await completeWithGemini({
       apiKey: "k",
-      model: "gemini-3.1-flash-lite-preview",
+      model: "gemini-3.1-flash-lite",
       message: "hi",
       systemPrompt: CALLER_PROMPT,
       responseFormat: "json",
@@ -119,7 +119,7 @@ describe("Gemini completeWithGemini() — caller systemPrompt is forwarded byte-
     const schema = { type: "object", properties: { ok: { type: "boolean" } } };
     await completeWithGemini({
       apiKey: "k",
-      model: "gemini-3.1-flash-lite-preview",
+      model: "gemini-3.1-flash-lite",
       message: "hi",
       systemPrompt: CALLER_PROMPT,
       responseFormat: "json",

--- a/tests/unit/complete.test.ts
+++ b/tests/unit/complete.test.ts
@@ -450,9 +450,10 @@ describe("resolveModel", () => {
     expect(resolved.provider).toBe("anthropic");
   });
 
-  it("resolves google + flash-lite to gemini-3.1-flash-lite-preview", () => {
+  it("resolves google + flash-lite to gemini-3.1-flash-lite (stable, no -preview)", () => {
     const resolved = resolveModel("google", "flash-lite");
-    expect(resolved.apiModelId).toBe("gemini-3.1-flash-lite-preview");
+    expect(resolved.apiModelId).toBe("gemini-3.1-flash-lite");
+    expect(resolved.apiModelId).not.toContain("-preview");
     expect(resolved.costPrefix).toBe("google-flash-lite-3.1");
     expect(resolved.provider).toBe("google");
   });
@@ -483,8 +484,12 @@ describe("resolveModel", () => {
 // --- Gemini model helpers ---
 
 describe("isGeminiModel", () => {
-  it("returns true for gemini-3.1-flash-lite-preview", () => {
-    expect(isGeminiModel("gemini-3.1-flash-lite-preview")).toBe(true);
+  it("returns true for gemini-3.1-flash-lite", () => {
+    expect(isGeminiModel("gemini-3.1-flash-lite")).toBe(true);
+  });
+
+  it("returns false for the sunset gemini-3.1-flash-lite-preview ID", () => {
+    expect(isGeminiModel("gemini-3.1-flash-lite-preview")).toBe(false);
   });
 
   it("returns true for gemini-3-flash-preview", () => {
@@ -506,8 +511,8 @@ describe("isGeminiModel", () => {
 });
 
 describe("geminiCostPrefix", () => {
-  it("returns correct prefix for gemini-3.1-flash-lite-preview", () => {
-    expect(geminiCostPrefix("gemini-3.1-flash-lite-preview")).toBe("google-flash-lite-3.1");
+  it("returns correct prefix for gemini-3.1-flash-lite", () => {
+    expect(geminiCostPrefix("gemini-3.1-flash-lite")).toBe("google-flash-lite-3.1");
   });
 
   it("returns correct prefix for gemini-3-flash-preview", () => {
@@ -520,8 +525,8 @@ describe("geminiCostPrefix", () => {
 });
 
 describe("costPrefixForModel", () => {
-  it("returns correct prefix for gemini-3.1-flash-lite-preview", () => {
-    expect(costPrefixForModel("gemini-3.1-flash-lite-preview")).toBe("google-flash-lite-3.1");
+  it("returns correct prefix for gemini-3.1-flash-lite", () => {
+    expect(costPrefixForModel("gemini-3.1-flash-lite")).toBe("google-flash-lite-3.1");
   });
 
   it("returns correct prefix for anthropic models", () => {

--- a/tests/unit/gemini.test.ts
+++ b/tests/unit/gemini.test.ts
@@ -408,7 +408,7 @@ describe("completeWithGemini", () => {
     expect(fallbackUrl).toContain("gemini-2.5-pro");
   });
 
-  it("falls back to gemini-2.5-flash after all retries fail for flash-lite-preview", async () => {
+  it("falls back to gemini-2.5-flash after all retries fail for flash-lite", async () => {
     fetchSpy
       .mockResolvedValueOnce(errorResponse(503))
       .mockResolvedValueOnce(errorResponse(503))
@@ -416,7 +416,7 @@ describe("completeWithGemini", () => {
       .mockResolvedValueOnce(errorResponse(503))
       .mockResolvedValueOnce(okResponse("lite-fallback"));
 
-    const result = await runWithTimers({ ...baseOptions, model: "gemini-3.1-flash-lite-preview" });
+    const result = await runWithTimers({ ...baseOptions, model: "gemini-3.1-flash-lite" });
     expect(result.content).toBe("lite-fallback");
     expect(result.model).toBe("gemini-2.5-flash");
   });


### PR DESCRIPTION
## Summary
- Google sunset `gemini-3.1-flash-lite-preview` → graduated to `gemini-3.1-flash-lite`. Every `/complete` Google call with `model=flash-lite` was 404ing in prod.
- Surgical rename of the model ID across `anthropic.ts` (`MODEL_MAP` + `SUPPORTED_MODELS`), `gemini.ts` (`GEMINI_MODELS` / `GEMINI_TIMEOUT_MS` / `GEMINI_FALLBACK_MODEL` / comment), `gemini-chat.ts` (timeout map). Cost prefix unchanged.
- `flash` (`gemini-3-flash-preview`) and `pro` (`gemini-3.1-pro-preview`) kept as-is per scope decision.

## Root cause
`completeWithGemini` retry loop only catches `[429, 500, 503, 504]`. 404 throws non-retryable Error at `src/lib/gemini.ts:158`, bypassing the `gemini-2.5-flash` fallback wired below.

## Regression test
`isGeminiModel("gemini-3.1-flash-lite-preview")` now returns `false` — sunset ID cannot sneak back in.

## Test plan
- [x] `npm test` — 584 passed (2 integration tests skipped on local missing `CHAT_SERVICE_DATABASE_URL`, unrelated)
- [x] `npm run build` — clean, openapi regen no-op
- [ ] Post-deploy: curl `/complete` with `provider=google, model=flash-lite` returns 200
- [ ] Railway logs free of `gemini-3.1-flash-lite-preview ... NOT_FOUND` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)