### PR TITLE
feat(complete): opt-in native web search (Gemini + Anthropic)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,11 @@ Request body:
   - **Google** → `generationConfig.responseSchema` (supported on all Gemini 2.5+ models: `pro`, `flash`, `flash-lite`). Gemini accepts only an OpenAPI 3.0 subset; chat-service auto-sanitizes the caller-supplied schema before forwarding by stripping unsupported JSON-Schema keywords (`additionalProperties`, `$schema`, `$ref`, `$defs`, `definitions`, `patternProperties`, `unevaluatedProperties`, `if`/`then`/`else`, `not`, `const`, `examples`, `default`, `exclusiveMinimum`/`exclusiveMaximum`, `multipleOf`, etc.). A `[chat-service] Gemini schema sanitized` warning is logged once per call when any field is removed.
   - **Anthropic** → `output_config.format = { type: "json_schema", schema }` (Claude 4.x). **Strict schema required**: `additionalProperties: false` and an explicit `properties` map. Permissive schemas are rejected with 400 by Anthropic.
 - `temperature` (optional) — sampling temperature, 0–2 (default: model default)
+- `webSearch` (optional, default `false`) — opt-in native web search. When `true`, the resolved provider answers using its **own** native web search so the response reflects live web content instead of the model's parametric memory:
+  - **Google** → `googleSearch` grounding tool. The number of search queries is read from `groundingMetadata.webSearchQueries`; source URLs from `groundingMetadata.groundingChunks[].web`.
+  - **Anthropic** → server-side `web_search_20250305` tool (`max_uses: 5`). The search count is read from `usage.server_tool_use.web_search_requests`; source URLs from citation + result blocks.
+  - In **text mode**, deduped citation source URLs are appended to `content` as a trailing `Sources:` block, so they surface in the response text. In **JSON mode** (`responseFormat: "json"` / `responseSchema`) the content is left untouched (a Sources block would corrupt the JSON), but grounding still applies and the search cost is still declared.
+  - Omitted or `false` → no grounding, byte-identical to a non-grounded call (no extra cost). The web-search cost is metered per query/search and billed in addition to tokens — see the **Cost** section below.
 - `imageUrl` (optional) — URL of an image to include as visual input. The image is fetched server-side. Supported by all models, but recommended with `google` + `flash-lite` for cost-effective vision tasks.
 - `imageContext` (optional) — metadata about the image to help the model classify it: `{ alt?: string, title?: string, sourceUrl?: string }`. Injected into the prompt alongside the image. Only meaningful when `imageUrl` is provided.
 
@@ -248,13 +253,13 @@ Error responses: 400 (validation), 401 (auth), 402 (insufficient credits), 502 (
 }
 ```
 
-Same fields as `POST /complete` (including the optional `responseSchema`) except **no `imageUrl` or `imageContext`** support.
+Same fields as `POST /complete` (including the optional `responseSchema` and `webSearch`) except **no `imageUrl` or `imageContext`** support.
 
 **Key differences from `POST /complete`:**
-- **No billing** — platform-level calls are not charged to any org
-- **No run tracking** — no run is created in runs-service
-- **No campaign context** — no `x-campaign-id` enrichment
-- **Platform key resolution** — uses `GET /keys/platform/{provider}/decrypt` directly (no org-level key lookup)
+- **No org billing** — platform-level calls are not charged to any org's credit balance (no affordability authorize).
+- **Platform run tracking + cost** — a **platform run** is created in runs-service (`POST /v1/platform-runs`, `x-service-name: chat-service`, `taskName: platform-complete`) and the LLM (and web-search) spend is declared on it as `actual` costs (`costSource: platform`). Platform runs have no cost-status PATCH, so costs are posted post-call as `actual` (no provision/cancel). Fail-loud: if the platform run can't be created or its cost can't be declared, the call returns **502** rather than spending silently.
+- **No campaign context** — no `x-campaign-id` enrichment.
+- **Platform key resolution** — uses `GET /keys/platform/{provider}/decrypt` directly (no org-level key lookup).
 
 Use this endpoint when a service needs an LLM call during startup or for platform-level operations that don't belong to a specific org or user (e.g. workflow upgrades, schema analysis).
 
@@ -624,10 +629,12 @@ Buttons are extracted from the AI response when it ends with lines formatted as 
 
 `POST /chat` and `POST /complete` declare LLM spend with the platform cost rule. Output tokens are unknown until the call finishes, so the **worst case** is reserved up front and trued up to the real usage after:
 
-1. **Provision** — before the model call, two `provisioned` cost rows (`<costPrefix>-tokens-input` + `-tokens-output`) are written to runs-service with the worst-case quantity (input estimate + the model's output budget). Validates the cost names are declarable.
-2. **Authorize** — credit affordability is checked against billing-service for platform-key requests (`keySource: "platform"`). BYOK orgs (`keySource: "org"`) skip this — they pay their provider directly. (`/chat` authorizes pre-stream; `/complete` authorizes inline.)
+1. **Provision** — before the model call, two `provisioned` cost rows (`<costPrefix>-tokens-input` + `-tokens-output`) are written to runs-service with the worst-case quantity (input estimate + the model's output budget). When `webSearch: true`, a third `provisioned` web-search row is added at the worst-case search count (5). Validates the cost names are declarable.
+2. **Authorize** — credit affordability is checked against billing-service for platform-key requests (`keySource: "platform"`). BYOK orgs (`keySource: "org"`) skip this — they pay their provider directly. (`/chat` authorizes pre-stream; `/complete` authorizes inline.) The web-search hold is included in the authorize when `webSearch` is on.
 3. **Execute** — the model call runs only after provision + authorize succeed.
-4. **Reconcile** — the **actual** token counts are recorded (`actual` rows) and the provisioned worst-case holds are `cancelled`. If the actual write fails, the provisioned-max rows remain as a fallback record — the cost is never silently lost.
+4. **Reconcile** — the **actual** token counts (and, when `webSearch` ran, the **actual** search count) are recorded (`actual` rows) and the provisioned worst-case holds are `cancelled`. If the actual write fails, the provisioned-max rows remain as a fallback record — the cost is never silently lost.
+
+**Web-search cost names** (byte-equal to the costs-service catalog): Google grounding → `google-search-query`; Anthropic web search → `anthropic-web-search`. `POST /internal/platform-complete` declares the same token + web-search costs on a **platform run** as `actual` (no provision/authorize/cancel — platform spend, no org).
 
 If the org has insufficient credits, the endpoint returns a **402** (JSON, not SSE on `/chat`):
 ```json

--- a/openapi.json
+++ b/openapi.json
@@ -727,6 +727,11 @@
             "description": "Model alias (version-free). The service resolves the latest versioned model internally.\n\n**Anthropic models:** `haiku` (fast/cheap), `sonnet` (balanced), `opus` (highest quality).\n**Google models:** `flash-lite` (cheapest, vision), `flash` (balanced, reasoning), `pro` (most powerful).\n\nThe model must match the provider: anthropic → haiku|sonnet|opus, google → flash-lite|flash|pro.",
             "example": "sonnet"
           },
