### PR TITLE
feat(rag-score): native multi-brand brandIds[] (DIS-67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,28 +296,43 @@ Used by **journalists-quotes-service** to rank quote requests against a brand fo
 
 **Auth:** `x-api-key` + `x-org-id` + `x-user-id` + `x-run-id` (standard).
 
-**Request:**
+**Request (multi-brand, preferred):**
 ```json
 {
-  "brandId": "550e8400-e29b-41d4-a716-446655440000",
+  "brandIds": [
+    "550e8400-e29b-41d4-a716-446655440000",
+    "660f9500-f30c-42e5-b827-557766551111"
+  ],
   "documents": [
     { "id": "quote-7c2b", "text": "Looking to interview a B2B SaaS founder about pricing experiments." },
     { "id": "quote-9f1a", "text": "Need a quote on AI safety from a research lab." }
   ],
-  "query": "B2B SaaS pricing experiments"   // optional override
+  "query": "B2B SaaS pricing experiments"
+}
+```
+
+**Request (legacy single-brand, still accepted):**
+```json
+{
+  "brandId": "550e8400-e29b-41d4-a716-446655440000",
+  "documents": [{ "id": "quote-7c2b", "text": "..." }]
 }
 ```
 
 | Field | Required | Notes |
 |---|---|---|
-| `brandId` | yes | UUID. Brand whose profile is used as the semantic query. |
+| `brandIds` | one of | 1–5 UUIDs. Brand IDs whose joint profile is used as the semantic query. brand-service consolidates field values (industry, expertise, target audience, voice) across all brands in ONE call; chat-service then computes ONE embedding against the consolidated profile. |
+| `brandId` | one of | Legacy single-brand field. Equivalent to `brandIds: [brandId]`. When both are provided, `brandIds` wins. At least one of `brandIds` / `brandId` is required. |
 | `documents` | yes | 1–100 items. Each has `id` (caller-supplied, returned verbatim) and `text` (body to embed). |
-| `query` | no | When omitted, the service synthesizes a query from the brand profile (industry, expertise, target audience, voice). When present, the override is used directly. |
+| `query` | no | When omitted, the service synthesizes a query from the (joint) brand profile. When present, the override is used directly. |
 
-**Response:**
+**Response (multi-brand):**
 ```json
 {
-  "brandId": "550e8400-e29b-41d4-a716-446655440000",
+  "brandIds": [
+    "550e8400-e29b-41d4-a716-446655440000",
+    "660f9500-f30c-42e5-b827-557766551111"
+  ],
   "queryText": "industry: B2B SaaS\nexpertise: pricing experiments\ntarget audience: founders\nvoice: data-driven",
   "cacheHit": true,
   "model": "gemini-embedding-001",
@@ -328,23 +343,36 @@ Used by **journalists-quotes-service** to rank quote requests against a brand fo
 }
 ```
 
-`results` is sorted by `score` descending. Scores are cosine similarity in `[0, 1]` (negatives clamped to `0`).
+**Response (single-brand — `brandId` echo preserved for legacy consumers):**
+```json
+{
+  "brandIds": ["550e8400-e29b-41d4-a716-446655440000"],
+  "brandId": "550e8400-e29b-41d4-a716-446655440000",
+  "queryText": "...",
+  "cacheHit": true,
+  "model": "gemini-embedding-001",
+  "results": [{ "id": "quote-7c2b", "score": 0.92 }]
+}
+```
+
+`brandIds` is always present and canonical-sorted ascending. `brandId` is echoed **only** when the request resolved to exactly one brand. `results` is sorted by `score` descending. Scores are cosine similarity in `[0, 1]` (negatives clamped to `0`).
 
 **Pipeline:**
-1. Resolve brand context from brand-service (`industry`, `expertise`, `target_audience`, `voice`).
-2. Synthesize a brand-profile query string (or use `query` override).
-3. Compute the brand-profile embedding via Gemini `gemini-embedding-001` (cached per `(orgId, brandId, contentHash)` in the `brand_profile_embeddings` table — only the brand-profile vector is cached; document vectors are recomputed per request).
-4. Batch-embed every `documents[i].text`.
-5. Cosine similarity between brand-profile vector and each document vector.
+1. Canonical-sort `brandIds` ascending (e.g. `[b, a]` → `[a, b]`).
+2. Resolve joint brand context from brand-service in ONE call (`industry`, `expertise`, `target_audience`, `voice`). brand-service merges field values across all input brands.
+3. Synthesize a brand-profile query string (or use `query` override).
+4. Compute the brand-profile embedding via Gemini `gemini-embedding-001` (cached per `(orgId, canonical-sorted brandIds CSV, contentHash)` in the `brand_profile_embeddings` table — only the brand-profile vector is cached; document vectors are recomputed per request).
+5. Batch-embed every `documents[i].text`.
+6. Cosine similarity between brand-profile vector and each document vector.
 
-The cache automatically invalidates when **any** resolved brand field changes (the hash covers all fields). Repeated calls with unchanged brand context skip the brand-profile Gemini call entirely.
+The cache automatically invalidates when **any** resolved brand field changes (the hash covers all fields). Repeated calls with unchanged brand context skip the brand-profile Gemini call entirely. Reversed-order brandIds (e.g. `[b, a]` after `[a, b]`) hit the same cache row since the key is canonical-sorted.
 
 **Errors:**
-- `400` — validation (`documents` empty, `documents.length > 100`, `brandId` not UUID, etc.) or empty resolved brand profile (provide an explicit `query` when this happens).
-- `404` — `brandId` not found in brand-service.
+- `400` — validation (`documents` empty, `documents.length > 100`, `brandIds.length > 5` or empty, non-UUID, neither `brandIds` nor `brandId` provided, etc.) or empty resolved brand profile (provide an explicit `query` when this happens).
+- `404` — one or more `brandIds` not found in brand-service.
 - `502` — upstream failure (brand-service, key-service, runs-service, or Gemini).
 
-**Volume:** designed for batches of up to **100** documents per request. Larger batches must be chunked by the caller.
+**Volume:** designed for batches of up to **100** documents per request, up to **5** brands per joint profile. Larger batches must be chunked by the caller.
 
 The Gemini embedding model defaults to `gemini-embedding-001` and is overridable via `GEMINI_EMBEDDING_MODEL`. Key resolution uses the standard `google` provider in key-service.
 

--- a/openapi.json
+++ b/openapi.json
@@ -930,9 +930,16 @@
       "RagScoreResponse": {
         "type": "object",
         "properties": {
+          "brandIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Canonical-sorted list of brand IDs used to build the joint brand profile. For a single-brand request this is a 1-element array; for multi-brand it is sorted ascending."
+          },
           "brandId": {
             "type": "string",
-            "description": "Echo of the request brandId."
+            "description": "Echo of the legacy `brandId` field. Present only when the request resolved to exactly one brand (either via legacy `brandId` or `brandIds: [single]`). Omitted on multi-brand requests."
           },
           "queryText": {
             "type": "string",
@@ -956,7 +963,7 @@
           }
         },
         "required": [
-          "brandId",
+          "brandIds",
           "queryText",
           "cacheHit",
           "model",
@@ -992,10 +999,24 @@
             "maxItems": 100,
             "description": "List of documents to score against the brand profile. At most 100 items per request."
           },
+          "brandIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "minItems": 1,
+            "maxItems": 5,
+            "description": "Brand IDs whose joint profile is used as the semantic query. Resolved via brand-service (industry, expertise, target audience, voice). When more than one is provided, brand-service consolidates field values across brands and one embedding is computed against the consolidated profile. Preferred over legacy `brandId`.",
+            "example": [
+              "550e8400-e29b-41d4-a716-446655440000",
+              "660f9500-f30c-52e5-b827-557766551111"
+            ]
+          },
           "brandId": {
             "type": "string",
             "format": "uuid",
-            "description": "Brand whose profile is used as the semantic query. Resolved via brand-service (industry, expertise, target audience, voice).",
+            "description": "Legacy single-brand field. Equivalent to `brandIds: [brandId]`. When both are provided, `brandIds` wins. At least one of `brandIds` / `brandId` is required.",
             "example": "550e8400-e29b-41d4-a716-446655440000"
           },
           "query": {
@@ -1005,8 +1026,7 @@
           }
         },
         "required": [
-          "documents",
-          "brandId"
+          "documents"
         ],
         "additionalProperties": false
       },
