### PR TITLE
feat(complete,chat): provision→authorize→reconcile LLM cost (RAG parity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,11 +620,16 @@ data: {"type":"buttons","buttons":[{"label":"Send Cold Emails","value":"Send Col
 ```
 Buttons are extracted from the AI response when it ends with lines formatted as `- [Button Text]`. The button `label` and `value` are both set to the text inside the brackets. Button lines are stripped from the token stream to prevent duplication.
 
-### Credit Authorization (402)
+### Cost: provision → authorize → execute → reconcile (402)
 
-Before streaming, the service checks credit authorization via billing-service for platform-key requests (`keySource: "platform"`). BYOK orgs (`keySource: "org"`) skip this check — they pay their provider directly.
+`POST /chat` and `POST /complete` declare LLM spend with the platform cost rule. Output tokens are unknown until the call finishes, so the **worst case** is reserved up front and trued up to the real usage after:
 
-If the org has insufficient credits, the endpoint returns a **402 JSON response** (not SSE):
+1. **Provision** — before the model call, two `provisioned` cost rows (`<costPrefix>-tokens-input` + `-tokens-output`) are written to runs-service with the worst-case quantity (input estimate + the model's output budget). Validates the cost names are declarable.
+2. **Authorize** — credit affordability is checked against billing-service for platform-key requests (`keySource: "platform"`). BYOK orgs (`keySource: "org"`) skip this — they pay their provider directly. (`/chat` authorizes pre-stream; `/complete` authorizes inline.)
+3. **Execute** — the model call runs only after provision + authorize succeed.
+4. **Reconcile** — the **actual** token counts are recorded (`actual` rows) and the provisioned worst-case holds are `cancelled`. If the actual write fails, the provisioned-max rows remain as a fallback record — the cost is never silently lost.
+
+If the org has insufficient credits, the endpoint returns a **402** (JSON, not SSE on `/chat`):
 ```json
 {
   "error": "Insufficient credits",
@@ -633,7 +638,7 @@ If the org has insufficient credits, the endpoint returns a **402 JSON response*
 }
 ```
 
-If billing-service is unreachable, a **502 JSON response** is returned instead.
+If a cost can't be declared (runs-service `422 Unknown cost name`) or billing-service is unreachable, the spend is blocked: `502` on `/complete`, an SSE `error` event on `/chat` (the stream is already open by provisioning time). The model is never called when the cost can't be declared or afforded.
 
 ### 7. Error (optional)
 Sent when the AI model returns an empty response, is overloaded, or an unexpected error occurs:

--- a/src/index.ts
+++ b/src/index.ts
@@ -338,49 +338,15 @@ app.post("/complete", requireAuth, async (req, res) => {
     });
   }
 
-  // Cost prefix from model resolution
+  // Cost prefix + source from model / key resolution.
   const effectiveCostPrefix = resolved.costPrefix;
+  const costSource: "platform" | "org" = resolvedKey.keySource === "org" ? "org" : "platform";
+  // Provision quantities (worst case): input estimate + output budget. /complete has no
+  // caller maxTokens param, so the model's output budget is the theoretical max.
+  const estimatedInputTokens = Math.max(Math.ceil(message.length / 4), 500);
+  const maxOutputTokens = 64_000;
 
-  // Credit authorization for platform keys
-  if (resolvedKey.keySource === "platform") {
-    const estimatedInputTokens = Math.max(Math.ceil(message.length / 4), 500);
-    const estimatedOutputTokens = 64_000;
-    try {
-      const authResult = await authorizeCredits({
-        items: [
-          { costName: `${effectiveCostPrefix}-tokens-input`, quantity: estimatedInputTokens },
-          { costName: `${effectiveCostPrefix}-tokens-output`, quantity: estimatedOutputTokens },
-        ],
-        description: `complete — ${effectiveModel}`,
-        orgId,
-        userId,
-        runId: parentRunId,
-        trackingHeaders: Object.keys(trackingHeaders).length > 0 ? trackingHeaders : undefined,
-      });
-      if (!authResult.sufficient) {
-        console.warn(
-          `[complete] insufficient credits: org="${orgId}" balance_cents=${authResult.balance_cents} required_cents=${authResult.required_cents}`,
-        );
-        return res.status(402).json({
-          error: "Insufficient credits",
-          balance_cents: authResult.balance_cents,
-          required_cents: authResult.required_cents,
-        });
-      }
-    } catch (billingErr) {
-      console.error(`[complete] billing authorization failed for org="${orgId}":`, billingErr);
-      if (billingErr instanceof BillingError && billingErr.isClientError) {
-        return res.status(billingErr.statusCode).json({
-          error: `Billing authorization rejected: ${billingErr.upstreamBody}`,
-        });
-      }
-      return res.status(502).json({
-        error: "Billing service unavailable. Please try again.",
-      });
-    }
-  }
-
-  // Register run (mandatory)
+  // Register run (mandatory) — must precede provisioning (cost rows attach to the run).
   let runId: string | null = null;
   try {
     const run = await createRun(
@@ -402,7 +368,27 @@ app.post("/complete", requireAuth, async (req, res) => {
   let completeFailed = false;
   let totalPromptTokens = 0;
   let totalOutputTokens = 0;
+  let provisionedCostIds: string[] = [];
   try {
+    // PROVISION worst case → AUTHORIZE (platform) before the LLM call. Fail loud — never
+    // spend on an undeclarable or unaffordable cost.
+    try {
+      provisionedCostIds = await provisionAndAuthorizeLlmCost({
+        runId,
+        costPrefix: effectiveCostPrefix,
+        inputTokens: estimatedInputTokens,
+        outputTokens: maxOutputTokens,
+        keySource: resolvedKey.keySource,
+        identity: { orgId, userId, runId },
+        trackingHeaders,
+        description: `complete — ${effectiveModel}`,
+      });
+    } catch (costErr) {
+      completeFailed = true;
+      const r = costErrorResponse(costErr, "complete", orgId);
+      return res.status(r.status).json(r.body);
+    }
+
     let result: { content: string; tokensInput: number; tokensOutput: number; model: string };
 
     if (runId) {
@@ -479,11 +465,12 @@ app.post("/complete", requireAuth, async (req, res) => {
       error: "LLM call failed. Please try again.",
     });
   } finally {
-    // Report run status and costs
+    // Reconcile: record ACTUAL real tokens, then release the provisioned worst-case holds.
+    // If the actual POST fails, the provisioned-max rows stay as a fallback record — the
+    // cost is never silently lost.
     if (runId) {
-      const costSource: "platform" | "org" =
-        resolvedKey.keySource === "org" ? "org" : "platform";
-      const costItems = [
+      const runIdentity = { orgId, userId, runId };
+      const actualItems = [
         ...(totalPromptTokens > 0
           ? [{ costName: `${effectiveCostPrefix}-tokens-input`, quantity: totalPromptTokens, costSource }]
           : []),
@@ -491,14 +478,20 @@ app.post("/complete", requireAuth, async (req, res) => {
           ? [{ costName: `${effectiveCostPrefix}-tokens-output`, quantity: totalOutputTokens, costSource }]
           : []),
       ];
-      const runIdentity = { orgId, userId, runId };
       try {
-        await Promise.all([
-          updateRunStatus(runId, completeFailed ? "failed" : "completed", runIdentity, trackingHeaders),
-          addRunCosts(runId, costItems, runIdentity, trackingHeaders),
-        ]);
+        await updateRunStatus(runId, completeFailed ? "failed" : "completed", runIdentity, trackingHeaders);
       } catch (runErr) {
         console.error(`[chat-service] /complete failed to finalize run runId="${runId}" orgId="${orgId}":`, runErr);
+      }
+      if (provisionedCostIds.length > 0) {
+        try {
+          if (actualItems.length > 0) {
+            await addRunCosts(runId, actualItems, runIdentity, trackingHeaders);
+          }
+          await cancelProvisionedCosts(runId, provisionedCostIds, runIdentity, trackingHeaders);
+        } catch (costErr) {
+          console.error(`[complete] cost reconcile failed runId="${runId}" — provisioned-max kept as fallback:`, costErr);
+        }
       }
     }
   }
@@ -620,6 +613,90 @@ function costErrorResponse(
   }
   console.error(`[${tag}] cost provision/authorize failed for org="${orgId}":`, err);
   return { status: 502, body: { error: "Cost authorization failed. Please try again." } };
+}
+
+/** Cancel a set of provisioned cost rows (release the worst-case hold). Best-effort, logged. */
+async function cancelProvisionedCosts(
+  runId: string,
+  costIds: string[],
+  identity: RunIdentityHeaders,
+  trackingHeaders: Record<string, string>,
+): Promise<void> {
+  await Promise.all(
+    costIds.map((id) =>
+      updateRunCostStatus(runId, id, "cancelled", identity, trackingHeaders).catch((e) =>
+        console.error(`[cost] cancel provisioned failed runId="${runId}" costId="${id}":`, e),
+      ),
+    ),
+  );
+}
+
+/**
+ * Provision the worst-case LLM cost (input estimate + output max) as two `provisioned`
+ * rows. Output tokens are unknown pre-call, so reserve the max and true up to actual
+ * after (POST actual + cancel these holds). Returns the provisioned cost ids. Throws if
+ * the cost is undeclarable (runs-service 422) — caller fails loud, never spends.
+ */
+async function provisionLlmCost(args: {
+  runId: string;
+  costPrefix: string;
+  inputTokens: number;
+  outputTokens: number;
+  keySource: "org" | "platform";
+  identity: RunIdentityHeaders;
+  trackingHeaders: Record<string, string>;
+}): Promise<string[]> {
+  const { runId, costPrefix, inputTokens, outputTokens, keySource, identity, trackingHeaders } = args;
+  const items: CostItem[] = [
+    { costName: `${costPrefix}-tokens-input`, quantity: inputTokens, costSource: keySource, status: "provisioned" },
+    { costName: `${costPrefix}-tokens-output`, quantity: outputTokens, costSource: keySource, status: "provisioned" },
+  ];
+  const costs = await addRunCosts(runId, items, identity, trackingHeaders);
+  return costs.map((c) => c.id);
+}
+
+/**
+ * Provision (worst case) then authorize (platform keys) BEFORE the call. Returns the
+ * provisioned cost ids to reconcile after. Throws on any failure so the caller fails
+ * loud; releases the provision if authorization fails. Used by non-streaming `/complete`
+ * (streaming `/chat` authorizes pre-stream and calls `provisionLlmCost` directly).
+ */
+async function provisionAndAuthorizeLlmCost(args: {
+  runId: string;
+  costPrefix: string;
+  inputTokens: number;
+  outputTokens: number;
+  keySource: "org" | "platform";
+  identity: RunIdentityHeaders;
+  trackingHeaders: Record<string, string>;
+  description: string;
+}): Promise<string[]> {
+  const { runId, costPrefix, inputTokens, outputTokens, keySource, identity, trackingHeaders, description } = args;
+  const costIds = await provisionLlmCost(args);
+  if (keySource === "platform") {
+    try {
+      const auth = await authorizeCredits({
+        items: [
+          { costName: `${costPrefix}-tokens-input`, quantity: inputTokens },
+          { costName: `${costPrefix}-tokens-output`, quantity: outputTokens },
+        ],
+        description,
+        orgId: identity.orgId,
+        userId: identity.userId,
+        runId,
+        trackingHeaders: Object.keys(trackingHeaders).length > 0 ? trackingHeaders : undefined,
+      });
+      if (!auth.sufficient) {
+        await cancelProvisionedCosts(runId, costIds, identity, trackingHeaders);
+        throw new InsufficientCreditsError(auth.balance_cents, auth.required_cents);
+      }
+    } catch (err) {
+      if (err instanceof InsufficientCreditsError) throw err;
+      await cancelProvisionedCosts(runId, costIds, identity, trackingHeaders);
+      throw err;
+    }
+  }
+  return costIds;
 }
 
 app.post("/orgs/rag/score", requireAuth, async (req, res) => {
@@ -1312,6 +1389,7 @@ app.post("/chat", requireAuth, async (req, res) => {
   let chatFailed = false;
   let totalPromptTokens = 0;
   let totalOutputTokens = 0;
+  let provisionedCostIds: string[] = [];
 
   try {
     // Get or create session (scoped by org + user + app)
@@ -1381,6 +1459,33 @@ app.post("/chat", requireAuth, async (req, res) => {
         type: "error",
         code: "internal_error",
         message: "Service temporarily unavailable (run tracking). Please try again.",
+      });
+      sendSSE(res, "[DONE]");
+      res.end();
+      return;
+    }
+
+    // PROVISION worst-case LLM cost (input estimate + output budget) before the model
+    // call. Authorize already ran pre-stream above; output tokens are unknown until the
+    // stream ends, so reserve the max and true up to actual in the finally. Fail loud
+    // (SSE error — the stream is already open) if the cost can't be declared.
+    try {
+      provisionedCostIds = await provisionLlmCost({
+        runId,
+        costPrefix: resolvedModelInfo.costPrefix,
+        inputTokens: Math.max(Math.ceil(message.length / 4), 500),
+        outputTokens: 64_000,
+        keySource: resolvedKey.keySource,
+        identity: { orgId, userId, runId },
+        trackingHeaders,
+      });
+    } catch (provErr) {
+      chatFailed = true;
+      console.error(`[chat] cost provision failed runId="${runId}" org="${orgId}":`, provErr);
+      sendSSE(res, {
+        type: "error",
+        code: "internal_error",
+        message: "Cost provisioning failed. Please try again.",
       });
       sendSSE(res, "[DONE]");
       res.end();
@@ -2230,39 +2335,36 @@ app.post("/chat", requireAuth, async (req, res) => {
     // End SSE stream immediately so the client is not blocked
     res.end();
 
-    // Report run status and costs
+    // Reconcile: record ACTUAL real tokens, then release the provisioned worst-case holds.
+    // If the actual POST fails, the provisioned-max rows stay as a fallback record — the
+    // cost is never silently lost.
     if (runId) {
       const costSource: "platform" | "org" =
         resolvedKey.keySource === "org" ? "org" : "platform";
       const chatCostPrefix = resolvedModelInfo.costPrefix;
-      const costItems = [
+      const actualItems = [
         ...(totalPromptTokens > 0
-          ? [
-              {
-                costName: `${chatCostPrefix}-tokens-input`,
-                quantity: totalPromptTokens,
-                costSource,
-              },
-            ]
+          ? [{ costName: `${chatCostPrefix}-tokens-input`, quantity: totalPromptTokens, costSource }]
           : []),
         ...(totalOutputTokens > 0
-          ? [
-              {
-                costName: `${chatCostPrefix}-tokens-output`,
-                quantity: totalOutputTokens,
-                costSource,
-              },
-            ]
+          ? [{ costName: `${chatCostPrefix}-tokens-output`, quantity: totalOutputTokens, costSource }]
           : []),
       ];
       const runIdentity = { orgId, userId, runId };
       try {
-        await Promise.all([
-          updateRunStatus(runId, chatFailed ? "failed" : "completed", runIdentity, trackingHeaders),
-          addRunCosts(runId, costItems, runIdentity, trackingHeaders),
-        ]);
+        await updateRunStatus(runId, chatFailed ? "failed" : "completed", runIdentity, trackingHeaders);
       } catch (runErr) {
         console.error(`[chat-service] /chat failed to finalize run runId="${runId}" orgId="${orgId}":`, runErr);
+      }
+      if (provisionedCostIds.length > 0) {
+        try {
+          if (actualItems.length > 0) {
+            await addRunCosts(runId, actualItems, runIdentity, trackingHeaders);
+          }
+          await cancelProvisionedCosts(runId, provisionedCostIds, runIdentity, trackingHeaders);
+        } catch (costErr) {
+          console.error(`[chat] cost reconcile failed runId="${runId}" — provisioned-max kept as fallback:`, costErr);
+        }
       }
     }
   }

--- a/tests/integration/complete-cost.test.ts
+++ b/tests/integration/complete-cost.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
+import request from "supertest";
+
+// /complete cost flow: provision (worst case) → authorize (platform) → execute →
+// reconcile (POST actual real tokens + cancel the provisioned holds). google provider
+// (fetch-mockable, non-streaming, no DB).
+
+process.env.NODE_ENV = "test";
+process.env.KEY_SERVICE_API_KEY = process.env.KEY_SERVICE_API_KEY || "test-key-svc-key";
+process.env.KEY_SERVICE_URL = process.env.KEY_SERVICE_URL || "https://key.test.local";
+process.env.ADMIN_DISTRIBUTE_API_KEY = process.env.ADMIN_DISTRIBUTE_API_KEY || "test-api-svc-key";
+process.env.API_SERVICE_URL = process.env.API_SERVICE_URL || "https://api.test.local";
+process.env.RUNS_SERVICE_API_KEY = process.env.RUNS_SERVICE_API_KEY || "test-runs-key";
+process.env.RUNS_SERVICE_URL = process.env.RUNS_SERVICE_URL || "https://runs.test.local";
+process.env.BILLING_SERVICE_API_KEY = process.env.BILLING_SERVICE_API_KEY || "test-billing-key";
+process.env.BILLING_SERVICE_URL = process.env.BILLING_SERVICE_URL || "https://billing.test.local";
+
+interface MockRoute {
+  match: (url: string, init?: RequestInit) => boolean;
+  respond: (url: string, init?: RequestInit) => { ok: boolean; status?: number; body: unknown };
+}
+
+let routes: MockRoute[] = [];
+let fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
+
+function buildResponse(out: { ok: boolean; status?: number; body: unknown }): Response {
+  return {
+    ok: out.ok,
+    status: out.status ?? (out.ok ? 200 : 500),
+    json: () => Promise.resolve(out.body),
+    text: () =>
+      Promise.resolve(typeof out.body === "string" ? out.body : JSON.stringify(out.body)),
+    headers: new Headers(),
+  } as unknown as Response;
+}
+
+function installFetchMock() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      fetchCalls.push({ url, init });
+      for (const route of routes) {
+        if (route.match(url, init)) return buildResponse(route.respond(url, init));
+      }
+      throw new Error(`[test] Unmocked fetch: ${url}`);
+    }),
+  );
+}
+
+// Captures every POST /v1/runs/:id/costs body (provision AND actual) + every cost-status
+// PATCH. `provisionStatus` forces a runs-service rejection on the provision POST.
+function mockRunsCostRoutes(cap: {
+  postedItems: Array<Array<{ costName: string; quantity: number; status?: string }>>;
+  patchedStatuses: string[];
+  provisionStatus?: number;
+}) {
+  return [
+    {
+      match: (url: string, init?: RequestInit) =>
+        /\/v1\/runs\/[^/]+\/costs$/.test(url) && (init?.method ?? "GET") === "POST",
+      respond: (_url: string, init?: RequestInit) => {
+        const items = init?.body
+          ? (JSON.parse(init.body as string) as { items: Array<{ costName: string; quantity: number; status?: string }> }).items
+          : [];
+        cap.postedItems.push(items);
+        const isProvision = items[0]?.status === "provisioned";
+        if (isProvision && cap.provisionStatus && cap.provisionStatus >= 400) {
+          return { ok: false, status: cap.provisionStatus, body: { error: "Unknown cost name" } };
+        }
+        return { ok: true, status: 201, body: { costs: items.map((it, i) => ({ id: `cost-${i}`, ...it })) } };
+      },
+    },
+    {
+      match: (url: string, init?: RequestInit) =>
+        /\/v1\/runs\/[^/]+\/costs\/[^/]+$/.test(url) && (init?.method ?? "GET") === "PATCH",
+      respond: (_url: string, init?: RequestInit) => {
+        const body = init?.body ? (JSON.parse(init.body as string) as { status: string }) : { status: "?" };
+        cap.patchedStatuses.push(body.status);
+        return { ok: true, body: { id: "cost-0", status: body.status } };
+      },
+    },
+  ] satisfies MockRoute[];
+}
+
+function mockRunsCreate() {
+  return {
+    match: (url: string, init?: RequestInit) => url.endsWith("/v1/runs") && (init?.method ?? "GET") === "POST",
+    respond: () => ({ ok: true, status: 201, body: { id: "run-own-1", status: "running" } }),
+  } satisfies MockRoute;
+}
+
+function mockRunsStatusPatch() {
+  return {
+    match: (url: string, init?: RequestInit) => /\/v1\/runs\/[^/]+$/.test(url) && (init?.method ?? "GET") === "PATCH",
+    respond: () => ({ ok: true, body: { id: "run-own-1", status: "completed" } }),
+  } satisfies MockRoute;
+}
+
+function mockKeyDecrypt() {
+  return {
+    match: (url: string) => url.includes("/keys/google/decrypt"),
+    respond: () => ({ ok: true, body: { provider: "google", key: "fake-google-key", keySource: "platform" } }),
+  } satisfies MockRoute;
+}
+
+function mockBilling(opts?: { sufficient?: boolean }) {
+  return {
+    match: (url: string, init?: RequestInit) =>
+      url.includes("/v1/customer_balance/authorize") && (init?.method ?? "GET") === "POST",
+    respond: () => ({
+      ok: true,
+      body: { sufficient: opts?.sufficient ?? true, balance_cents: "100000", required_cents: "1" },
+    }),
+  } satisfies MockRoute;
+}
+
+function mockGeminiComplete(cap: { calls: number }) {
+  return {
+    match: (url: string) => url.includes(":generateContent") && url.includes("generativelanguage.googleapis.com"),
+    respond: () => {
+      cap.calls += 1;
+      return {
+        ok: true,
+        body: {
+          candidates: [{ content: { parts: [{ text: "hello world" }] }, finishReason: "STOP" }],
+          usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5 },
+        },
+      };
+    },
+  } satisfies MockRoute;
+}
+
+const AUTH = { "x-api-key": "test-key", "x-org-id": "org-1", "x-user-id": "user-1", "x-run-id": "parent-run-1" };
+
+describe("POST /complete — cost provision → authorize → execute → reconcile", () => {
+  let app: Awaited<ReturnType<typeof loadApp>>;
+  async function loadApp() {
+    vi.resetModules();
+    return (await import("../../src/index.js")).default;
+  }
+  beforeAll(async () => {
+    app = await loadApp();
+  });
+  beforeEach(() => {
+    routes = [];
+    fetchCalls = [];
+    installFetchMock();
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("provisions worst-case before the call, then records actual real tokens + cancels the holds", async () => {
+    const cap = { postedItems: [] as Array<Array<{ costName: string; quantity: number; status?: string }>>, patchedStatuses: [] as string[] };
+    const gemini = { calls: 0 };
+    routes.push(mockRunsCreate(), mockKeyDecrypt(), mockBilling(), mockGeminiComplete(gemini), ...mockRunsCostRoutes(cap), mockRunsStatusPatch());
+
+    const res = await request(app)
+      .post("/complete")
+      .set(AUTH)
+      .send({ message: "hi", systemPrompt: "be brief", provider: "google", model: "flash" });
+
+    expect(res.status).toBe(200);
+    expect(gemini.calls).toBe(1);
+
+    // PROVISION: first POST /costs is 2 worst-case items, status "provisioned".
+    const provision = cap.postedItems[0];
+    expect(provision).toHaveLength(2);
+    expect(provision.every((i) => i.status === "provisioned")).toBe(true);
+    expect(provision.map((i) => i.costName).sort()).toEqual([
+      "google-flash-3-tokens-input",
+      "google-flash-3-tokens-output",
+    ]);
+    // Output provisioned at the worst-case budget (64k), not the real 5.
+    expect(provision.find((i) => i.costName.endsWith("output"))!.quantity).toBe(64_000);
+
+    // ORDER: provision precedes the Gemini call.
+    const provisionIdx = fetchCalls.findIndex(
+      (c) => /\/v1\/runs\/[^/]+\/costs$/.test(c.url) && (c.init?.method ?? "GET") === "POST",
+    );
+    const llmIdx = fetchCalls.findIndex((c) => c.url.includes(":generateContent"));
+    expect(provisionIdx).toBeGreaterThanOrEqual(0);
+    expect(llmIdx).toBeGreaterThan(provisionIdx);
+
+    // ACTUAL: a later POST /costs records the REAL tokens (10 in / 5 out), no provisioned status.
+    const actual = cap.postedItems.find((items) => items.some((i) => i.status === undefined));
+    expect(actual).toBeDefined();
+    expect(actual!.find((i) => i.costName.endsWith("input"))!.quantity).toBe(10);
+    expect(actual!.find((i) => i.costName.endsWith("output"))!.quantity).toBe(5);
+
+    // RECONCILE: the 2 provisioned holds are cancelled.
+    expect(cap.patchedStatuses.filter((s) => s === "cancelled")).toHaveLength(2);
+  });
+
+  it("fails loud (502) and does NOT call the model when provision is rejected", async () => {
+    const cap = { postedItems: [] as Array<Array<{ costName: string; quantity: number; status?: string }>>, patchedStatuses: [] as string[], provisionStatus: 422 };
+    const gemini = { calls: 0 };
+    routes.push(mockRunsCreate(), mockKeyDecrypt(), mockBilling(), mockGeminiComplete(gemini), ...mockRunsCostRoutes(cap), mockRunsStatusPatch());
+
+    const res = await request(app)
+      .post("/complete")
+      .set(AUTH)
+      .send({ message: "hi", systemPrompt: "be brief", provider: "google", model: "flash" });
+
+    expect(res.status).toBe(502);
+    expect(gemini.calls).toBe(0);
+  });
+
+  it("returns 402 and does NOT call the model when billing reports insufficient credits", async () => {
+    const cap = { postedItems: [] as Array<Array<{ costName: string; quantity: number; status?: string }>>, patchedStatuses: [] as string[] };
+    const gemini = { calls: 0 };
+    routes.push(mockRunsCreate(), mockKeyDecrypt(), mockBilling({ sufficient: false }), mockGeminiComplete(gemini), ...mockRunsCostRoutes(cap), mockRunsStatusPatch());
+
+    const res = await request(app)
+      .post("/complete")
+      .set(AUTH)
+      .send({ message: "hi", systemPrompt: "be brief", provider: "google", model: "flash" });
+
+    expect(res.status).toBe(402);
+    expect(res.body.error).toMatch(/Insufficient credits/);
+    expect(gemini.calls).toBe(0);
+    // provisioned holds released on insufficient credits
+    expect(cap.patchedStatuses).toContain("cancelled");
+  });
+});


### PR DESCRIPTION
## What

`/complete` + `/chat` now declare LLM spend with the full **provision → authorize → execute → actualize** rule, matching `/orgs/rag/*` (DIS-82). Closes the parity follow-up.

## The output-token problem

LLM output tokens are unknown until the call finishes, and runs-service `PATCH /costs/{id}` is status-only (no quantity update). So we **reserve the worst case** before the call and **true up to the real tokens** after — no runs-service change needed (per discussion: `POST /costs` already takes a quantity).

1. **Provision** — 2 `provisioned` rows (`<costPrefix>-tokens-input` + `-output`), quantity = input estimate + the model's output budget (theoretical max; neither endpoint takes a caller `maxTokens`).
2. **Authorize** — billing affordability, platform keys only (BYOK skips).
3. **Execute** — model call only after 1+2 succeed.
4. **Reconcile** — POST the **actual** real tokens (`actual`) + `cancel` the provisioned holds. If the actual POST fails, the provisioned-max rows stay as a fallback — cost never silently lost.

## Endpoint specifics

- **`/complete`** (non-streaming): `createRun → provision+authorize → execute → reconcile`. Provision/authorize failure → `502`/`402`, model never called.
- **`/chat`** (streaming): authorize stays **pre-stream** (`402` before SSE opens, unchanged); provision lands after `createRun` (mid-stream, before the model call) → SSE `error` event on failure; reconcile in the finally. Order is authorize→provision here (streaming structure) vs provision→authorize on `/complete` — functionally identical (authorize uses explicit estimate items, not the provisioned row).

## Scope

`/complete` + `/chat` only. **Not** `/internal/platform-complete` (no run tracking / no billing). No runs-service change. No new env var.

## Tests

`tests/integration/complete-cost.test.ts` (google provider, no DB): provision-before-call order, actual real tokens (10 in / 5 out) recorded, worst-case output (64k) reserved, holds cancelled, `422`→no-call+`502`, insufficient→`402`. **591 unit + 14 no-DB integration green**, build clean.

⚠️ **Note:** `/chat` has no pre-existing integration harness (DB + streaming + tool loop), so its cost wiring is build-verified + covered transitively by the shared helpers (`provisionLlmCost`, `cancelProvisionedCosts`) which `/complete` exercises. A dedicated `/chat` cost integration test is a sensible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)