### PR TITLE
feat(rag): provision→authorize→actualize embedding cost, fail loud

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,14 @@ The cache automatically invalidates when **any** resolved brand field changes (t
 
 The Gemini embedding model defaults to `gemini-embedding-001` and is overridable via `GEMINI_EMBEDDING_MODEL`. Key resolution uses the standard `google` provider in key-service.
 
-**Cost reporting:** every call reports embedding input-token spend to runs-service under the call's run, as cost name `google-embedding-001-tokens-input` (matches the costs-service catalog; `costSource` is `org` or `platform` per the resolved key). Tokens are estimated at ~4 chars/token because Gemini `batchEmbedContents` returns no usage metadata. A cache hit on the brand-profile vector reports only the document tokens; a miss also includes the synthesized-query tokens. Errors that exit before embedding (validation `400`, brand `404`, key-resolve `502`) report no cost.
+**Cost handling (provision → authorize → execute → actualize):** the embedding spend is reserved **before** the Gemini call, never after. The flow per request:
+
+1. **Provision** — `POST /v1/runs/{id}/costs` with `status: "provisioned"`, cost name `google-embedding-001-tokens-input` (byte-equal to the costs-service catalog; `costSource` is `org`/`platform` per the resolved key), `quantity` = input-token estimate (~4 chars/token; a cache hit on the brand-profile vector excludes the query tokens, a miss includes them).
+2. **Authorize** — platform-key spend is checked against billing-service (`/v1/customer_balance/authorize`); BYOK/org keys skip this.
+3. **Execute** — the Gemini embed runs only after 1 + 2 succeed.
+4. **Actualize / cancel** — the provisioned cost is set to `actual` on success, or `cancelled` if the embed fails.
+
+**Fail loud:** any provision/authorize/actualize failure returns an error and skips (or aborts) the spend — `502` on a runs-service `422 Unknown cost name` or downstream error, `402` (`Insufficient credits`) when billing rejects a platform-key request. A cost that cannot be declared perfectly blocks the operation rather than under-reporting silently. Errors that exit before provisioning (validation `400`, brand `404`, key-resolve `502`) reserve nothing.
 
 ## RAG Embed (`/orgs/rag/embed`)
 
@@ -427,7 +434,7 @@ No vector storage, no similarity, no caching — callers persist and compare vec
 
 **Volume:** designed for batches of up to **100** documents per request, **8000** characters per text. Larger inputs must be chunked or truncated by the caller.
 
-**Cost reporting:** reports embedding input-token spend to runs-service under the call's run, as cost name `google-embedding-001-tokens-input` (matches the costs-service catalog; `costSource` is `org` or `platform` per the resolved key). Tokens are estimated at ~4 chars/token. Early-exit paths (validation `400`, key-resolve `502`) report no cost.
+**Cost handling:** same **provision → authorize → execute → actualize** flow as `/orgs/rag/score` (see above). The embedding cost (`google-embedding-001-tokens-input`, quantity = document input-token estimate) is provisioned in runs-service and authorized against billing (platform keys) **before** the Gemini call; actualized on success, cancelled on failure. Any cost-declaration failure fails loud (`502`, or `402` on insufficient credits) — the spend is never made if the cost cannot be declared. Early-exit paths (validation `400`, key-resolve `502`) reserve nothing.
 
 Determinism: Gemini `gemini-embedding-001` is deterministic for identical input texts under stable model versions, but Google does not contractually guarantee bit-exact output across server-side updates. Callers that depend on stable vectors over time should re-embed after a model version change.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ import {
 } from "./lib/workflow-client.js";
 import { getPromptTemplate, updatePromptTemplate } from "./lib/content-generation-client.js";
 import { listServices, listServiceEndpoints } from "./lib/api-registry-client.js";
-import { createRun, updateRunStatus, addRunCosts, type CostItem } from "./lib/runs-client.js";
+import { createRun, updateRunStatus, addRunCosts, updateRunCostStatus, type CostItem, type RunIdentityHeaders } from "./lib/runs-client.js";
 import { traceEvent } from "./lib/trace-event.js";
 import { createFeature, updateFeature, listFeatures, getFeature, getFeatureInputs, prefillFeature, getFeatureStats } from "./lib/features-client.js";
 import { extractBrandFields, BrandError } from "./lib/brand-client.js";
@@ -526,6 +526,102 @@ function buildBrandProfileQuery(fields: Record<string, string>): string {
   return lines.join("\n");
 }
 
+/** Thrown when billing reports the org cannot afford a platform-key spend. */
+class InsufficientCreditsError extends Error {
+  constructor(
+    public readonly balanceCents: string | number,
+    public readonly requiredCents: string | number,
+  ) {
+    super("Insufficient credits");
+    this.name = "InsufficientCreditsError";
+  }
+}
+
+/**
+ * PROVISION (runs ledger) then AUTHORIZE (billing affordability, platform keys only)
+ * an embedding spend BEFORE the Gemini call. Returns the provisioned cost id to
+ * actualize/cancel later, or null when there is nothing to charge (inputTokens <= 0).
+ *
+ * Throws on any failure so the caller fails loud — never spend on an undeclarable or
+ * unaffordable cost. Releases (cancels) the provision if authorization fails.
+ */
+async function provisionAndAuthorizeEmbeddingCost(args: {
+  runId: string;
+  inputTokens: number;
+  keySource: "org" | "platform";
+  identity: RunIdentityHeaders;
+  trackingHeaders: Record<string, string>;
+  description: string;
+}): Promise<string | null> {
+  const { runId, inputTokens, keySource, identity, trackingHeaders, description } = args;
+  if (inputTokens <= 0) return null;
+
+  const costName = `${embeddingCostPrefix(DEFAULT_EMBEDDING_MODEL)}-tokens-input`;
+
+  // 1. PROVISION — reserve in the runs ledger; validates the cost name is declarable
+  //    (runs-service 422s an unknown cost name → throws → caller 502s, no spend).
+  const items: CostItem[] = [
+    { costName, quantity: inputTokens, costSource: keySource, status: "provisioned" },
+  ];
+  const costs = await addRunCosts(runId, items, identity, trackingHeaders);
+  const costId = costs[0]?.id;
+  if (!costId) {
+    throw new Error("[rag] provision returned no cost id");
+  }
+
+  // 2. AUTHORIZE — affordability, platform-key spend only (BYOK pays the provider directly).
+  if (keySource === "platform") {
+    try {
+      const auth = await authorizeCredits({
+        items: [{ costName, quantity: inputTokens }],
+        description,
+        orgId: identity.orgId,
+        userId: identity.userId,
+        runId,
+        trackingHeaders: Object.keys(trackingHeaders).length > 0 ? trackingHeaders : undefined,
+      });
+      if (!auth.sufficient) {
+        await updateRunCostStatus(runId, costId, "cancelled", identity, trackingHeaders).catch((e) =>
+          console.error(`[rag] cancel after insufficient credits failed runId="${runId}":`, e),
+        );
+        throw new InsufficientCreditsError(auth.balance_cents, auth.required_cents);
+      }
+    } catch (err) {
+      if (err instanceof InsufficientCreditsError) throw err;
+      // Billing call itself failed — release the reservation, then rethrow.
+      await updateRunCostStatus(runId, costId, "cancelled", identity, trackingHeaders).catch((e) =>
+        console.error(`[rag] cancel after billing error failed runId="${runId}":`, e),
+      );
+      throw err;
+    }
+  }
+
+  return costId;
+}
+
+/** Map a provision/authorize failure to an HTTP status + body. */
+function costErrorResponse(
+  err: unknown,
+  tag: string,
+  orgId: string,
+): { status: number; body: Record<string, unknown> } {
+  if (err instanceof InsufficientCreditsError) {
+    console.warn(
+      `[${tag}] insufficient credits: org="${orgId}" balance_cents=${err.balanceCents} required_cents=${err.requiredCents}`,
+    );
+    return {
+      status: 402,
+      body: { error: "Insufficient credits", balance_cents: err.balanceCents, required_cents: err.requiredCents },
+    };
+  }
+  if (err instanceof BillingError && err.isClientError) {
+    console.error(`[${tag}] billing authorization rejected for org="${orgId}":`, err);
+    return { status: err.statusCode, body: { error: `Billing authorization rejected: ${err.upstreamBody}` } };
+  }
+  console.error(`[${tag}] cost provision/authorize failed for org="${orgId}":`, err);
+  return { status: 502, body: { error: "Cost authorization failed. Please try again." } };
+}
+
 app.post("/orgs/rag/score", requireAuth, async (req, res) => {
   const { orgId, userId, parentRunId, workflowTracking } = res.locals as AuthLocals;
 
@@ -587,10 +683,9 @@ app.post("/orgs/rag/score", requireAuth, async (req, res) => {
   }
 
   let scoreFailed = false;
-  // Embedding-cost accounting (reported in finally). Hoisted to handler scope
-  // because resolvedKey / docTexts live inside the try and are invisible there.
-  let embedInputTokens = 0;
-  let embedKeySource: "org" | "platform" | null = null;
+  // Embedding cost is provisioned before the Gemini call and actualized/cancelled
+  // after. Hoisted so the catch can release (cancel) a provision if the embed throws.
+  let provisionedCostId: string | null = null;
   try {
     // Resolve joint brand context. Pass own runId so brand-service sees us as the parent.
     // For multi-brand, brand-service consolidates field values across all brandIds and
@@ -662,11 +757,8 @@ app.post("/orgs/rag/score", requireAuth, async (req, res) => {
         error: "Failed to resolve google API key. Ensure the key is configured in key-service.",
       });
     }
-    embedKeySource = resolvedKey.keySource;
-
-    // Cache lookup
-    let queryEmbedding: number[];
-    let cacheHit = false;
+    // Cache lookup — determine hit WITHOUT embedding yet. The embedding cost must be
+    // provisioned + authorized before any Gemini call.
     const cached = await db
       .select()
       .from(brandProfileEmbeddings)
@@ -678,14 +770,35 @@ app.post("/orgs/rag/score", requireAuth, async (req, res) => {
         ),
       )
       .limit(1);
+    const cacheHit = cached.length > 0;
 
-    if (cached.length > 0) {
+    const docTexts = documents.map((d) => d.text);
+    // Tokens are known from the inputs: the query embeds only on a cache miss; docs always.
+    const embedInputTokens =
+      (cacheHit ? 0 : estimateTokens([queryText])) + estimateTokens(docTexts);
+
+    // PROVISION (runs ledger) → AUTHORIZE (billing, platform keys) BEFORE the Gemini spend.
+    try {
+      provisionedCostId = await provisionAndAuthorizeEmbeddingCost({
+        runId,
+        inputTokens: embedInputTokens,
+        keySource: resolvedKey.keySource,
+        identity: { orgId, userId, runId },
+        trackingHeaders,
+        description: `rag-score — ${DEFAULT_EMBEDDING_MODEL}`,
+      });
+    } catch (costErr) {
+      scoreFailed = true;
+      const r = costErrorResponse(costErr, "rag-score", orgId);
+      return res.status(r.status).json(r.body);
+    }
+
+    // EXECUTE — embed now that the cost is provisioned + authorized.
+    let queryEmbedding: number[];
+    if (cacheHit) {
       queryEmbedding = cached[0].embedding;
-      cacheHit = true;
     } else {
       queryEmbedding = await embedText(resolvedKey.key, queryText);
-      // Only a cache miss embeds the query; a hit reuses the stored vector at no cost.
-      embedInputTokens += estimateTokens([queryText]);
       // Race-safe insert: another concurrent request may have already populated it.
       await db
         .insert(brandProfileEmbeddings)
@@ -706,11 +819,7 @@ app.post("/orgs/rag/score", requireAuth, async (req, res) => {
         });
     }
 
-    // Embed documents in batch
-    const docTexts = documents.map((d) => d.text);
     const docEmbeddings = await embedTexts(resolvedKey.key, docTexts);
-    // Documents are always embedded fresh (no doc cache), so always metered.
-    embedInputTokens += estimateTokens(docTexts);
 
     // Score
     const scored = documents.map((d, i) => {
@@ -720,6 +829,26 @@ app.post("/orgs/rag/score", requireAuth, async (req, res) => {
       return { id: d.id, score };
     });
     scored.sort((a, b) => b.score - a.score);
+
+    // ACTUALIZE the provisioned cost. Fail loud on failure, but leave the row
+    // `provisioned` — the embedding already happened, so never cancel a paid spend.
+    if (provisionedCostId) {
+      try {
+        await updateRunCostStatus(
+          runId,
+          provisionedCostId,
+          "actual",
+          { orgId, userId, runId },
+          trackingHeaders,
+        );
+      } catch (actErr) {
+        scoreFailed = true;
+        provisionedCostId = null;
+        console.error(`[rag-score] cost actualize failed runId="${runId}" orgId="${orgId}":`, actErr);
+        return res.status(502).json({ error: "Cost finalization failed. Please try again." });
+      }
+      provisionedCostId = null;
+    }
 
     if (runId) {
       traceEvent(runId, "rag-score-done", { orgId, userId }, workflowTracking, {
@@ -744,6 +873,19 @@ app.post("/orgs/rag/score", requireAuth, async (req, res) => {
     });
   } catch (err) {
     scoreFailed = true;
+    // Embedding/scoring threw AFTER provisioning → release the reservation (no spend completed).
+    if (runId && provisionedCostId) {
+      await updateRunCostStatus(
+        runId,
+        provisionedCostId,
+        "cancelled",
+        { orgId, userId, runId },
+        trackingHeaders,
+      ).catch((cancelErr) =>
+        console.error(`[rag-score] cost cancel failed runId="${runId}" orgId="${orgId}":`, cancelErr),
+      );
+      provisionedCostId = null;
+    }
     console.error(`[rag-score] org="${orgId}" brands="${brandCacheKey}" error:`, err);
     if (runId) {
       traceEvent(runId, "rag-score-failed", { orgId, userId }, workflowTracking, {
@@ -756,35 +898,16 @@ app.post("/orgs/rag/score", requireAuth, async (req, res) => {
       error: "RAG score failed. Please try again.",
     });
   } finally {
+    // Costs are provisioned/actualized/cancelled inline above — the finally only
+    // closes the run status (best-effort run tracking, distinct from cost integrity).
     if (runId) {
-      const runIdentity = { orgId, userId, runId };
-      // Report embedding spend (input tokens) under this run. Resolve the cost
-      // name in its own guard so an unmapped-model throw can never skip the
-      // status finalization below.
-      let costItems: CostItem[] = [];
-      if (embedInputTokens > 0 && embedKeySource) {
-        try {
-          costItems = [
-            {
-              costName: `${embeddingCostPrefix(DEFAULT_EMBEDDING_MODEL)}-tokens-input`,
-              quantity: embedInputTokens,
-              costSource: embedKeySource,
-            },
-          ];
-        } catch (prefixErr) {
-          console.error(`[rag-score] embedding cost prefix unresolved:`, prefixErr);
-        }
-      }
       try {
-        await Promise.all([
-          updateRunStatus(
-            runId,
-            scoreFailed ? "failed" : "completed",
-            runIdentity,
-            trackingHeaders,
-          ),
-          addRunCosts(runId, costItems, runIdentity, trackingHeaders),
-        ]);
+        await updateRunStatus(
+          runId,
+          scoreFailed ? "failed" : "completed",
+          { orgId, userId, runId },
+          trackingHeaders,
+        );
       } catch (runErr) {
         console.error(
           `[rag-score] failed to finalize run runId="${runId}" orgId="${orgId}":`,
@@ -840,10 +963,9 @@ app.post("/orgs/rag/embed", requireAuth, async (req, res) => {
   }
 
   let embedFailed = false;
-  // Embedding-cost accounting (reported in finally). Hoisted to handler scope
-  // because resolvedKey / docTexts live inside the try and are invisible there.
-  let embedInputTokens = 0;
-  let embedKeySource: "org" | "platform" | null = null;
+  // Embedding cost is provisioned before the Gemini call and actualized/cancelled
+  // after. Hoisted so the catch can release (cancel) a provision if the embed throws.
+  let provisionedCostId: string | null = null;
   try {
     let resolvedKey;
     try {
@@ -861,11 +983,27 @@ app.post("/orgs/rag/embed", requireAuth, async (req, res) => {
         error: "Failed to resolve google API key. Ensure the key is configured in key-service.",
       });
     }
-    embedKeySource = resolvedKey.keySource;
-
     const docTexts = documents.map((d) => d.text);
+    const embedInputTokens = estimateTokens(docTexts);
+
+    // PROVISION (runs ledger) → AUTHORIZE (billing, platform keys) BEFORE the Gemini spend.
+    try {
+      provisionedCostId = await provisionAndAuthorizeEmbeddingCost({
+        runId,
+        inputTokens: embedInputTokens,
+        keySource: resolvedKey.keySource,
+        identity: { orgId, userId, runId },
+        trackingHeaders,
+        description: `rag-embed — ${DEFAULT_EMBEDDING_MODEL}`,
+      });
+    } catch (costErr) {
+      embedFailed = true;
+      const r = costErrorResponse(costErr, "rag-embed", orgId);
+      return res.status(r.status).json(r.body);
+    }
+
+    // EXECUTE — embed now that the cost is provisioned + authorized.
     const docEmbeddings = await embedTexts(resolvedKey.key, docTexts);
-    embedInputTokens += estimateTokens(docTexts);
 
     if (docEmbeddings.length !== documents.length) {
       throw new Error(
@@ -877,6 +1015,26 @@ app.post("/orgs/rag/embed", requireAuth, async (req, res) => {
       id: d.id,
       embedding: docEmbeddings[i],
     }));
+
+    // ACTUALIZE the provisioned cost. Fail loud on failure, but leave the row
+    // `provisioned` — the embedding already happened, so never cancel a paid spend.
+    if (provisionedCostId) {
+      try {
+        await updateRunCostStatus(
+          runId,
+          provisionedCostId,
+          "actual",
+          { orgId, userId, runId },
+          trackingHeaders,
+        );
+      } catch (actErr) {
+        embedFailed = true;
+        provisionedCostId = null;
+        console.error(`[rag-embed] cost actualize failed runId="${runId}" orgId="${orgId}":`, actErr);
+        return res.status(502).json({ error: "Cost finalization failed. Please try again." });
+      }
+      provisionedCostId = null;
+    }
 
     if (runId) {
       traceEvent(runId, "rag-embed-done", { orgId, userId }, workflowTracking, {
@@ -894,6 +1052,19 @@ app.post("/orgs/rag/embed", requireAuth, async (req, res) => {
     });
   } catch (err) {
     embedFailed = true;
+    // Embedding threw AFTER provisioning → release the reservation (no spend completed).
+    if (runId && provisionedCostId) {
+      await updateRunCostStatus(
+        runId,
+        provisionedCostId,
+        "cancelled",
+        { orgId, userId, runId },
+        trackingHeaders,
+      ).catch((cancelErr) =>
+        console.error(`[rag-embed] cost cancel failed runId="${runId}" orgId="${orgId}":`, cancelErr),
+      );
+      provisionedCostId = null;
+    }
     console.error(`[rag-embed] org="${orgId}" error:`, err);
     if (runId) {
       traceEvent(runId, "rag-embed-failed", { orgId, userId }, workflowTracking, {
@@ -906,35 +1077,16 @@ app.post("/orgs/rag/embed", requireAuth, async (req, res) => {
       error: "RAG embed failed. Please try again.",
     });
   } finally {
+    // Costs are provisioned/actualized/cancelled inline above — the finally only
+    // closes the run status (best-effort run tracking, distinct from cost integrity).
     if (runId) {
-      const runIdentity = { orgId, userId, runId };
-      // Report embedding spend (input tokens) under this run. Resolve the cost
-      // name in its own guard so an unmapped-model throw can never skip the
-      // status finalization below.
-      let costItems: CostItem[] = [];
-      if (embedInputTokens > 0 && embedKeySource) {
-        try {
-          costItems = [
-            {
-              costName: `${embeddingCostPrefix(DEFAULT_EMBEDDING_MODEL)}-tokens-input`,
-              quantity: embedInputTokens,
-              costSource: embedKeySource,
-            },
-          ];
-        } catch (prefixErr) {
-          console.error(`[rag-embed] embedding cost prefix unresolved:`, prefixErr);
-        }
-      }
       try {
-        await Promise.all([
-          updateRunStatus(
-            runId,
-            embedFailed ? "failed" : "completed",
-            runIdentity,
-            trackingHeaders,
-          ),
-          addRunCosts(runId, costItems, runIdentity, trackingHeaders),
-        ]);
+        await updateRunStatus(
+          runId,
+          embedFailed ? "failed" : "completed",
+          { orgId, userId, runId },
+          trackingHeaders,
+        );
       } catch (runErr) {
         console.error(
           `[rag-embed] failed to finalize run runId="${runId}" orgId="${orgId}":`,

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -27,6 +27,21 @@ export interface CostItem {
   costName: string;
   quantity: number;
   costSource: "platform" | "org";
+  /** Defaults to "actual" server-side. Use "provisioned" to reserve before a costly op. */
+  status?: "actual" | "provisioned" | "cancelled";
+}
+
+export interface RunCost {
+  id: string;
+  runId: string;
+  costName: string;
+  costSource: "platform" | "org";
+  quantity: string;
+  unitCostInUsdCents: string;
+  totalCostInUsdCents: string;
+  status: "actual" | "provisioned" | "cancelled";
+  idempotencyKey: string | null;
+  createdAt: string;
 }
 
 export interface TrackingHeaders {
@@ -101,7 +116,34 @@ export async function addRunCosts(
   items: CostItem[],
   identity: RunIdentityHeaders,
   trackingHeaders?: TrackingHeaders,
-): Promise<void> {
-  if (items.length === 0) return;
-  await runsRequest("POST", `/v1/runs/${id}/costs`, identity, { items }, trackingHeaders);
+): Promise<RunCost[]> {
+  if (items.length === 0) return [];
+  const res = await runsRequest<{ costs: RunCost[] }>(
+    "POST",
+    `/v1/runs/${id}/costs`,
+    identity,
+    { items },
+    trackingHeaders,
+  );
+  return res.costs;
+}
+
+/**
+ * Realize ("actual") or release ("cancelled") a previously provisioned cost.
+ * Throws on non-2xx (fail loud — a stuck provisioned cost under-reports spend).
+ */
+export async function updateRunCostStatus(
+  runId: string,
+  costId: string,
+  status: "actual" | "cancelled",
+  identity: RunIdentityHeaders,
+  trackingHeaders?: TrackingHeaders,
+): Promise<RunCost> {
+  return runsRequest<RunCost>(
+    "PATCH",
+    `/v1/runs/${runId}/costs/${costId}`,
+    identity,
+    { status },
+    trackingHeaders,
+  );
 }

--- a/tests/integration/rag-embed.test.ts
+++ b/tests/integration/rag-embed.test.ts
@@ -10,6 +10,8 @@ process.env.ADMIN_DISTRIBUTE_API_KEY = process.env.ADMIN_DISTRIBUTE_API_KEY || "
 process.env.API_SERVICE_URL = process.env.API_SERVICE_URL || "https://api.test.local";
 process.env.RUNS_SERVICE_API_KEY = process.env.RUNS_SERVICE_API_KEY || "test-runs-key";
 process.env.RUNS_SERVICE_URL = process.env.RUNS_SERVICE_URL || "https://runs.test.local";
+process.env.BILLING_SERVICE_API_KEY = process.env.BILLING_SERVICE_API_KEY || "test-billing-key";
+process.env.BILLING_SERVICE_URL = process.env.BILLING_SERVICE_URL || "https://billing.test.local";
 
 interface MockRoute {
   match: (url: string, init?: RequestInit) => boolean;
@@ -73,33 +75,69 @@ function mockRunsCreate(returnRunId: string, capture?: { headers?: Record<string
   } satisfies MockRoute;
 }
 
-// Finalization: PATCH /v1/runs/:id (status) AND POST /v1/runs/:id/costs (embedding
-// cost). Absorbs both so embedding tests don't hit an unmocked fetch in finally.
+// Run-status PATCH /v1/runs/:id AND cost-status PATCH /v1/runs/:id/costs/:costId
+// (actualize/cancel). Absorbs both so tests that don't assert them don't hit an
+// unmocked fetch.
 function mockRunsPatch() {
   return {
     match: (url: string, init?: RequestInit) => {
       const method = init?.method ?? "GET";
       return (
         (/\/v1\/runs\/[^/]+$/.test(url) && method === "PATCH") ||
-        (/\/v1\/runs\/[^/]+\/costs$/.test(url) && method === "POST")
+        (/\/v1\/runs\/[^/]+\/costs\/[^/]+$/.test(url) && method === "PATCH")
       );
     },
-    respond: () => ({ ok: true, body: { id: "ok" } }),
+    respond: () => ({ ok: true, body: { id: "ok", status: "actual" } }),
   } satisfies MockRoute;
 }
 
-// Capturing variant for asserting the embedding-cost payload. Push BEFORE
-// mockRunsPatch so it wins the POST /costs match.
-function mockRunsCosts(capture: { items?: unknown[]; calls: number }) {
+// PROVISION: POST /v1/runs/:id/costs. Returns created cost row(s) WITH an id so the
+// handler can actualize/cancel later. Captures the provisioned items. `status` lets a
+// test force a runs-service rejection (e.g. 422 unknown cost name).
+function mockRunsProvision(capture?: { items?: unknown[]; calls: number }, opts?: { status?: number; body?: unknown }) {
   return {
     match: (url: string, init?: RequestInit) =>
       /\/v1\/runs\/[^/]+\/costs$/.test(url) && (init?.method ?? "GET") === "POST",
     respond: (_url: string, init?: RequestInit) => {
-      capture.calls += 1;
-      if (init?.body) {
-        capture.items = (JSON.parse(init.body as string) as { items: unknown[] }).items;
+      const items = init?.body ? (JSON.parse(init.body as string) as { items: unknown[] }).items : [];
+      if (capture) {
+        capture.calls += 1;
+        capture.items = items;
       }
-      return { ok: true, body: { ok: true } };
+      if (opts?.status && opts.status >= 400) {
+        return { ok: false, status: opts.status, body: opts.body ?? { error: "Unknown cost name" } };
+      }
+      return {
+        ok: true,
+        status: 201,
+        body: { costs: items.map((it, i) => ({ id: `cost-${i}`, ...(it as object) })) },
+      };
+    },
+  } satisfies MockRoute;
+}
+
+// PATCH /v1/runs/:id/costs/:costId — capture actualize/cancel status transitions.
+function mockRunsCostStatus(capture: { statuses: string[] }) {
+  return {
+    match: (url: string, init?: RequestInit) =>
+      /\/v1\/runs\/[^/]+\/costs\/[^/]+$/.test(url) && (init?.method ?? "GET") === "PATCH",
+    respond: (_url: string, init?: RequestInit) => {
+      const body = init?.body ? (JSON.parse(init.body as string) as { status: string }) : { status: "?" };
+      capture.statuses.push(body.status);
+      return { ok: true, body: { id: "cost-0", status: body.status } };
+    },
+  } satisfies MockRoute;
+}
+
+// Billing affordability check (platform keys). Defaults to sufficient.
+function mockBillingAuthorize(opts?: { sufficient?: boolean; capture?: { calls: number } }) {
+  const sufficient = opts?.sufficient ?? true;
+  return {
+    match: (url: string, init?: RequestInit) =>
+      url.includes("/v1/customer_balance/authorize") && (init?.method ?? "GET") === "POST",
+    respond: () => {
+      if (opts?.capture) opts.capture.calls += 1;
+      return { ok: true, body: { sufficient, balance_cents: "100000", required_cents: "1" } };
     },
   } satisfies MockRoute;
 }
@@ -174,7 +212,7 @@ describe("POST /orgs/rag/embed", { timeout: 30_000 }, () => {
     };
   }
 
-  it("returns 3 embeddings in input order, ids preserved 1:1, dimensionality matches mock", async () => {
+  it("provisions → authorizes → embeds → actualizes; returns 3 embeddings in input order", async () => {
     const orgId = `org-${crypto.randomUUID()}`;
     const ownRunId = crypto.randomUUID();
     const parentRunId = crypto.randomUUID();
@@ -188,10 +226,14 @@ describe("POST /orgs/rag/embed", { timeout: 30_000 }, () => {
     const embedCapture = { calls: 0, bodies: [] as unknown[] };
     const runsCapture = { headers: undefined as Record<string, string> | undefined };
     const costCapture = { items: undefined as unknown[] | undefined, calls: 0 };
+    const billingCapture = { calls: 0 };
+    const statusCapture = { statuses: [] as string[] };
 
     routes.push(mockRunsCreate(ownRunId, runsCapture));
-    routes.push(mockRunsCosts(costCapture));
+    routes.push(mockRunsProvision(costCapture));
+    routes.push(mockRunsCostStatus(statusCapture));
     routes.push(mockRunsPatch());
+    routes.push(mockBillingAuthorize({ capture: billingCapture }));
     routes.push(mockKeyServiceDecrypt());
     routes.push(mockGeminiBatchEmbed(docVectors, embedCapture));
 
@@ -208,33 +250,41 @@ describe("POST /orgs/rag/embed", { timeout: 30_000 }, () => {
 
     expect(res.status).toBe(200);
     expect(res.body.model).toBe("gemini-embedding-001");
-    expect(res.body.results).toHaveLength(3);
-    expect(res.body.results.map((r: { id: string }) => r.id)).toEqual([
-      "alpha",
-      "beta",
-      "gamma",
-    ]);
+    expect(res.body.results.map((r: { id: string }) => r.id)).toEqual(["alpha", "beta", "gamma"]);
     for (let i = 0; i < 3; i++) {
       expect(res.body.results[i].embedding).toEqual(docVectors[i]);
-      expect(res.body.results[i].embedding).toHaveLength(4);
     }
 
     expect(embedCapture.calls).toBe(1);
-    expect((embedCapture.bodies[0] as { requests: unknown[] }).requests).toHaveLength(3);
-
     expect(runsCapture.headers?.["x-run-id"]).toBe(parentRunId);
 
-    // Embedding spend reported under the run: input tokens, costs-service catalog
-    // name (google-*), costSource derived from the resolved (platform) key.
+    // PROVISION: cost reserved with status "provisioned", google-* catalog name,
+    // costSource from the (platform) key, quantity from input tokens.
     expect(costCapture.items).toHaveLength(1);
     const costItem = costCapture.items![0] as {
       costName: string;
       quantity: number;
       costSource: string;
+      status: string;
     };
     expect(costItem.costName).toBe("google-embedding-001-tokens-input");
     expect(costItem.costSource).toBe("platform");
     expect(costItem.quantity).toBeGreaterThan(0);
+    expect(costItem.status).toBe("provisioned");
+
+    // AUTHORIZE: billing called once (platform key).
+    expect(billingCapture.calls).toBe(1);
+
+    // ACTUALIZE: the provisioned cost is realized to "actual" (no cancel).
+    expect(statusCapture.statuses).toEqual(["actual"]);
+
+    // ORDER: provision happens BEFORE the Gemini embed (never spend on an undeclarable cost).
+    const provisionIdx = fetchCalls.findIndex(
+      (c) => /\/v1\/runs\/[^/]+\/costs$/.test(c.url) && (c.init?.method ?? "GET") === "POST",
+    );
+    const embedIdx = fetchCalls.findIndex((c) => c.url.includes(":batchEmbedContents"));
+    expect(provisionIdx).toBeGreaterThanOrEqual(0);
+    expect(embedIdx).toBeGreaterThan(provisionIdx);
   });
 
   it("same input twice returns identical vectors when provider is deterministic", async () => {
@@ -246,7 +296,9 @@ describe("POST /orgs/rag/embed", { timeout: 30_000 }, () => {
       fetchCalls = [];
       installFetchMock();
       routes.push(mockRunsCreate(crypto.randomUUID()));
+      routes.push(mockRunsProvision());
       routes.push(mockRunsPatch());
+      routes.push(mockBillingAuthorize());
       routes.push(mockKeyServiceDecrypt());
       routes.push(mockGeminiBatchEmbed([fixedVector]));
     };
@@ -283,7 +335,7 @@ describe("POST /orgs/rag/embed", { timeout: 30_000 }, () => {
     const orgId = `org-${crypto.randomUUID()}`;
     const costCapture = { items: undefined as unknown[] | undefined, calls: 0 };
     routes.push(mockRunsCreate(crypto.randomUUID()));
-    routes.push(mockRunsCosts(costCapture));
+    routes.push(mockRunsProvision(costCapture));
     routes.push(mockRunsPatch());
 
     const docs = Array.from({ length: 101 }, (_, i) => ({ id: `d-${i}`, text: "x" }));
@@ -294,7 +346,7 @@ describe("POST /orgs/rag/embed", { timeout: 30_000 }, () => {
 
     expect(res.status).toBe(400);
     expect(JSON.stringify(res.body)).toMatch(/at most/);
-    // No embedding happened → no cost reported (addRunCosts no-ops on empty items).
+    // Validation fails before provisioning → no cost reserved.
     expect(costCapture.calls).toBe(0);
   });
 
@@ -325,5 +377,73 @@ describe("POST /orgs/rag/embed", { timeout: 30_000 }, () => {
 
     expect(res.status).toBe(502);
     expect(res.body.error).toMatch(/google API key/);
+  });
+
+  it("fails loud (502) and does NOT embed when provision is rejected (unknown cost name)", async () => {
+    const orgId = `org-${crypto.randomUUID()}`;
+    const embedCapture = { calls: 0, bodies: [] as unknown[] };
+    routes.push(mockRunsCreate(crypto.randomUUID()));
+    routes.push(mockRunsProvision(undefined, { status: 422, body: { error: "Unknown cost name" } }));
+    routes.push(mockRunsPatch());
+    routes.push(mockBillingAuthorize());
+    routes.push(mockKeyServiceDecrypt());
+    routes.push(mockGeminiBatchEmbed([[1, 0]], embedCapture));
+
+    const res = await request(app)
+      .post("/orgs/rag/embed")
+      .set(authHeaders(orgId, crypto.randomUUID()))
+      .send({ documents: [{ id: "x", text: "hello" }] });
+
+    expect(res.status).toBe(502);
+    // The costly Gemini call must NOT happen when the cost can't be declared.
+    expect(embedCapture.calls).toBe(0);
+  });
+
+  it("returns 402 and does NOT embed when billing reports insufficient credits", async () => {
+    const orgId = `org-${crypto.randomUUID()}`;
+    const embedCapture = { calls: 0, bodies: [] as unknown[] };
+    const statusCapture = { statuses: [] as string[] };
+    routes.push(mockRunsCreate(crypto.randomUUID()));
+    routes.push(mockRunsProvision());
+    routes.push(mockRunsCostStatus(statusCapture));
+    routes.push(mockRunsPatch());
+    routes.push(mockBillingAuthorize({ sufficient: false }));
+    routes.push(mockKeyServiceDecrypt());
+    routes.push(mockGeminiBatchEmbed([[1, 0]], embedCapture));
+
+    const res = await request(app)
+      .post("/orgs/rag/embed")
+      .set(authHeaders(orgId, crypto.randomUUID()))
+      .send({ documents: [{ id: "x", text: "hello" }] });
+
+    expect(res.status).toBe(402);
+    expect(res.body.error).toMatch(/Insufficient credits/);
+    // No spend, and the provisioned reservation is released.
+    expect(embedCapture.calls).toBe(0);
+    expect(statusCapture.statuses).toContain("cancelled");
+  });
+
+  it("cancels the provisioned cost when the embedding call fails", async () => {
+    const orgId = `org-${crypto.randomUUID()}`;
+    const statusCapture = { statuses: [] as string[] };
+    routes.push(mockRunsCreate(crypto.randomUUID()));
+    routes.push(mockRunsProvision());
+    routes.push(mockRunsCostStatus(statusCapture));
+    routes.push(mockRunsPatch());
+    routes.push(mockBillingAuthorize());
+    routes.push(mockKeyServiceDecrypt());
+    // Gemini returns a non-retryable 400 → embedTexts throws → handler cancels + 502.
+    routes.push({
+      match: (url: string) => url.includes(":batchEmbedContents"),
+      respond: () => ({ ok: false, status: 400, body: "bad request" }),
+    });
+
+    const res = await request(app)
+      .post("/orgs/rag/embed")
+      .set(authHeaders(orgId, crypto.randomUUID()))
+      .send({ documents: [{ id: "x", text: "hello" }] });
+
+    expect(res.status).toBe(502);
+    expect(statusCapture.statuses).toContain("cancelled");
   });
 });

--- a/tests/integration/rag-score.test.ts
+++ b/tests/integration/rag-score.test.ts
@@ -14,6 +14,8 @@ process.env.ADMIN_DISTRIBUTE_API_KEY = process.env.ADMIN_DISTRIBUTE_API_KEY || "
 process.env.API_SERVICE_URL = process.env.API_SERVICE_URL || "https://api.test.local";
 process.env.RUNS_SERVICE_API_KEY = process.env.RUNS_SERVICE_API_KEY || "test-runs-key";
 process.env.RUNS_SERVICE_URL = process.env.RUNS_SERVICE_URL || "https://runs.test.local";
+process.env.BILLING_SERVICE_API_KEY = process.env.BILLING_SERVICE_API_KEY || "test-billing-key";
+process.env.BILLING_SERVICE_URL = process.env.BILLING_SERVICE_URL || "https://billing.test.local";
 
 const connectionString = process.env.CHAT_SERVICE_DATABASE_URL;
 
@@ -27,6 +29,17 @@ interface MockRoute {
 let routes: MockRoute[] = [];
 let fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
 
+function buildResponse(out: { ok: boolean; status?: number; body: unknown }): Response {
+  return {
+    ok: out.ok,
+    status: out.status ?? (out.ok ? 200 : 500),
+    json: () => Promise.resolve(out.body),
+    text: () =>
+      Promise.resolve(typeof out.body === "string" ? out.body : JSON.stringify(out.body)),
+    headers: new Headers(),
+  } as unknown as Response;
+}
+
 function installFetchMock() {
   vi.stubGlobal(
     "fetch",
@@ -35,18 +48,30 @@ function installFetchMock() {
       fetchCalls.push({ url, init });
       for (const route of routes) {
         if (route.match(url, init)) {
-          const out = await route.respond(url, init);
-          return {
-            ok: out.ok,
-            status: out.status ?? (out.ok ? 200 : 500),
-            json: () => Promise.resolve(out.body),
-            text: () =>
-              Promise.resolve(
-                typeof out.body === "string" ? out.body : JSON.stringify(out.body),
-              ),
-            headers: new Headers(),
-          } as unknown as Response;
+          return buildResponse(await route.respond(url, init));
         }
+      }
+      // Happy defaults for the cost/billing infra so the many tests that don't assert
+      // on them need no per-test mocks. Explicit routes above always win.
+      const method = init?.method ?? "GET";
+      if (/\/v1\/runs\/[^/]+\/costs$/.test(url) && method === "POST") {
+        const items = init?.body
+          ? (JSON.parse(init.body as string) as { items: Array<Record<string, unknown>> }).items
+          : [];
+        return buildResponse({
+          ok: true,
+          status: 201,
+          body: { costs: items.map((it, i) => ({ id: `cost-${i}`, ...it })) },
+        });
+      }
+      if (/\/v1\/runs\/[^/]+\/costs\/[^/]+$/.test(url) && method === "PATCH") {
+        return buildResponse({ ok: true, body: { id: "cost-0", status: "actual" } });
+      }
+      if (url.includes("/v1/customer_balance/authorize") && method === "POST") {
+        return buildResponse({
+          ok: true,
+          body: { sufficient: true, balance_cents: "100000", required_cents: "1" },
+        });
       }
       throw new Error(`[test] Unmocked fetch: ${url}`);
     }),
@@ -81,32 +106,64 @@ function mockRunsCreate(returnRunId: string, capture?: { headers?: Record<string
   } satisfies MockRoute;
 }
 
-// Finalization: PATCH /v1/runs/:id (status) AND POST /v1/runs/:id/costs (embedding
-// cost). Absorbs both so embedding tests don't hit an unmocked fetch in finally.
+// Run-status PATCH /v1/runs/:id AND cost-status PATCH /v1/runs/:id/costs/:costId
+// (actualize/cancel). Provision (POST /costs) + billing are handled by installFetchMock
+// happy-defaults, so most tests only push this for the run-status close.
 function mockRunsPatch() {
   return {
     match: (url: string, init?: RequestInit) => {
       const method = init?.method ?? "GET";
       return (
         (/\/v1\/runs\/[^/]+$/.test(url) && method === "PATCH") ||
-        (/\/v1\/runs\/[^/]+\/costs$/.test(url) && method === "POST")
+        (/\/v1\/runs\/[^/]+\/costs\/[^/]+$/.test(url) && method === "PATCH")
       );
     },
-    respond: () => ({ ok: true, body: { id: "ok" } }),
+    respond: () => ({ ok: true, body: { id: "ok", status: "actual" } }),
   } satisfies MockRoute;
 }
 
-// Capturing variant for asserting the embedding-cost payload. Push BEFORE
-// mockRunsPatch so it wins the POST /costs match.
-function mockRunsCosts(capture: { items?: unknown[] }) {
+// PROVISION capture (POST /v1/runs/:id/costs). Push BEFORE the default so it wins;
+// returns created cost row(s) WITH an id. `status` forces a runs-service rejection.
+function mockRunsProvision(capture?: { items?: unknown[]; calls: number }, opts?: { status?: number; body?: unknown }) {
   return {
     match: (url: string, init?: RequestInit) =>
       /\/v1\/runs\/[^/]+\/costs$/.test(url) && (init?.method ?? "GET") === "POST",
     respond: (_url: string, init?: RequestInit) => {
-      if (init?.body) {
-        capture.items = (JSON.parse(init.body as string) as { items: unknown[] }).items;
+      const items = init?.body ? (JSON.parse(init.body as string) as { items: unknown[] }).items : [];
+      if (capture) {
+        capture.calls += 1;
+        capture.items = items;
       }
-      return { ok: true, body: { ok: true } };
+      if (opts?.status && opts.status >= 400) {
+        return { ok: false, status: opts.status, body: opts.body ?? { error: "Unknown cost name" } };
+      }
+      return { ok: true, status: 201, body: { costs: items.map((it, i) => ({ id: `cost-${i}`, ...(it as object) })) } };
+    },
+  } satisfies MockRoute;
+}
+
+// PATCH /v1/runs/:id/costs/:costId — capture actualize/cancel status transitions.
+function mockRunsCostStatus(capture: { statuses: string[] }) {
+  return {
+    match: (url: string, init?: RequestInit) =>
+      /\/v1\/runs\/[^/]+\/costs\/[^/]+$/.test(url) && (init?.method ?? "GET") === "PATCH",
+    respond: (_url: string, init?: RequestInit) => {
+      const body = init?.body ? (JSON.parse(init.body as string) as { status: string }) : { status: "?" };
+      capture.statuses.push(body.status);
+      return { ok: true, body: { id: "cost-0", status: body.status } };
+    },
+  } satisfies MockRoute;
+}
+
+// Billing affordability check (platform keys). Defaults to sufficient.
+function mockBillingAuthorize(opts?: { sufficient?: boolean; capture?: { calls: number } }) {
+  const sufficient = opts?.sufficient ?? true;
+  return {
+    match: (url: string, init?: RequestInit) =>
+      url.includes("/v1/customer_balance/authorize") && (init?.method ?? "GET") === "POST",
+    respond: () => {
+      if (opts?.capture) opts.capture.calls += 1;
+      return { ok: true, body: { sufficient, balance_cents: "100000", required_cents: "1" } };
     },
   } satisfies MockRoute;
 }
@@ -268,11 +325,11 @@ describe("POST /orgs/rag/score", { timeout: 30_000 }, () => {
     const embedCapture = { calls: 0, bodies: [] as unknown[] };
     const brandCapture = { headers: undefined as Record<string, string> | undefined, body: undefined as unknown };
     const runsCapture = { headers: undefined as Record<string, string> | undefined };
-    const costCapture = { items: undefined as unknown[] | undefined };
+    const costCapture = { items: undefined as unknown[] | undefined, calls: 0 };
     const ownRunId = crypto.randomUUID();
 
     routes.push(mockRunsCreate(ownRunId, runsCapture));
-    routes.push(mockRunsCosts(costCapture));
+    routes.push(mockRunsProvision(costCapture));
     routes.push(mockRunsPatch());
     routes.push(
       mockBrandExtract(
@@ -354,17 +411,19 @@ describe("POST /orgs/rag/score", { timeout: 30_000 }, () => {
     expect(cached).toHaveLength(1);
     expect(cached[0].embedding).toEqual(queryVector);
 
-    // Embedding spend reported under the run: input tokens, costs-service catalog
-    // name (google-*), costSource derived from the resolved (platform) key.
+    // PROVISION: cost reserved before the embed with status "provisioned", google-*
+    // catalog name, costSource from the (platform) key, quantity from input tokens.
     expect(costCapture.items).toHaveLength(1);
     const costItem = costCapture.items![0] as {
       costName: string;
       quantity: number;
       costSource: string;
+      status: string;
     };
     expect(costItem.costName).toBe("google-embedding-001-tokens-input");
     expect(costItem.costSource).toBe("platform");
     expect(costItem.quantity).toBeGreaterThan(0);
+    expect(costItem.status).toBe("provisioned");
 
     await cleanupBrandCache(orgId, brandId);
   });

--- a/tests/unit/runs-client.test.ts
+++ b/tests/unit/runs-client.test.ts
@@ -201,6 +201,75 @@ describe("addRunCosts", () => {
   });
 });
 
+describe("addRunCosts (provisioning)", () => {
+  it("forwards status and returns the created cost rows with ids", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          costs: [
+            { id: "cost-1", runId: "run-1", costName: "google-embedding-001-tokens-input", status: "provisioned" },
+          ],
+        }),
+    });
+
+    const { addRunCosts } = await loadModule();
+    const costs = await addRunCosts(
+      "run-1",
+      [{ costName: "google-embedding-001-tokens-input", quantity: 100, costSource: "platform", status: "provisioned" }],
+      identity,
+    );
+
+    expect(costs).toHaveLength(1);
+    expect(costs[0].id).toBe("cost-1");
+    expect(costs[0].status).toBe("provisioned");
+    const body = JSON.parse((fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
+    expect(body.items[0].status).toBe("provisioned");
+  });
+
+  it("returns [] without a request when items are empty", async () => {
+    const { addRunCosts } = await loadModule();
+    const costs = await addRunCosts("run-1", [], identity);
+    expect(costs).toEqual([]);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("updateRunCostStatus", () => {
+  it("sends PATCH /v1/runs/:id/costs/:costId with the new status", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: "cost-1", status: "actual" }),
+    });
+
+    const { updateRunCostStatus } = await loadModule();
+    const result = await updateRunCostStatus("run-1", "cost-1", "actual", identity);
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://runs.test.local/v1/runs/run-1/costs/cost-1",
+      expect.objectContaining({
+        method: "PATCH",
+        headers: expect.objectContaining({ "x-org-id": "org-uuid-123" }),
+        body: JSON.stringify({ status: "actual" }),
+      }),
+    );
+    expect(result.status).toBe("actual");
+  });
+
+  it("supports 'cancelled' and throws on HTTP error", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve("not found"),
+    });
+
+    const { updateRunCostStatus } = await loadModule();
+    await expect(
+      updateRunCostStatus("run-1", "missing", "cancelled", identity),
+    ).rejects.toThrow(/returned 404/);
+  });
+});
+
 describe("missing RUNS_SERVICE_API_KEY", () => {
   it("throws without making requests", async () => {
     delete process.env.RUNS_SERVICE_API_KEY;


### PR DESCRIPTION
## What

Realizes the global **provision → authorize → execute → actualize** cost rule for `/orgs/rag/score` + `/orgs/rag/embed`. The embedding spend is now reserved **before** the Gemini call, not reported (and swallowed) in a `finally` after.

Per request:
1. **PROVISION** — runs-service cost row `status=provisioned` (quantity from inputs). Validates the cost name is declarable — runs-service `422 Unknown cost name` → no spend.
2. **AUTHORIZE** — billing-service affordability for platform keys (BYOK skips). Insufficient → `402`, no spend.
3. **EXECUTE** — Gemini embed only after 1+2 succeed.
4. **ACTUALIZE** — `PATCH status=actual` on success; `cancelled` if the embed throws.

## Why

Cost integrity is not best-effort. The prior v0.30.1 wiring reported the cost in a `finally` and swallowed failures — a runs-service `422` (cost name missing from the costs-service catalog) silently dropped the cost. Now any provision/authorize/actualize failure **fails loud** (`502`/`402`) and an un-declarable or unaffordable cost blocks the spend instead of under-reporting.

## Changes

- `runs-client`: `CostItem.status`, `addRunCosts` returns created rows (for the cost id), new `updateRunCostStatus` (PATCH `actual`/`cancelled`).
- `index.ts`: shared `provisionAndAuthorizeEmbeddingCost` helper + both RAG handlers restructured (provision before embed, actualize after, cancel on throw).
- Tests: rag-embed integration covers provision-before-embed ordering, `422`→no-embed+`502`, insufficient→`402`, embed-fail→cancel; runs-client unit covers the new return + `updateRunCostStatus`. 591 unit green, rag-embed 9 green, build clean.

## Notes

- No new env var: RAG reuses the existing `billing-client` (`BILLING_SERVICE_*`) already wired for `/chat` + `/complete`.
- Global rule codified in `~/.claude/CLAUDE.md` + `service-architecture` skill (separate, out-of-repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)