+          "webSearch": {
+            "type": "boolean",
+            "description": "Opt-in native web search. When true, the resolved provider answers using its OWN native web search — Google Search grounding for `google`, the server-side `web_search` tool for `anthropic` — so the response reflects live web content instead of the model's parametric memory. Citation source URLs are appended to `content` (text mode only). Omitted or false = no grounding, byte-identical to a non-grounded call (no extra cost). The web-search cost is metered per query/search and billed in addition to tokens.",
+            "example": true
+          },
           "imageUrl": {
             "type": "string",
             "format": "uri",
@@ -818,6 +823,11 @@
             ],
             "description": "Model alias (version-free).",
             "example": "sonnet"
+          },
+          "webSearch": {
+            "type": "boolean",
+            "description": "Opt-in native web search. When true, the resolved provider answers using its OWN native web search (Google Search grounding for `google`, server-side `web_search` for `anthropic`). Citation source URLs are appended to `content` (text mode only). Omitted or false = no grounding, byte-identical to a non-grounded call. The web-search cost is declared on the platform run in addition to tokens.",
+            "example": true
           }
         },
         "required": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ import {
 } from "./lib/workflow-client.js";
 import { getPromptTemplate, updatePromptTemplate } from "./lib/content-generation-client.js";
 import { listServices, listServiceEndpoints } from "./lib/api-registry-client.js";
-import { createRun, updateRunStatus, addRunCosts, updateRunCostStatus, type CostItem, type RunIdentityHeaders } from "./lib/runs-client.js";
+import { createRun, updateRunStatus, addRunCosts, updateRunCostStatus, createPlatformRun, addPlatformRunCosts, updatePlatformRunStatus, type CostItem, type RunIdentityHeaders } from "./lib/runs-client.js";
 import { traceEvent } from "./lib/trace-event.js";
 import { createFeature, updateFeature, listFeatures, getFeature, getFeatureInputs, prefillFeature, getFeatureStats } from "./lib/features-client.js";
 import { extractBrandFields, BrandError } from "./lib/brand-client.js";