@@ -1818,7 +1838,7 @@
           "RAG"
         ],
         "summary": "Score documents against a brand profile (semantic similarity)",
-        "description": "RAG-style semantic similarity scoring for picking the best document(s) for a brand.\n\nUsed by journalists-quotes-service to rank quote requests against a brand profile, and by any other consumer that needs cheap document-vs-brand scoring.\n\n**Pipeline:**\n1. Resolve brand context via brand-service (industry, expertise, target audience, voice).\n2. Synthesize a brand-profile query string (or use the caller-supplied `query`).\n3. Compute the brand-profile embedding via Gemini's `gemini-embedding-001` (cached per (orgId, brandId, contentHash)).\n4. Compute embeddings for each `documents[i].text` in a single batch call.\n5. Score = cosine similarity, sorted descending.\n\n**Caching:** the brand-profile embedding is cached. Repeated calls with the same brand context (same resolved fields) reuse the cached vector — only document embeddings are recomputed. The cache automatically invalidates when any resolved brand field changes.\n\n**Volume:** designed for batches up to 100 documents per request.",
+        "description": "RAG-style semantic similarity scoring for picking the best document(s) for a brand.\n\nUsed by journalists-quotes-service to rank quote requests against a brand profile, and by any other consumer that needs cheap document-vs-brand scoring.\n\n**Multi-brand:** accepts `brandIds: string[]` (1..5) for joint scoring across multiple brands. Legacy `brandId: string` is still accepted and is equivalent to `brandIds: [brandId]`. When both are provided, `brandIds` wins. At least one is required. Multi-brand calls compute ONE embedding against the consolidated brand profile (brand-service merges field values across input brands) and ONE score per document.\n\n**Pipeline:**\n1. Canonical-sort `brandIds` ascending.\n2. Resolve consolidated brand context via brand-service (industry, expertise, target audience, voice) in ONE call.\n3. Synthesize a brand-profile query string (or use the caller-supplied `query`).\n4. Compute the brand-profile embedding via Gemini's `gemini-embedding-001` (cached per (orgId, sorted(brandIds), contentHash)).\n5. Compute embeddings for each `documents[i].text` in a single batch call.\n6. Score = cosine similarity, sorted descending.\n\n**Caching:** the brand-profile embedding is cached per canonical-sorted brand set + content hash. Same brand set, same resolved fields → cache hit. Different brand set (even subset) → cache miss. The cache automatically invalidates when any resolved brand field changes.\n\n**Volume:** designed for batches up to 100 documents per request, up to 5 brands per joint profile.",
         "parameters": [
           {
             "schema": {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -44,6 +44,11 @@ export const appConfigs = pgTable(
   (table) => [unique("app_configs_org_id_key_unique").on(table.orgId, table.key)],
 );
 
+// `brand_id` column is the canonical cache partition for /orgs/rag/score. It holds
+// either a single brand UUID (legacy single-brand cache rows + N=1 multi-brand requests)
+// or a comma-separated, ASCII-sorted list of brand UUIDs for N>=2 multi-brand requests
+// (e.g. "550e8400-...,660f9500-..."). The plural-name rename was skipped on purpose
+// so existing single-brand rows stay byte-identical and require no migration.
 export const brandProfileEmbeddings = pgTable(
   "brand_profile_embeddings",
   {

--- a/src/index.ts
+++ b/src/index.ts
@@ -538,12 +538,26 @@ app.post("/orgs/rag/score", requireAuth, async (req, res) => {
       .status(400)
       .json({ error: "Invalid request", details: parsed.error.flatten() });
   }
-  const { documents, brandId, query: queryOverride } = parsed.data;
+  const {
+    documents,
+    brandIds: brandIdsFromBody,
+    brandId: legacyBrandId,
+    query: queryOverride,
+  } = parsed.data;
 
-  // Body brandId is the authoritative target — overrides any forwarded x-brand-id.
+  // Derive canonical-sorted brandIds. `brandIds` wins; otherwise fall back to legacy
+  // `brandId`. The refine() above guarantees at least one is defined.
+  const rawBrandIds = brandIdsFromBody ?? [legacyBrandId!];
+  const brandIds = [...rawBrandIds].sort();
+  // DB column name is still `brand_id` (singular) — repurposed to hold the canonical
+  // sorted CSV. Single-brand → just the UUID (byte-identical to legacy cache rows).
+  const brandCacheKey = brandIds.join(",");
+  const isSingleBrand = brandIds.length === 1;
+
+  // Body brandIds/brandId is the authoritative target — overrides any forwarded x-brand-id.
   const trackingHeaders: Record<string, string> = {
     ...baseTrackingHeaders,
-    "x-brand-id": brandId,
+    "x-brand-id": brandCacheKey,
   };
 
   // Register run (mandatory)
@@ -556,7 +570,12 @@ app.post("/orgs/rag/score", requireAuth, async (req, res) => {
     );
     runId = run.id;
     traceEvent(runId, "run-created", { orgId, userId }, workflowTracking, {
-      data: { taskName: "rag-score", parentRunId, brandId, documentCount: documents.length },
+      data: {
+        taskName: "rag-score",
+        parentRunId,
+        brandIds,
+        documentCount: documents.length,
+      },
     });
   } catch (runErr) {
     console.error(`[rag-score] org="${orgId}" run creation failed:`, runErr);
@@ -567,12 +586,14 @@ app.post("/orgs/rag/score", requireAuth, async (req, res) => {
 
   let scoreFailed = false;
   try {
-    // Resolve brand context. Pass own runId so brand-service sees us as the parent.
+    // Resolve joint brand context. Pass own runId so brand-service sees us as the parent.
+    // For multi-brand, brand-service consolidates field values across all brandIds and
+    // returns a single `fields[key].value` per field — no client-side joining needed.
     let brandResults;
     try {
       brandResults = await extractBrandFields(
         RAG_BRAND_FIELDS,
-        [brandId],
+        brandIds,
         {
           orgId,
           userId,
@@ -583,7 +604,7 @@ app.post("/orgs/rag/score", requireAuth, async (req, res) => {
     } catch (err) {
       if (err instanceof BrandError && err.status === 404) {
         return res.status(404).json({
-          error: `Brand not found: ${brandId}`,
+          error: `Brand not found: ${brandCacheKey}`,
         });
       }
       throw err;
@@ -602,7 +623,7 @@ app.post("/orgs/rag/score", requireAuth, async (req, res) => {
     if (queryText.trim().length === 0) {
       scoreFailed = true;
       console.warn(
-        `[rag-score] org="${orgId}" brand="${brandId}" produced empty brand profile (no resolvable fields)`,
+        `[rag-score] org="${orgId}" brands="${brandCacheKey}" produced empty brand profile (no resolvable fields)`,
       );
       return res.status(400).json({
         error:
@@ -611,6 +632,8 @@ app.post("/orgs/rag/score", requireAuth, async (req, res) => {
     }
 
     // Cache key: hash of the resolved field values (or the override string).
+    // brandCacheKey (canonical sorted CSV) is the column-level partition; the hash
+    // covers the field values so any change in brand context invalidates the row.
     const hash = queryOverride
       ? contentHash({ __override__: queryOverride })
       : contentHash(fieldValues);
@@ -643,7 +666,7 @@ app.post("/orgs/rag/score", requireAuth, async (req, res) => {
       .where(
         and(
           eq(brandProfileEmbeddings.orgId, orgId),
-          eq(brandProfileEmbeddings.brandId, brandId),
+          eq(brandProfileEmbeddings.brandId, brandCacheKey),
           eq(brandProfileEmbeddings.contentHash, hash),
         ),
       )
@@ -659,7 +682,7 @@ app.post("/orgs/rag/score", requireAuth, async (req, res) => {
         .insert(brandProfileEmbeddings)
         .values({
           orgId,
-          brandId,
+          brandId: brandCacheKey,
           contentHash: hash,
           queryText,
           embedding: queryEmbedding,
@@ -690,7 +713,7 @@ app.post("/orgs/rag/score", requireAuth, async (req, res) => {
     if (runId) {
       traceEvent(runId, "rag-score-done", { orgId, userId }, workflowTracking, {
         data: {
-          brandId,
+          brandIds,
           documentCount: documents.length,
           cacheHit,
           model: DEFAULT_EMBEDDING_MODEL,
@@ -699,7 +722,10 @@ app.post("/orgs/rag/score", requireAuth, async (req, res) => {
     }
 
     res.json({
-      brandId,
+      brandIds,
+      // Echo legacy `brandId` only when exactly one brand was resolved, so existing
+      // single-brand consumers keep the same response shape byte-for-byte.
+      ...(isSingleBrand ? { brandId: brandIds[0] } : {}),
       queryText,
       cacheHit,
       model: DEFAULT_EMBEDDING_MODEL,
@@ -707,12 +733,12 @@ app.post("/orgs/rag/score", requireAuth, async (req, res) => {
     });
   } catch (err) {
     scoreFailed = true;
-    console.error(`[rag-score] org="${orgId}" brand="${brandId}" error:`, err);
+    console.error(`[rag-score] org="${orgId}" brands="${brandCacheKey}" error:`, err);
     if (runId) {
       traceEvent(runId, "rag-score-failed", { orgId, userId }, workflowTracking, {
         level: "error",
         detail: err instanceof Error ? err.message : String(err),
-        data: { brandId },
+        data: { brandIds },
       });
     }
     res.status(502).json({

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1073,6 +1073,8 @@ export const RagScoreDocumentSchema = z
   .strict()
   .openapi("RagScoreDocument");
 
+export const RAG_SCORE_BRAND_IDS_MAX = 5;
+
 export const RagScoreRequestSchema = z
   .object({
     documents: z
@@ -1085,12 +1087,35 @@ export const RagScoreRequestSchema = z
       .openapi({
         description: `List of documents to score against the brand profile. At most ${RAG_SCORE_DOCUMENTS_MAX} items per request.`,
       }),
-    brandId: z.string().uuid("brandId must be a UUID").openapi({
-      description:
-        "Brand whose profile is used as the semantic query. Resolved via brand-service " +
-        "(industry, expertise, target audience, voice).",
-      example: "550e8400-e29b-41d4-a716-446655440000",
-    }),
+    brandIds: z
+      .array(z.string().uuid("each brandIds entry must be a UUID"))
+      .min(1, "brandIds must contain at least one item")
+      .max(
+        RAG_SCORE_BRAND_IDS_MAX,
+        `brandIds may contain at most ${RAG_SCORE_BRAND_IDS_MAX} items`,
+      )
+      .optional()
+      .openapi({
+        description:
+          "Brand IDs whose joint profile is used as the semantic query. Resolved via brand-service " +
+          "(industry, expertise, target audience, voice). When more than one is provided, " +
+          "brand-service consolidates field values across brands and one embedding is computed " +
+          "against the consolidated profile. Preferred over legacy `brandId`.",
+        example: [
+          "550e8400-e29b-41d4-a716-446655440000",
+          "660f9500-f30c-52e5-b827-557766551111",
+        ],
+      }),
+    brandId: z
+      .string()
+      .uuid("brandId must be a UUID")
+      .optional()
+      .openapi({
+        description:
+          "Legacy single-brand field. Equivalent to `brandIds: [brandId]`. When both are provided, " +
+          "`brandIds` wins. At least one of `brandIds` / `brandId` is required.",
+        example: "550e8400-e29b-41d4-a716-446655440000",
+      }),
     query: z.string().min(1).optional().openapi({
       description:
         "Optional override for the brand-profile query string. When omitted, the service " +
@@ -1098,6 +1123,14 @@ export const RagScoreRequestSchema = z
     }),
   })
   .strict()
+  .refine(
+    (data) => data.brandIds !== undefined || data.brandId !== undefined,
+    {
+      message:
+        "Provide either `brandIds: string[]` (preferred) or legacy `brandId: string`.",
+      path: ["brandIds"],
+    },
+  )
   .openapi("RagScoreRequest");
 
 export const RagScoreResultSchema = z
@@ -1115,7 +1148,16 @@ export const RagScoreResultSchema = z
 
 export const RagScoreResponseSchema = z
   .object({
-    brandId: z.string().openapi({ description: "Echo of the request brandId." }),
+    brandIds: z.array(z.string()).openapi({
+      description:
+        "Canonical-sorted list of brand IDs used to build the joint brand profile. " +
+        "For a single-brand request this is a 1-element array; for multi-brand it is sorted ascending.",
+    }),
+    brandId: z.string().optional().openapi({
+      description:
+        "Echo of the legacy `brandId` field. Present only when the request resolved to exactly one brand " +
+        "(either via legacy `brandId` or `brandIds: [single]`). Omitted on multi-brand requests.",
+    }),
     queryText: z.string().openapi({
       description:
         "The brand-profile query string that was embedded. Useful for debugging and auditing.",
@@ -1145,16 +1187,19 @@ registry.registerPath({
 
 Used by journalists-quotes-service to rank quote requests against a brand profile, and by any other consumer that needs cheap document-vs-brand scoring.
 
+**Multi-brand:** accepts \`brandIds: string[]\` (1..${RAG_SCORE_BRAND_IDS_MAX}) for joint scoring across multiple brands. Legacy \`brandId: string\` is still accepted and is equivalent to \`brandIds: [brandId]\`. When both are provided, \`brandIds\` wins. At least one is required. Multi-brand calls compute ONE embedding against the consolidated brand profile (brand-service merges field values across input brands) and ONE score per document.
+
 **Pipeline:**
-1. Resolve brand context via brand-service (industry, expertise, target audience, voice).
-2. Synthesize a brand-profile query string (or use the caller-supplied \`query\`).
-3. Compute the brand-profile embedding via Gemini's \`gemini-embedding-001\` (cached per (orgId, brandId, contentHash)).
-4. Compute embeddings for each \`documents[i].text\` in a single batch call.
-5. Score = cosine similarity, sorted descending.
+1. Canonical-sort \`brandIds\` ascending.
+2. Resolve consolidated brand context via brand-service (industry, expertise, target audience, voice) in ONE call.
+3. Synthesize a brand-profile query string (or use the caller-supplied \`query\`).
+4. Compute the brand-profile embedding via Gemini's \`gemini-embedding-001\` (cached per (orgId, sorted(brandIds), contentHash)).
+5. Compute embeddings for each \`documents[i].text\` in a single batch call.
+6. Score = cosine similarity, sorted descending.
 
-**Caching:** the brand-profile embedding is cached. Repeated calls with the same brand context (same resolved fields) reuse the cached vector — only document embeddings are recomputed. The cache automatically invalidates when any resolved brand field changes.
+**Caching:** the brand-profile embedding is cached per canonical-sorted brand set + content hash. Same brand set, same resolved fields → cache hit. Different brand set (even subset) → cache miss. The cache automatically invalidates when any resolved brand field changes.
 
-**Volume:** designed for batches up to ${RAG_SCORE_DOCUMENTS_MAX} documents per request.`,
+**Volume:** designed for batches up to ${RAG_SCORE_DOCUMENTS_MAX} documents per request, up to ${RAG_SCORE_BRAND_IDS_MAX} brands per joint profile.`,
   request: {
     headers: z.object({
       "x-api-key": z.string().openapi({

--- a/tests/integration/rag-score.test.ts
+++ b/tests/integration/rag-score.test.ts
@@ -515,4 +515,251 @@ describe("POST /orgs/rag/score", { timeout: 30_000 }, () => {
     expect(res.status).toBe(404);
     expect(res.body.error).toMatch(/Brand not found/);
   });
+
+  // --- Multi-brand (brandIds: string[]) ---
+
+  it("legacy single-brand response includes both brandId and brandIds", async () => {
+    const orgId = `org-${crypto.randomUUID()}`;
+    const brandId = crypto.randomUUID();
+    await cleanupBrandCache(orgId, brandId);
+
+    routes.push(mockRunsCreate(crypto.randomUUID()));
+    routes.push(mockRunsPatch());
+    routes.push(
+      mockBrandExtract({
+        industry: "SaaS",
+        expertise: "pricing",
+        target_audience: "founders",
+        voice: "data-driven",
+      }),
+    );
+    routes.push(mockKeyServiceDecrypt());
+    routes.push(mockGeminiBatchEmbed([[1, 0]]));
+
+    const res = await request(app)
+      .post("/orgs/rag/score")
+      .set(authHeaders(orgId, crypto.randomUUID()))
+      .send({
+        brandId,
+        documents: [{ id: "x", text: "hello" }],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.brandId).toBe(brandId);
+    expect(res.body.brandIds).toEqual([brandId]);
+
+    await cleanupBrandCache(orgId, brandId);
+  });
+
+  it("multi-brand happy path: ONE query embed, ONE doc batch, canonical-sorted brandIds", async () => {
+    const orgId = `org-${crypto.randomUUID()}`;
+    // Pick two UUIDs and submit in REVERSE ASCII order so we can prove canonical-sort.
+    const a = "11111111-1111-4111-8111-111111111111";
+    const b = "22222222-2222-4222-8222-222222222222";
+    const cacheKey = `${a},${b}`;
+    await cleanupBrandCache(orgId, cacheKey);
+    await cleanupBrandCache(orgId, a);
+    await cleanupBrandCache(orgId, b);
+
+    const queryVector = [1, 0, 0];
+    const docVectors = [
+      [0.99, 0.1, 0],
+      [-1, 0, 0],
+    ];
+
+    const brandCapture = { headers: undefined as Record<string, string> | undefined, body: undefined as unknown };
+    const embedCapture = { calls: 0, bodies: [] as unknown[] };
+
+    routes.push(mockRunsCreate(crypto.randomUUID()));
+    routes.push(mockRunsPatch());
+    routes.push(
+      mockBrandExtract(
+        {
+          industry: "B2B SaaS",
+          expertise: "pricing experiments",
+          target_audience: "founders",
+          voice: "data-driven",
+        },
+        brandCapture,
+      ),
+    );
+    routes.push(mockKeyServiceDecrypt());
+    let embedCallIdx = 0;
+    routes.push({
+      match: (url: string) => url.includes(":batchEmbedContents"),
+      respond: (_url: string, init?: RequestInit) => {
+        embedCapture.calls += 1;
+        if (init?.body) embedCapture.bodies.push(JSON.parse(init.body as string));
+        const idx = embedCallIdx++;
+        const body = idx === 0
+          ? { embeddings: [{ values: queryVector }] }
+          : { embeddings: docVectors.map((v) => ({ values: v })) };
+        return { ok: true, body };
+      },
+    });
+
+    const res = await request(app)
+      .post("/orgs/rag/score")
+      .set(authHeaders(orgId, crypto.randomUUID()))
+      .send({
+        brandIds: [b, a],
+        documents: [
+          { id: "doc-good", text: "perfect match" },
+          { id: "doc-bad", text: "irrelevant" },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    // Response shape: brandIds canonical-sorted; brandId omitted on multi-brand.
+    expect(res.body.brandIds).toEqual([a, b]);
+    expect(res.body.brandId).toBeUndefined();
+    expect(res.body.cacheHit).toBe(false);
+    expect(res.body.results.map((r: { id: string }) => r.id)).toEqual(["doc-good", "doc-bad"]);
+
+    // Exactly ONE query embed + ONE doc batch (not N per-brand).
+    expect(embedCapture.calls).toBe(2);
+    expect((embedCapture.bodies[0] as { requests: unknown[] }).requests).toHaveLength(1);
+    expect((embedCapture.bodies[1] as { requests: unknown[] }).requests).toHaveLength(2);
+
+    // Outbound brand-service body carries canonical-sorted brandIds.
+    expect(brandCapture.body).toMatchObject({
+      brandIds: [a, b],
+      fields: expect.any(Array),
+    });
+    // Outbound x-brand-id header carries canonical CSV.
+    expect(brandCapture.headers?.["x-brand-id"]).toBe(cacheKey);
+
+    // Cache row written under canonical CSV key.
+    const cached = await db
+      .select()
+      .from(schema.brandProfileEmbeddings)
+      .where(
+        and(
+          eq(schema.brandProfileEmbeddings.orgId, orgId),
+          eq(schema.brandProfileEmbeddings.brandId, cacheKey),
+        ),
+      );
+    expect(cached).toHaveLength(1);
+    expect(cached[0].embedding).toEqual(queryVector);
+
+    await cleanupBrandCache(orgId, cacheKey);
+  });
+
+  it("cross-order brandIds hit the same cache row", async () => {
+    const orgId = `org-${crypto.randomUUID()}`;
+    const a = "33333333-3333-4333-8333-333333333333";
+    const b = "44444444-4444-4444-8444-444444444444";
+    const cacheKey = `${a},${b}`;
+    await cleanupBrandCache(orgId, cacheKey);
+
+    const queryVector = [1, 0];
+    const docVectors = [[1, 0]];
+
+    const setup = () => {
+      routes = [];
+      fetchCalls = [];
+      installFetchMock();
+      routes.push(mockRunsCreate(crypto.randomUUID()));
+      routes.push(mockRunsPatch());
+      routes.push(
+        mockBrandExtract({
+          industry: "SaaS",
+          expertise: "pricing",
+          target_audience: "founders",
+          voice: "data-driven",
+        }),
+      );
+      routes.push(mockKeyServiceDecrypt());
+      routes.push({
+        match: (url: string) => url.includes(":batchEmbedContents"),
+        respond: (_url: string, init?: RequestInit) => {
+          const body = JSON.parse(init!.body as string) as { requests: unknown[] };
+          return {
+            ok: true,
+            body:
+              body.requests.length === 1
+                ? { embeddings: [{ values: queryVector }] }
+                : { embeddings: docVectors.map((v) => ({ values: v })) },
+          };
+        },
+      });
+    };
+
+    // First call: [a, b]
+    setup();
+    const r1 = await request(app)
+      .post("/orgs/rag/score")
+      .set(authHeaders(orgId, crypto.randomUUID()))
+      .send({ brandIds: [a, b], documents: [{ id: "x", text: "hello" }] });
+    expect(r1.status).toBe(200);
+    expect(r1.body.cacheHit).toBe(false);
+    expect(r1.body.brandIds).toEqual([a, b]);
+
+    // Second call: [b, a] — reversed input must hit the same canonical cache row.
+    setup();
+    const r2 = await request(app)
+      .post("/orgs/rag/score")
+      .set(authHeaders(orgId, crypto.randomUUID()))
+      .send({ brandIds: [b, a], documents: [{ id: "x", text: "hello" }] });
+    expect(r2.status).toBe(200);
+    expect(r2.body.cacheHit).toBe(true);
+    expect(r2.body.brandIds).toEqual([a, b]);
+
+    await cleanupBrandCache(orgId, cacheKey);
+  });
+
+  it("when both brandIds and brandId are provided, brandIds wins", async () => {
+    const orgId = `org-${crypto.randomUUID()}`;
+    const a = "55555555-5555-4555-8555-555555555555";
+    const b = "66666666-6666-4666-8666-666666666666";
+    const stray = "77777777-7777-4777-8777-777777777777";
+    const cacheKey = `${a},${b}`;
+    await cleanupBrandCache(orgId, cacheKey);
+    await cleanupBrandCache(orgId, stray);
+
+    const brandCapture = { headers: undefined as Record<string, string> | undefined, body: undefined as unknown };
+
+    routes.push(mockRunsCreate(crypto.randomUUID()));
+    routes.push(mockRunsPatch());
+    routes.push(
+      mockBrandExtract(
+        { industry: "SaaS", expertise: "pricing", target_audience: "founders", voice: "data-driven" },
+        brandCapture,
+      ),
+    );
+    routes.push(mockKeyServiceDecrypt());
+    routes.push(mockGeminiBatchEmbed([[1, 0]]));
+
+    const res = await request(app)
+      .post("/orgs/rag/score")
+      .set(authHeaders(orgId, crypto.randomUUID()))
+      .send({
+        brandIds: [b, a],
+        brandId: stray,
+        documents: [{ id: "x", text: "hello" }],
+      });
+
+    expect(res.status).toBe(200);
+    // Response reflects brandIds, ignores stray legacy brandId.
+    expect(res.body.brandIds).toEqual([a, b]);
+    expect(res.body.brandId).toBeUndefined();
+    // Outbound brand-service body uses brandIds, not the stray legacy field.
+    expect(brandCapture.body).toMatchObject({ brandIds: [a, b] });
+
+    await cleanupBrandCache(orgId, cacheKey);
+  });
+
+  it("returns 400 when neither brandIds nor brandId is provided", async () => {
+    const orgId = `org-${crypto.randomUUID()}`;
+    routes.push(mockRunsCreate(crypto.randomUUID()));
+    routes.push(mockRunsPatch());
+
+    const res = await request(app)
+      .post("/orgs/rag/score")
+      .set(authHeaders(orgId, crypto.randomUUID()))
+      .send({ documents: [{ id: "x", text: "hello" }] });
+
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(res.body)).toMatch(/brandIds.*brandId/);
+  });
 });

--- a/tests/unit/rag-score-schema.test.ts
+++ b/tests/unit/rag-score-schema.test.ts
@@ -2,15 +2,26 @@ import { describe, it, expect } from "vitest";
 import {
   RagScoreRequestSchema,
   RAG_SCORE_DOCUMENTS_MAX,
+  RAG_SCORE_BRAND_IDS_MAX,
 } from "../../src/schemas.js";
 
 const validBrandId = "550e8400-e29b-41d4-a716-446655440000";
+const validBrandId2 = "660f9500-f30c-42e5-b827-557766551111";
+const validBrandId3 = "770fa600-040d-43e5-a938-668877662222";
 
 function makeDocs(n: number) {
   return Array.from({ length: n }, (_, i) => ({
     id: `doc-${i}`,
     text: `body ${i}`,
   }));
+}
+
+function makeBrandIds(n: number) {
+  // Deterministic, valid v4-shaped UUIDs (variant nibble 8/9/a/b — Zod is variant-strict).
+  return Array.from({ length: n }, (_, i) => {
+    const hex = i.toString(16).padStart(2, "0");
+    return `aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeee${hex}`;
+  });
 }
 
 describe("RagScoreRequestSchema", () => {
@@ -98,6 +109,78 @@ describe("RagScoreRequestSchema", () => {
     const result = RagScoreRequestSchema.safeParse({
       brandId: validBrandId,
       documents: [{ id: "a", text: "hello", extra: 1 }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  // --- Multi-brand (brandIds) ---
+
+  it("accepts brandIds alone (preferred path)", () => {
+    const result = RagScoreRequestSchema.safeParse({
+      brandIds: [validBrandId, validBrandId2],
+      documents: [{ id: "a", text: "hello" }],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.brandIds).toEqual([validBrandId, validBrandId2]);
+      expect(result.data.brandId).toBeUndefined();
+    }
+  });
+
+  it("accepts both brandIds and brandId (handler picks brandIds)", () => {
+    const result = RagScoreRequestSchema.safeParse({
+      brandIds: [validBrandId, validBrandId2],
+      brandId: validBrandId3,
+      documents: [{ id: "a", text: "hello" }],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.brandIds).toEqual([validBrandId, validBrandId2]);
+      expect(result.data.brandId).toBe(validBrandId3);
+    }
+  });
+
+  it("rejects when neither brandIds nor brandId is provided", () => {
+    const result = RagScoreRequestSchema.safeParse({
+      documents: [{ id: "a", text: "hello" }],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(JSON.stringify(result.error.issues)).toMatch(/brandIds.*brandId/);
+    }
+  });
+
+  it("rejects empty brandIds array", () => {
+    const result = RagScoreRequestSchema.safeParse({
+      brandIds: [],
+      documents: [{ id: "a", text: "hello" }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it(`rejects brandIds.length > ${RAG_SCORE_BRAND_IDS_MAX}`, () => {
+    const result = RagScoreRequestSchema.safeParse({
+      brandIds: makeBrandIds(RAG_SCORE_BRAND_IDS_MAX + 1),
+      documents: [{ id: "a", text: "hello" }],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(JSON.stringify(result.error.issues)).toMatch(/at most/);
+    }
+  });
+
+  it(`accepts brandIds.length == ${RAG_SCORE_BRAND_IDS_MAX} (boundary)`, () => {
+    const result = RagScoreRequestSchema.safeParse({
+      brandIds: makeBrandIds(RAG_SCORE_BRAND_IDS_MAX),
+      documents: [{ id: "a", text: "hello" }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects non-uuid entries in brandIds", () => {
+    const result = RagScoreRequestSchema.safeParse({
+      brandIds: [validBrandId, "not-a-uuid"],
+      documents: [{ id: "a", text: "hello" }],
     });
     expect(result.success).toBe(false);
   });


### PR DESCRIPTION
## Summary

`POST /orgs/rag/score` now accepts `brandIds: string[]` (1..5) natively. Replaces the journalists-quotes-service per-brand loop + arithmetic-mean aggregate (shipped today in v0.8.1) with one HTTP call → one consolidated embedding → one score per document.

- Schema: `brandIds: string[]` OR legacy `brandId: string`. Cross-field refine — at least one required, `brandIds` wins when both. Cap 5 brandIds.
- Handler: canonical-sort brandIds ascending; pass array to `extractBrandFields` (already accepts array — brand-service consolidates `fields[key].value` across input brands); cache key = canonical CSV.
- Cache: existing `brand_id text` column repurposed for canonical sorted CSV. **No migration.** Single-brand path stays byte-identical (column holds just the UUID, matches legacy rows).
- Response: `brandIds: string[]` always present, canonical-sorted. Legacy `brandId` echo preserved when N=1 so existing single-brand consumers see the same shape.
- README + `openapi.json` regenerated.

Linear: DIS-67 (follow-up to DIS-66 / journalists-quotes-service v0.8.1).

## Test plan

- [x] `npm run build` — TypeScript clean, OpenAPI regenerated
- [x] `npm run test:unit` — 582 passed (rag-score-schema +7 multi-brand cases)
- [ ] CI integration tests — Neon PR branch provisioned + `npm run test:integration` (5 new cases: single-brand response shape, multi-brand happy path with canonical-sort assertion, cross-order cache hit, brandIds-wins precedence, missing-both → 400)
- [ ] post-merge smoke: existing journalists-quotes-service per-brand loop continues to work (legacy `brandId` path unchanged)

## Back-compat

- Single-brand legacy `brandId: "uuid"` still accepted on the wire.
- Outbound api-service body unchanged for N=1 (already `brandIds: [brandId]` per commit 26d6628).
- Cache table column shape unchanged; single-brand rows pre-deploy remain valid.
- Response shape additive only (`brandIds` field added; `brandId` echo preserved for N=1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)