@@ -297,7 +297,8 @@ app.post("/complete", requireAuth, async (req, res) => {
       .json({ error: "Invalid request", details: parsed.error.flatten() });
   }
 
-  const { message, systemPrompt, responseFormat, responseSchema, temperature, provider: requestedProvider, model: requestedModel, imageUrl, imageContext } = parsed.data;
+  const { message, systemPrompt, responseFormat, responseSchema, temperature, provider: requestedProvider, model: requestedModel, imageUrl, imageContext, webSearch: webSearchRaw } = parsed.data;
+  const webSearch = webSearchRaw === true;
 
   // Passing a responseSchema implies JSON-mode parsing of the response.
   const jsonMode = responseFormat === "json" || responseSchema != null;
@@ -307,6 +308,9 @@ app.post("/complete", requireAuth, async (req, res) => {
   const effectiveModel = resolved.apiModelId;
   const isGemini = resolved.provider === "google";
   const provider = resolved.provider;
+
+  // Native web-search cost name (byte-equal to costs-service catalog) — only when opted in.
+  const searchCostName = webSearch ? webSearchCostName(isGemini) : undefined;
 
   // Anthropic JSON mode requires `responseSchema` — Anthropic API has no native
   // standalone JSON-mode flag; enforcement is only available via
@@ -367,6 +371,7 @@ app.post("/complete", requireAuth, async (req, res) => {
   let completeFailed = false;
   let totalPromptTokens = 0;
   let totalOutputTokens = 0;
+  let totalSearchCount = 0;
   let provisionedCostIds: string[] = [];
   try {
     // PROVISION worst case → AUTHORIZE (platform) before the LLM call. Fail loud — never
@@ -381,6 +386,8 @@ app.post("/complete", requireAuth, async (req, res) => {
         identity: { orgId, userId, runId },
         trackingHeaders,
         description: `complete — ${effectiveModel}`,
+        searchCostName,
+        searchQuantity: webSearch ? WORST_CASE_SEARCHES : undefined,
       });
     } catch (costErr) {
       completeFailed = true;
@@ -388,7 +395,7 @@ app.post("/complete", requireAuth, async (req, res) => {
       return res.status(r.status).json(r.body);
     }
 
-    let result: { content: string; tokensInput: number; tokensOutput: number; model: string };
+    let result: { content: string; tokensInput: number; tokensOutput: number; model: string; searchCount: number; sources: Array<{ url: string; title?: string }> };
 
     if (runId) {
       traceEvent(runId, "llm-call-start", { orgId, userId }, workflowTracking, {
@@ -407,6 +414,7 @@ app.post("/complete", requireAuth, async (req, res) => {
         responseFormat,
         responseSchema,
         temperature,
+        webSearch,
       });
     } else {
       const claude = createAnthropicClient({ apiKey: resolvedKey.key, systemPrompt });
@@ -416,11 +424,13 @@ app.post("/complete", requireAuth, async (req, res) => {
         temperature,
         model: effectiveModel,
         imageUrl,
+        webSearch,
       });
     }
 
     totalPromptTokens = result.tokensInput;
     totalOutputTokens = result.tokensOutput;
+    totalSearchCount = result.searchCount;
 
     if (runId) {
       traceEvent(runId, "llm-call-done", { orgId, userId }, workflowTracking, {
@@ -433,9 +443,11 @@ app.post("/complete", requireAuth, async (req, res) => {
       });
     }
 
-    // Build response
+    // Build response. In text mode, surface native-search citation URLs in the
+    // answer text itself. In JSON mode, leave content untouched — the provider
+    // returns strict JSON and appending a Sources block would corrupt the parse.
     const response: Record<string, unknown> = {
-      content: result.content,
+      content: jsonMode ? result.content : appendSources(result.content, result.sources),
       tokensInput: result.tokensInput,
       tokensOutput: result.tokensOutput,
       model: result.model,
@@ -475,6 +487,9 @@ app.post("/complete", requireAuth, async (req, res) => {
           : []),
         ...(totalOutputTokens > 0
           ? [{ costName: `${effectiveCostPrefix}-tokens-output`, quantity: totalOutputTokens, costSource }]
+          : []),
+        ...(searchCostName && totalSearchCount > 0
+          ? [{ costName: searchCostName, quantity: totalSearchCount, costSource }]
           : []),
       ];
       try {
@@ -631,6 +646,42 @@ async function cancelProvisionedCosts(
 }
 
 /**
+ * Append a deduped `Sources:` block of citation URLs to the model's text answer.
+ * Used when native web search ran, so the live source URLs surface in the
+ * response `content` itself (both providers return them in metadata, not prose;
+ * Anthropic's ToS also requires citing sources when displaying search output).
+ * No-op when there are no sources — preserves byte-identical non-grounded output.
+ */
+function appendSources(
+  content: string,
+  sources: Array<{ url: string; title?: string }>,
+): string {
+  if (!sources || sources.length === 0) return content;
+  const seen = new Set<string>();
+  const lines: string[] = [];
+  for (const s of sources) {
+    if (!s.url || seen.has(s.url)) continue;
+    seen.add(s.url);
+    lines.push(s.title ? `- ${s.title}: ${s.url}` : `- ${s.url}`);
+  }
+  if (lines.length === 0) return content;
+  return `${content}\n\nSources:\n${lines.join("\n")}`;
+}
+
+/**
+ * Resolve the byte-equal web-search cost-catalog name for a provider.
+ * Gemini → `google-search-query` (Google Search grounding, exists in catalog).
+ * Anthropic → `anthropic-web-search` (server-side web_search). Both must match
+ * the costs-service catalog exactly or runs-service 422s.
+ */
+function webSearchCostName(isGemini: boolean): string {
+  return isGemini ? "google-search-query" : "anthropic-web-search";
+}
+
+/** Worst-case web-search count provisioned/authorized before a call (reconciled to actual after). */
+const WORST_CASE_SEARCHES = 5;
+
+/**
  * Provision the worst-case LLM cost (input estimate + output max) as two `provisioned`
  * rows. Output tokens are unknown pre-call, so reserve the max and true up to actual
  * after (POST actual + cancel these holds). Returns the provisioned cost ids. Throws if
@@ -644,11 +695,17 @@ async function provisionLlmCost(args: {
   keySource: "org" | "platform";
   identity: RunIdentityHeaders;
   trackingHeaders: Record<string, string>;
+  /** When set (webSearch on), also provision a worst-case web-search hold. */
+  searchCostName?: string;
+  searchQuantity?: number;
 }): Promise<string[]> {
-  const { runId, costPrefix, inputTokens, outputTokens, keySource, identity, trackingHeaders } = args;
+  const { runId, costPrefix, inputTokens, outputTokens, keySource, identity, trackingHeaders, searchCostName, searchQuantity } = args;
   const items: CostItem[] = [
     { costName: `${costPrefix}-tokens-input`, quantity: inputTokens, costSource: keySource, status: "provisioned" },
     { costName: `${costPrefix}-tokens-output`, quantity: outputTokens, costSource: keySource, status: "provisioned" },
+    ...(searchCostName && searchQuantity
+      ? [{ costName: searchCostName, quantity: searchQuantity, costSource: keySource, status: "provisioned" as const }]
+      : []),
   ];
   const costs = await addRunCosts(runId, items, identity, trackingHeaders);
   return costs.map((c) => c.id);
@@ -669,8 +726,11 @@ async function provisionAndAuthorizeLlmCost(args: {
   identity: RunIdentityHeaders;
   trackingHeaders: Record<string, string>;
   description: string;
+  /** When set (webSearch on), provision + authorize a worst-case web-search hold. */
+  searchCostName?: string;
+  searchQuantity?: number;
 }): Promise<string[]> {
-  const { runId, costPrefix, inputTokens, outputTokens, keySource, identity, trackingHeaders, description } = args;
+  const { runId, costPrefix, inputTokens, outputTokens, keySource, identity, trackingHeaders, description, searchCostName, searchQuantity } = args;
   const costIds = await provisionLlmCost(args);
   if (keySource === "platform") {
     try {
@@ -678,6 +738,9 @@ async function provisionAndAuthorizeLlmCost(args: {
         items: [
           { costName: `${costPrefix}-tokens-input`, quantity: inputTokens },
           { costName: `${costPrefix}-tokens-output`, quantity: outputTokens },
+          ...(searchCostName && searchQuantity
+            ? [{ costName: searchCostName, quantity: searchQuantity }]
+            : []),
         ],
         description,
         orgId: identity.orgId,
@@ -1173,7 +1236,7 @@ app.post("/orgs/rag/embed", requireAuth, async (req, res) => {
   }
 });
 
-// --- Internal Platform Complete (no billing, no run tracking) ---
+// --- Internal Platform Complete (platform run tracking + cost, no org billing) ---
 
 app.post("/internal/platform-complete", requireInternalAuth, async (req, res) => {
   const parsed = InternalPlatformCompleteRequestSchema.safeParse(req.body);
@@ -1183,12 +1246,16 @@ app.post("/internal/platform-complete", requireInternalAuth, async (req, res) =>
       .json({ error: "Invalid request", details: parsed.error.flatten() });
   }
 
-  const { message, systemPrompt, responseFormat, responseSchema, temperature, provider: requestedProvider, model: requestedModel } = parsed.data;
+  const { message, systemPrompt, responseFormat, responseSchema, temperature, provider: requestedProvider, model: requestedModel, webSearch: webSearchRaw } = parsed.data;
+  const webSearch = webSearchRaw === true;
 
   const resolved = resolveModel(requestedProvider as Provider, requestedModel as ModelAlias);
   const effectiveModel = resolved.apiModelId;
   const isGemini = resolved.provider === "google";
   const provider = resolved.provider;
+  const costPrefix = resolved.costPrefix;
+  // Native web-search cost name (byte-equal to costs-service catalog) — only when opted in.
+  const searchCostName = webSearch ? webSearchCostName(isGemini) : undefined;
 
   // Passing a responseSchema implies JSON-mode parsing of the response.
   const jsonMode = responseFormat === "json" || responseSchema != null;
@@ -1215,8 +1282,23 @@ app.post("/internal/platform-complete", requireInternalAuth, async (req, res) =>
     });
   }
 
+  // Create a platform run so LLM (and web-search) spend is declared. Platform
+  // key spend, no org → costSource "platform", no affordability authorize. Fail
+  // loud — a cost that can't be tracked must block the op, not silently spend.
+  let runId: string;
   try {
-    let result: { content: string; tokensInput: number; tokensOutput: number; model: string };
+    const run = await createPlatformRun({ serviceName: "chat-service", taskName: "platform-complete" });
+    runId = run.id;
+  } catch (runErr) {
+    console.error(`[internal/platform-complete] platform-run creation failed:`, runErr);
+    return res.status(502).json({
+      error: "Service temporarily unavailable (run tracking). Please try again.",
+    });
+  }
+
+  let platformFailed = false;
+  try {
+    let result: { content: string; tokensInput: number; tokensOutput: number; model: string; searchCount: number; sources: Array<{ url: string; title?: string }> };
 
     if (isGemini) {
       result = await completeWithGemini({
@@ -1227,6 +1309,7 @@ app.post("/internal/platform-complete", requireInternalAuth, async (req, res) =>
         responseFormat,
         responseSchema,
         temperature,
+        webSearch,
       });
     } else {
       const claude = createAnthropicClient({ apiKey, systemPrompt });
@@ -1235,11 +1318,28 @@ app.post("/internal/platform-complete", requireInternalAuth, async (req, res) =>
         responseSchema,
         temperature,
         model: effectiveModel,
+        webSearch,
       });
     }
 
+    // Declare ACTUAL costs on the platform run BEFORE responding. Platform runs
+    // have no cost-status PATCH, so there is no provision/cancel — costs are
+    // posted as `actual` post-call. Throws (fail loud → 502) if undeclarable.
+    const costItems: CostItem[] = [
+      ...(result.tokensInput > 0
+        ? [{ costName: `${costPrefix}-tokens-input`, quantity: result.tokensInput, costSource: "platform" as const }]
+        : []),
+      ...(result.tokensOutput > 0
+        ? [{ costName: `${costPrefix}-tokens-output`, quantity: result.tokensOutput, costSource: "platform" as const }]
+        : []),
+      ...(searchCostName && result.searchCount > 0
+        ? [{ costName: searchCostName, quantity: result.searchCount, costSource: "platform" as const }]
+        : []),
+    ];
+    await addPlatformRunCosts(runId, "chat-service", costItems);
+
     const response: Record<string, unknown> = {
-      content: result.content,
+      content: jsonMode ? result.content : appendSources(result.content, result.sources),
       tokensInput: result.tokensInput,
       tokensOutput: result.tokensOutput,
       model: result.model,
@@ -1252,10 +1352,17 @@ app.post("/internal/platform-complete", requireInternalAuth, async (req, res) =>
 
     res.json(response);
   } catch (err) {
+    platformFailed = true;
     console.error(`[internal/platform-complete] LLM call failed:`, err);
     res.status(502).json({
       error: "LLM call failed. Please try again.",
     });
+  } finally {
+    try {
+      await updatePlatformRunStatus(runId, "chat-service", platformFailed ? "failed" : "completed");
+    } catch (statusErr) {
+      console.error(`[internal/platform-complete] failed to finalize platform run runId="${runId}":`, statusErr);
+    }
   }
 });
 

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -1106,12 +1106,23 @@ export function createAnthropicClient({ apiKey, systemPrompt }: AnthropicOptions
         temperature?: number;
         model?: string;
         imageUrl?: string;
+        /**
+         * Opt-in native server-side web search. When true, attaches Anthropic's
+         * `web_search_20250305` tool so Claude answers from live web results.
+         * Default (false/undefined) is byte-identical to a non-grounded call.
+         * See POST /complete `webSearch`.
+         */
+        webSearch?: boolean;
       },
     ): Promise<{
       content: string;
       tokensInput: number;
       tokensOutput: number;
       model: string;
+      /** Number of server-side web searches Claude ran (0 when off). */
+      searchCount: number;
+      /** Citation/result source URLs surfaced by web_search (empty when off). */
+      sources: Array<{ url: string; title?: string }>;
     }> {
       const effectiveModel = options?.model ?? MODEL;
 
@@ -1148,6 +1159,15 @@ export function createAnthropicClient({ apiKey, systemPrompt }: AnthropicOptions
               },
             }
           : {}),
+        // Native server-side web search. Attached only when requested, keeping
+        // non-grounded calls byte-identical. max_uses caps billable searches.
+        ...(options?.webSearch
+          ? {
+              tools: [
+                { type: "web_search_20250305", name: "web_search", max_uses: 5 },
+              ],
+            }
+          : {}),
       };
 
       const timeoutMs = ANTHROPIC_TIMEOUT_MS[effectiveModel] ?? DEFAULT_ANTHROPIC_TIMEOUT_MS;
@@ -1176,11 +1196,40 @@ export function createAnthropicClient({ apiKey, systemPrompt }: AnthropicOptions
       );
       const content = textBlocks.map((b) => b.text).join("");
 
+      // Native web-search accounting. The Anthropic SDK types lag the
+      // server-tool fields, so read them structurally. searchCount is the
+      // billable unit (one per `web_search_requests`); sources are the cited
+      // and returned result URLs (deduped) surfaced for the caller's answer.
+      const usage = response.usage as unknown as {
+        server_tool_use?: { web_search_requests?: number };
+      };
+      const searchCount = usage.server_tool_use?.web_search_requests ?? 0;
+      const sources: Array<{ url: string; title?: string }> = [];
+      const seenUrls = new Set<string>();
+      const addSource = (url: unknown, title: unknown) => {
+        if (typeof url !== "string" || url.length === 0 || seenUrls.has(url)) return;
+        seenUrls.add(url);
+        sources.push({ url, title: typeof title === "string" ? title : undefined });
+      };
+      for (const block of response.content as unknown as Array<Record<string, unknown>>) {
+        if (block.type === "text" && Array.isArray(block.citations)) {
+          for (const c of block.citations as Array<Record<string, unknown>>) {
+            if (c?.type === "web_search_result_location") addSource(c.url, c.title);
+          }
+        } else if (block.type === "web_search_tool_result" && Array.isArray(block.content)) {
+          for (const r of block.content as Array<Record<string, unknown>>) {
+            if (r?.type === "web_search_result") addSource(r.url, r.title);
+          }
+        }
+      }
+
       return {
         content,
         tokensInput: response.usage.input_tokens,
         tokensOutput: response.usage.output_tokens,
         model: effectiveModel,
+        searchCount,
+        sources,
       };
     },
   };

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -74,6 +74,19 @@ interface GeminiCompleteOptions {
    */
   responseSchema?: Record<string, unknown>;
   temperature?: number;
+  /**
+   * Opt-in native Google Search grounding. When true, the request attaches the
+   * `googleSearch` tool so Gemini answers from live web results instead of
+   * parametric memory. Default (false/undefined) is byte-identical to a
+   * non-grounded call. See POST /complete `webSearch`.
+   */
+  webSearch?: boolean;
+}
+
+/** A web source surfaced by native grounding/search (provider-agnostic shape). */
+export interface WebSearchSource {
+  url: string;
+  title?: string;
 }
 
 interface GeminiCompleteResult {
@@ -81,6 +94,10 @@ interface GeminiCompleteResult {
   tokensInput: number;
   tokensOutput: number;
   model: string;
+  /** Number of Google Search queries the model ran (0 when grounding is off). */
+  searchCount: number;
+  /** Grounding source URLs surfaced via groundingMetadata (empty when off). */
+  sources: WebSearchSource[];
 }
 
 /**
@@ -162,6 +179,10 @@ async function callGeminiOnce(
     candidates?: Array<{
       content?: { parts?: Array<{ text?: string }> };
       finishReason?: string;
+      groundingMetadata?: {
+        webSearchQueries?: string[];
+        groundingChunks?: Array<{ web?: { uri?: string; title?: string } }>;
+      };
     }>;
     usageMetadata?: {
       promptTokenCount?: number;
@@ -187,11 +208,26 @@ async function callGeminiOnce(
       ?.map((p) => p.text ?? "")
       .join("") ?? "";
 
+  // Grounding metadata (present only when the googleSearch tool ran).
+  const grounding = data.candidates?.[0]?.groundingMetadata;
+  const searchCount = grounding?.webSearchQueries?.length ?? 0;
+  const seen = new Set<string>();
+  const sources: WebSearchSource[] = [];
+  for (const chunk of grounding?.groundingChunks ?? []) {
+    const uri = chunk.web?.uri;
+    if (typeof uri === "string" && uri.length > 0 && !seen.has(uri)) {
+      seen.add(uri);
+      sources.push({ url: uri, title: chunk.web?.title });
+    }
+  }
+
   return {
     content,
     tokensInput: data.usageMetadata?.promptTokenCount ?? 0,
     tokensOutput: data.usageMetadata?.candidatesTokenCount ?? 0,
     model,
+    searchCount,
+    sources,
   };
 }
 
@@ -289,6 +325,7 @@ export async function completeWithGemini(options: GeminiCompleteOptions): Promis
     responseFormat,
     responseSchema,
     temperature,
+    webSearch,
   } = options;
 
   // Passing a responseSchema implies JSON mode regardless of responseFormat.
@@ -331,7 +368,9 @@ export async function completeWithGemini(options: GeminiCompleteOptions): Promis
     }
   }
 
-  // Build request body
+  // Build request body. When webSearch is on, attach the native googleSearch
+  // grounding tool so Gemini answers from live web results. Omitted entirely
+  // when off, keeping non-grounded requests byte-identical.
   const body: Record<string, unknown> = {
     contents: [{ parts }],
     systemInstruction: { parts: [{ text: systemPrompt }] },
@@ -340,6 +379,7 @@ export async function completeWithGemini(options: GeminiCompleteOptions): Promis
       ...(jsonMode ? { responseMimeType: "application/json" } : {}),
       ...(sanitizedSchema != null ? { responseSchema: sanitizedSchema } : {}),
     },
+    ...(webSearch ? { tools: [{ googleSearch: {} }] } : {}),
   };
 
   // --- Retry loop on the primary model ---

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -147,3 +147,81 @@ export async function updateRunCostStatus(
     trackingHeaders,
   );
 }
+
+// --- Platform runs (no org/user identity — system-level callers) -------------
+//
+// Platform runs let internal, org-less calls (e.g. /internal/platform-complete
+// used for startup workflow upgrades) declare their LLM spend. Auth is
+// x-api-key + x-service-name only — no x-org-id/x-user-id/x-run-id. There is no
+// cost-status PATCH on platform runs, so callers declare costs as `actual`
+// after the call rather than provision→cancel.
+
+function buildPlatformHeaders(serviceName: string): Record<string, string> {
+  if (!RUNS_SERVICE_API_KEY) {
+    throw new Error("[runs-client] RUNS_SERVICE_API_KEY is required");
+  }
+  return {
+    "Content-Type": "application/json",
+    "x-api-key": RUNS_SERVICE_API_KEY,
+    "x-service-name": serviceName,
+  };
+}
+
+async function platformRunsRequest<T>(
+  method: string,
+  path: string,
+  serviceName: string,
+  body?: unknown,
+): Promise<T> {
+  const res = await fetch(`${RUNS_SERVICE_URL}${path}`, {
+    method,
+    headers: buildPlatformHeaders(serviceName),
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `[runs-client] ${method} ${path} returned ${res.status}: ${text}`,
+    );
+  }
+  return (await res.json()) as T;
+}
+
+export async function createPlatformRun(
+  params: CreateRunParams,
+): Promise<RunsRun> {
+  return platformRunsRequest<RunsRun>(
+    "POST",
+    "/v1/platform-runs",
+    params.serviceName,
+    { serviceName: params.serviceName, taskName: params.taskName },
+  );
+}
+
+export async function addPlatformRunCosts(
+  id: string,
+  serviceName: string,
+  items: CostItem[],
+): Promise<RunCost[]> {
+  if (items.length === 0) return [];
+  const res = await platformRunsRequest<{ costs: RunCost[] }>(
+    "POST",
+    `/v1/platform-runs/${id}/costs`,
+    serviceName,
+    { items },
+  );
+  return res.costs;
+}
+
+export async function updatePlatformRunStatus(
+  id: string,
+  serviceName: string,
+  status: "completed" | "failed",
+): Promise<RunsRun> {
+  return platformRunsRequest<RunsRun>(
+    "PATCH",
+    `/v1/platform-runs/${id}`,
+    serviceName,
+    { status },
+  );
+}

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -413,6 +413,16 @@ export const CompleteRequestSchema = z
         "The model must match the provider: anthropic → haiku|sonnet|opus, google → flash-lite|flash|pro.",
       example: "sonnet",
     }),
+    webSearch: z.boolean().optional().openapi({
+      description:
+        "Opt-in native web search. When true, the resolved provider answers using its OWN " +
+        "native web search — Google Search grounding for `google`, the server-side `web_search` " +
+        "tool for `anthropic` — so the response reflects live web content instead of the model's " +
+        "parametric memory. Citation source URLs are appended to `content` (text mode only). " +
+        "Omitted or false = no grounding, byte-identical to a non-grounded call (no extra cost). " +
+        "The web-search cost is metered per query/search and billed in addition to tokens.",
+      example: true,
+    }),
     imageUrl: z.string().url().optional().openapi({
       description: "URL of an image to include in the prompt. The image is fetched server-side and sent to the model as a visual input. Supported by all models, but recommended with provider: \"google\", model: \"flash-lite\" for cost-effective vision tasks (image classification, scoring, analysis).",
       example: "https://example.com/images/hero.jpg",
@@ -591,6 +601,15 @@ export const InternalPlatformCompleteRequestSchema = z
     model: z.enum(["haiku", "sonnet", "opus", "flash-lite", "flash", "pro"]).openapi({
       description: "Model alias (version-free).",
       example: "sonnet",
+    }),
+    webSearch: z.boolean().optional().openapi({
+      description:
+        "Opt-in native web search. When true, the resolved provider answers using its OWN native " +
+        "web search (Google Search grounding for `google`, server-side `web_search` for `anthropic`). " +
+        "Citation source URLs are appended to `content` (text mode only). Omitted or false = no " +
+        "grounding, byte-identical to a non-grounded call. The web-search cost is declared on the " +
+        "platform run in addition to tokens.",
+      example: true,
     }),
   })
   .openapi("InternalPlatformCompleteRequest");

--- a/tests/integration/complete-cost.test.ts
+++ b/tests/integration/complete-cost.test.ts
@@ -131,6 +131,32 @@ function mockGeminiComplete(cap: { calls: number }) {
   } satisfies MockRoute;
 }
 
+// Grounded Gemini response: 3 search queries + 1 source chunk.
+function mockGeminiGrounded(cap: { calls: number }) {
+  return {
+    match: (url: string) => url.includes(":generateContent") && url.includes("generativelanguage.googleapis.com"),
+    respond: () => {
+      cap.calls += 1;
+      return {
+        ok: true,
+        body: {
+          candidates: [
+            {
+              content: { parts: [{ text: "Live answer." }] },
+              finishReason: "STOP",
+              groundingMetadata: {
+                webSearchQueries: ["q1", "q2", "q3"],
+                groundingChunks: [{ web: { uri: "https://src.example/1", title: "Src 1" } }],
+              },
+            },
+          ],
+          usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5 },
+        },
+      };
+    },
+  } satisfies MockRoute;
+}
+
 const AUTH = { "x-api-key": "test-key", "x-org-id": "org-1", "x-user-id": "user-1", "x-run-id": "parent-run-1" };
 
 describe("POST /complete — cost provision → authorize → execute → reconcile", () => {
@@ -203,6 +229,43 @@ describe("POST /complete — cost provision → authorize → execute → reconc
 
     expect(res.status).toBe(502);
     expect(gemini.calls).toBe(0);
+  });
+
+  it("webSearch:true provisions + authorizes + actuals the google-search-query cost and appends Sources", async () => {
+    const cap = { postedItems: [] as Array<Array<{ costName: string; quantity: number; status?: string }>>, patchedStatuses: [] as string[] };
+    const gemini = { calls: 0 };
+    routes.push(mockRunsCreate(), mockKeyDecrypt(), mockBilling(), mockGeminiGrounded(gemini), ...mockRunsCostRoutes(cap), mockRunsStatusPatch());
+
+    const res = await request(app)
+      .post("/complete")
+      .set(AUTH)
+      .send({ message: "who won?", systemPrompt: "be brief", provider: "google", model: "flash", webSearch: true });
+
+    expect(res.status).toBe(200);
+    expect(gemini.calls).toBe(1);
+
+    // PROVISION: 3 worst-case items incl the google-search-query hold (qty 5).
+    const provision = cap.postedItems[0];
+    expect(provision).toHaveLength(3);
+    expect(provision.every((i) => i.status === "provisioned")).toBe(true);
+    expect(provision.map((i) => i.costName).sort()).toEqual([
+      "google-flash-3-tokens-input",
+      "google-flash-3-tokens-output",
+      "google-search-query",
+    ]);
+    expect(provision.find((i) => i.costName === "google-search-query")!.quantity).toBe(5);
+
+    // ACTUAL: google-search-query records the REAL query count (3).
+    const actual = cap.postedItems.find((items) => items.some((i) => i.status === undefined));
+    expect(actual).toBeDefined();
+    expect(actual!.find((i) => i.costName === "google-search-query")!.quantity).toBe(3);
+
+    // Citation source URLs surface in the response content text.
+    expect(res.body.content).toContain("Sources:");
+    expect(res.body.content).toContain("https://src.example/1");
+
+    // RECONCILE: all 3 provisioned holds cancelled.
+    expect(cap.patchedStatuses.filter((s) => s === "cancelled")).toHaveLength(3);
   });
 
   it("returns 402 and does NOT call the model when billing reports insufficient credits", async () => {

--- a/tests/integration/platform-complete-cost.test.ts
+++ b/tests/integration/platform-complete-cost.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
+import request from "supertest";
+
+// /internal/platform-complete now declares its LLM (and web-search) spend on a
+// platform run: create platform-run → execute → POST actual costs → PATCH status.
+// Platform key spend, no org → costSource "platform", no affordability authorize,
+// no provision/cancel (platform runs have no cost-status PATCH). google provider
+// (fetch-mockable, non-streaming, no DB).
+
+process.env.NODE_ENV = "test";
+process.env.KEY_SERVICE_API_KEY = process.env.KEY_SERVICE_API_KEY || "test-key-svc-key";
+process.env.KEY_SERVICE_URL = process.env.KEY_SERVICE_URL || "https://key.test.local";
+process.env.RUNS_SERVICE_API_KEY = process.env.RUNS_SERVICE_API_KEY || "test-runs-key";
+process.env.RUNS_SERVICE_URL = process.env.RUNS_SERVICE_URL || "https://runs.test.local";
+
+interface MockRoute {
+  match: (url: string, init?: RequestInit) => boolean;
+  respond: (url: string, init?: RequestInit) => { ok: boolean; status?: number; body: unknown };
+}
+
+let routes: MockRoute[] = [];
+let fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
+
+function buildResponse(out: { ok: boolean; status?: number; body: unknown }): Response {
+  return {
+    ok: out.ok,
+    status: out.status ?? (out.ok ? 200 : 500),
+    json: () => Promise.resolve(out.body),
+    text: () =>
+      Promise.resolve(typeof out.body === "string" ? out.body : JSON.stringify(out.body)),
+    headers: new Headers(),
+  } as unknown as Response;
+}
+
+function installFetchMock() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      fetchCalls.push({ url, init });
+      for (const route of routes) {
+        if (route.match(url, init)) return buildResponse(route.respond(url, init));
+      }
+      throw new Error(`[test] Unmocked fetch: ${url}`);
+    }),
+  );
+}
+
+function mockPlatformKey() {
+  return {
+    match: (url: string) => url.includes("/keys/platform/google/decrypt"),
+    respond: () => ({ ok: true, body: { provider: "google", key: "fake-google-key", keySource: "platform" } }),
+  } satisfies MockRoute;
+}
+
+function mockPlatformRunCreate(cap: { headers: Array<Record<string, unknown>>; bodies: unknown[] }) {
+  return {
+    match: (url: string, init?: RequestInit) => url.endsWith("/v1/platform-runs") && (init?.method ?? "GET") === "POST",
+    respond: (_url: string, init?: RequestInit) => {
+      cap.headers.push((init?.headers ?? {}) as Record<string, unknown>);
+      cap.bodies.push(init?.body ? JSON.parse(init.body as string) : null);
+      return { ok: true, status: 201, body: { id: "prun-1", status: "running" } };
+    },
+  } satisfies MockRoute;
+}
+
+function mockPlatformRunCosts(cap: {
+  postedItems: Array<Array<{ costName: string; quantity: number; status?: string; costSource?: string }>>;
+  costStatus?: number;
+}) {
+  return {
+    match: (url: string, init?: RequestInit) =>
+      /\/v1\/platform-runs\/[^/]+\/costs$/.test(url) && (init?.method ?? "GET") === "POST",
+    respond: (_url: string, init?: RequestInit) => {
+      const items = init?.body
+        ? (JSON.parse(init.body as string) as { items: Array<{ costName: string; quantity: number; status?: string; costSource?: string }> }).items
+        : [];
+      cap.postedItems.push(items);
+      if (cap.costStatus && cap.costStatus >= 400) {
+        return { ok: false, status: cap.costStatus, body: { error: "Unknown cost" } };
+      }
+      return { ok: true, status: 201, body: { costs: items.map((it, i) => ({ id: `cost-${i}`, ...it })) } };
+    },
+  } satisfies MockRoute;
+}
+
+function mockPlatformRunStatus(cap: { patchedStatuses: string[] }) {
+  return {
+    match: (url: string, init?: RequestInit) =>
+      /\/v1\/platform-runs\/[^/]+$/.test(url) && (init?.method ?? "GET") === "PATCH",
+    respond: (_url: string, init?: RequestInit) => {
+      const body = init?.body ? (JSON.parse(init.body as string) as { status: string }) : { status: "?" };
+      cap.patchedStatuses.push(body.status);
+      return { ok: true, body: { id: "prun-1", status: body.status } };
+    },
+  } satisfies MockRoute;
+}
+
+function mockGemini(cap: { calls: number }, grounded = false) {
+  return {
+    match: (url: string) => url.includes(":generateContent") && url.includes("generativelanguage.googleapis.com"),
+    respond: () => {
+      cap.calls += 1;
+      const candidate: Record<string, unknown> = {
+        content: { parts: [{ text: "platform answer" }] },
+        finishReason: "STOP",
+      };
+      if (grounded) {
+        candidate.groundingMetadata = {
+          webSearchQueries: ["q1", "q2"],
+          groundingChunks: [{ web: { uri: "https://src.example/1", title: "Src 1" } }],
+        };
+      }
+      return {
+        ok: true,
+        body: { candidates: [candidate], usageMetadata: { promptTokenCount: 12, candidatesTokenCount: 7 } },
+      };
+    },
+  } satisfies MockRoute;
+}
+
+const AUTH = { "x-api-key": "test-key" };
+
+describe("POST /internal/platform-complete — platform run tracking + cost", () => {
+  let app: Awaited<ReturnType<typeof loadApp>>;
+  async function loadApp() {
+    vi.resetModules();
+    return (await import("../../src/index.js")).default;
+  }
+  beforeAll(async () => {
+    app = await loadApp();
+  });
+  beforeEach(() => {
+    routes = [];
+    fetchCalls = [];
+    installFetchMock();
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("creates a platform run, declares actual token costs, and finalizes the run", async () => {
+    const runCap = { headers: [] as Array<Record<string, unknown>>, bodies: [] as unknown[] };
+    const costCap = { postedItems: [] as Array<Array<{ costName: string; quantity: number; status?: string; costSource?: string }>> };
+    const statusCap = { patchedStatuses: [] as string[] };
+    const gemini = { calls: 0 };
+    routes.push(
+      mockPlatformKey(),
+      mockPlatformRunCreate(runCap),
+      mockPlatformRunCosts(costCap),
+      mockPlatformRunStatus(statusCap),
+      mockGemini(gemini),
+    );
+
+    const res = await request(app)
+      .post("/internal/platform-complete")
+      .set(AUTH)
+      .send({ message: "hi", systemPrompt: "be brief", provider: "google", model: "flash" });
+
+    expect(res.status).toBe(200);
+    expect(gemini.calls).toBe(1);
+
+    // Platform run created with serviceName/taskName + x-service-name header.
+    expect(runCap.bodies[0]).toMatchObject({ serviceName: "chat-service", taskName: "platform-complete" });
+    expect((runCap.headers[0] as Record<string, string>)["x-service-name"]).toBe("chat-service");
+
+    // ACTUAL token costs posted (no provisioned status), costSource platform.
+    const actual = costCap.postedItems[0];
+    expect(actual.find((i) => i.costName === "google-flash-3-tokens-input")!.quantity).toBe(12);
+    expect(actual.find((i) => i.costName === "google-flash-3-tokens-output")!.quantity).toBe(7);
+    expect(actual.every((i) => i.status === undefined)).toBe(true);
+    expect(actual.every((i) => i.costSource === "platform")).toBe(true);
+
+    // Run finalized completed.
+    expect(statusCap.patchedStatuses).toContain("completed");
+  });
+
+  it("declares the google-search-query cost and appends Sources when webSearch is true", async () => {
+    const runCap = { headers: [] as Array<Record<string, unknown>>, bodies: [] as unknown[] };
+    const costCap = { postedItems: [] as Array<Array<{ costName: string; quantity: number; status?: string; costSource?: string }>> };
+    const statusCap = { patchedStatuses: [] as string[] };
+    const gemini = { calls: 0 };
+    routes.push(
+      mockPlatformKey(),
+      mockPlatformRunCreate(runCap),
+      mockPlatformRunCosts(costCap),
+      mockPlatformRunStatus(statusCap),
+      mockGemini(gemini, true),
+    );
+
+    const res = await request(app)
+      .post("/internal/platform-complete")
+      .set(AUTH)
+      .send({ message: "who won?", systemPrompt: "be brief", provider: "google", model: "flash", webSearch: true });
+
+    expect(res.status).toBe(200);
+    const actual = costCap.postedItems[0];
+    expect(actual.find((i) => i.costName === "google-search-query")!.quantity).toBe(2);
+    expect(res.body.content).toContain("Sources:");
+    expect(res.body.content).toContain("https://src.example/1");
+  });
+
+  it("fails loud (502) when platform-run creation fails and does NOT call the model", async () => {
+    const gemini = { calls: 0 };
+    routes.push(
+      mockPlatformKey(),
+      {
+        match: (url: string, init?: RequestInit) => url.endsWith("/v1/platform-runs") && (init?.method ?? "GET") === "POST",
+        respond: () => ({ ok: false, status: 502, body: { error: "down" } }),
+      },
+      mockGemini(gemini),
+    );
+
+    const res = await request(app)
+      .post("/internal/platform-complete")
+      .set(AUTH)
+      .send({ message: "hi", systemPrompt: "be brief", provider: "google", model: "flash" });
+
+    expect(res.status).toBe(502);
+    expect(gemini.calls).toBe(0);
+  });
+});

--- a/tests/unit/anthropic-web-search.test.ts
+++ b/tests/unit/anthropic-web-search.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Native server-side web search on Anthropic complete(): the web_search_20250305
+ * tool is attached only when webSearch is true; the response's
+ * usage.server_tool_use.web_search_requests is surfaced as searchCount, and
+ * citation/result URLs are collected (deduped) as sources. webSearch off must be
+ * byte-identical to a non-grounded call.
+ */
+
+let capturedParams: Record<string, unknown> | undefined;
+
+const SEARCH_FINAL = {
+  content: [
+    { type: "text", text: "I'll search." },
+    { type: "server_tool_use", id: "srv1", name: "web_search", input: { query: "q" } },
+    {
+      type: "web_search_tool_result",
+      tool_use_id: "srv1",
+      content: [
+        { type: "web_search_result", url: "https://en.wikipedia.org/wiki/X", title: "X - Wikipedia", page_age: "April 2025" },
+      ],
+    },
+    {
+      type: "text",
+      text: "X was founded in 1916.",
+      citations: [
+        { type: "web_search_result_location", url: "https://en.wikipedia.org/wiki/X", title: "X - Wikipedia", cited_text: "X was founded..." },
+        { type: "web_search_result_location", url: "https://other.example/y", title: "Y", cited_text: "..." },
+      ],
+    },
+  ],
+  usage: { input_tokens: 100, output_tokens: 50, server_tool_use: { web_search_requests: 2 } },
+  stop_reason: "end_turn",
+};
+
+vi.mock("@anthropic-ai/sdk", () => {
+  return {
+    default: class MockAnthropic {
+      messages = {
+        create: () => {
+          throw new Error("create not implemented in mock — complete() must use stream");
+        },
+        stream: (params: Record<string, unknown>) => {
+          capturedParams = params;
+          return { finalMessage: async () => SEARCH_FINAL };
+        },
+      };
+    },
+  };
+});
+
+const { createAnthropicClient } = await import("../../src/lib/anthropic.js");
+
+describe("anthropic complete() — native web search", () => {
+  beforeEach(() => {
+    capturedParams = undefined;
+  });
+
+  it("attaches the web_search_20250305 tool only when webSearch is true", async () => {
+    const claude = createAnthropicClient({ apiKey: "test-key", systemPrompt: "Be brief." });
+    await claude.complete("who founded X?", { webSearch: true });
+
+    expect(capturedParams).toBeDefined();
+    expect(capturedParams!.tools).toEqual([
+      { type: "web_search_20250305", name: "web_search", max_uses: 5 },
+    ]);
+  });
+
+  it("does NOT attach tools when webSearch is off (byte-identical params)", async () => {
+    const claude = createAnthropicClient({ apiKey: "test-key", systemPrompt: "Be brief." });
+    await claude.complete("hello");
+
+    expect(capturedParams).toBeDefined();
+    expect(capturedParams!.tools).toBeUndefined();
+  });
+
+  it("surfaces searchCount from usage.server_tool_use.web_search_requests", async () => {
+    const claude = createAnthropicClient({ apiKey: "test-key", systemPrompt: "Be brief." });
+    const r = await claude.complete("who founded X?", { webSearch: true });
+    expect(r.searchCount).toBe(2);
+  });
+
+  it("collects deduped sources from citations and web_search_tool_result blocks", async () => {
+    const claude = createAnthropicClient({ apiKey: "test-key", systemPrompt: "Be brief." });
+    const r = await claude.complete("who founded X?", { webSearch: true });
+    expect(r.sources).toEqual([
+      { url: "https://en.wikipedia.org/wiki/X", title: "X - Wikipedia" },
+      { url: "https://other.example/y", title: "Y" },
+    ]);
+    // content is the concatenation of text blocks only
+    expect(r.content).toBe("I'll search.X was founded in 1916.");
+  });
+});

--- a/tests/unit/complete.test.ts
+++ b/tests/unit/complete.test.ts
@@ -30,6 +30,44 @@ describe("CompleteRequestSchema", () => {
     }
   });
 
+  it("accepts webSearch boolean (true)", () => {
+    const result = CompleteRequestSchema.safeParse({
+      message: "who won the match?",
+      systemPrompt: "Be brief.",
+      provider: "google",
+      model: "flash",
+      webSearch: true,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.webSearch).toBe(true);
+    }
+  });
+
+  it("defaults webSearch to undefined when omitted (no silent default)", () => {
+    const result = CompleteRequestSchema.safeParse({
+      message: "Hello",
+      systemPrompt: "You are helpful.",
+      provider: "anthropic",
+      model: "sonnet",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.webSearch).toBeUndefined();
+    }
+  });
+
+  it("rejects non-boolean webSearch", () => {
+    const result = CompleteRequestSchema.safeParse({
+      message: "Hello",
+      systemPrompt: "You are helpful.",
+      provider: "anthropic",
+      model: "sonnet",
+      webSearch: "yes",
+    });
+    expect(result.success).toBe(false);
+  });
+
   it("accepts optional responseSchema (JSON Schema object)", () => {
     const schema = {
       type: "object",

--- a/tests/unit/gemini-web-search.test.ts
+++ b/tests/unit/gemini-web-search.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { completeWithGemini } from "../../src/lib/gemini.js";
+
+// Native Google Search grounding on completeWithGemini: the googleSearch tool is
+// attached only when webSearch is true, and groundingMetadata is parsed into a
+// search-query count + deduped source URLs. webSearch off must be byte-identical.
+
+describe("completeWithGemini — native web search", () => {
+  const fetchSpy = vi.fn();
+
+  beforeEach(() => {
+    fetchSpy.mockReset();
+    vi.stubGlobal("fetch", fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  const base = {
+    apiKey: "test-key",
+    model: "gemini-3-flash-preview",
+    message: "who won the match?",
+    systemPrompt: "Be brief.",
+  };
+
+  const grounded = {
+    ok: true,
+    json: async () => ({
+      candidates: [
+        {
+          content: { parts: [{ text: "Team A won." }] },
+          finishReason: "STOP",
+          groundingMetadata: {
+            webSearchQueries: ["who won the match", "match result"],
+            groundingChunks: [
+              { web: { uri: "https://news.example/a", title: "News A" } },
+              { web: { uri: "https://news.example/a", title: "News A" } }, // dup
+              { web: { uri: "https://news.example/b", title: "News B" } },
+            ],
+          },
+        },
+      ],
+      usageMetadata: { promptTokenCount: 20, candidatesTokenCount: 8 },
+    }),
+  };
+
+  const ungrounded = {
+    ok: true,
+    json: async () => ({
+      candidates: [{ content: { parts: [{ text: "x" }] }, finishReason: "STOP" }],
+      usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1 },
+    }),
+  };
+
+  it("attaches the googleSearch tool only when webSearch is true", async () => {
+    fetchSpy.mockResolvedValueOnce(grounded);
+    await completeWithGemini({ ...base, webSearch: true });
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    expect(body.tools).toEqual([{ googleSearch: {} }]);
+  });
+
+  it("omits tools entirely when webSearch is off (byte-identical request)", async () => {
+    fetchSpy.mockResolvedValueOnce(ungrounded);
+    await completeWithGemini({ ...base });
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    expect(body.tools).toBeUndefined();
+  });
+
+  it("parses searchCount + deduped sources from groundingMetadata", async () => {
+    fetchSpy.mockResolvedValueOnce(grounded);
+    const r = await completeWithGemini({ ...base, webSearch: true });
+    expect(r.searchCount).toBe(2);
+    expect(r.sources).toEqual([
+      { url: "https://news.example/a", title: "News A" },
+      { url: "https://news.example/b", title: "News B" },
+    ]);
+    expect(r.content).toBe("Team A won.");
+  });
+
+  it("returns searchCount 0 and empty sources when no grounding metadata is present", async () => {
+    fetchSpy.mockResolvedValueOnce(ungrounded);
+    const r = await completeWithGemini({ ...base });
+    expect(r.searchCount).toBe(0);
+    expect(r.sources).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Job (JTBD)
ai-visibility-score-service measures how often brands appear in AI answers by querying a panel (google/flash + anthropic/sonnet) via `POST /complete`. Today `/complete` has no web search, so the panel answers from stale parametric memory — not the live, web-grounded answer a real user sees. This adds **opt-in** native web search so the measured answer reflects live web content (parity with Evertune/Profound).

## What changed
`POST /complete` and `POST /internal/platform-complete` accept **`webSearch?: boolean`** (default `false`).
- `google` → native Google Search grounding (`googleSearch` tool).
- `anthropic` → server-side `web_search_20250305` tool (`max_uses: 5`).
- **Default OFF → byte-identical to today** for every existing caller (no cost, no behavior change).
- Citation source URLs are appended to `content` as a `Sources:` block in **text mode** (surface in response text per AC1/AC2 + Anthropic ToS); JSON mode content is left untouched.
- Web-search cost declared via the existing **provision → authorize → reconcile** flow. Cost names byte-equal to costs-service catalog: `google-search-query` (exists) / `anthropic-web-search` (**new — see ordering**). Fail-loud on undeclarable cost.

## Bug fix bundled (per request)
`/internal/platform-complete` previously spent LLM tokens with **zero cost tracking**. It now creates a **platform run** (runs-service `POST /v1/platform-runs`) and declares actual token + web-search costs (`costSource: platform`, no org billing, no authorize, actual-only — platform runs have no cost-status PATCH). Fail-loud → 502 if the run/cost can't be declared.

## ⚠️ Deployment ordering
- **Gemini path** is self-contained — `google-search-query` already in the catalog. Safe on merge.
- **Anthropic path** needs the new `anthropic-web-search` costs-service catalog row (separate PR, spawned) deployed first, else runs-service 422 → 502. This PR is **non-breaking regardless**: the new cost only fires on an explicit `webSearch:true`+`anthropic` call, and the sole such caller (ai-visibility-score-service PR #39) is not yet merged.
- **Consumer** ai-visibility-score-service PR #39 sends `webSearch: boolean` (verified byte-equal) — merge after this deploys.

## Tests
- `gemini-web-search.test.ts`, `anthropic-web-search.test.ts` — tool attached only when on; searchCount + deduped sources parsed; off = byte-identical.
- `complete.test.ts` — `webSearch` schema accept/reject.
- `complete-cost.test.ts` — `webSearch:true` provisions+authorizes+actuals `google-search-query`; Sources appended.
- `platform-complete-cost.test.ts` — platform run created, actual costs declared, status finalized; +search cost; fail-loud 502.

649 passed / 16 skipped. (2 unrelated DB-gated integration tests need `CHAT_SERVICE_DATABASE_URL`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)