### PR TITLE
fix: gate chat provider calls by credits

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -93,6 +93,12 @@ import { buildContextUsageEvent } from "./lib/context-usage.js";
  * Returns a user-facing message and an error code the frontend can act on.
  */
 function classifyErrorForClient(err: unknown): { message: string; code: string } {
+  if (err instanceof ChatCostGateError) {
+    return {
+      code: err.statusCode === 402 ? "insufficient_credits" : "internal_error",
+      message: err.message,
+    };
+  }
   if (err instanceof Anthropic.APIError) {
     const errorBody = err.error as { type?: string; error?: { type?: string } } | undefined;
     const errorType = errorBody?.error?.type;
@@ -514,6 +520,20 @@ class InsufficientCreditsError extends Error {
     super("Insufficient credits");
     this.name = "InsufficientCreditsError";
   }
+}
+
+class ChatCostGateError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
+  ) {
+    super(message);
+    this.name = "ChatCostGateError";
+  }
+}
+
+function estimateRequestTokens(payload: unknown): number {
+  return Math.max(Math.ceil(JSON.stringify(payload).length / 4), 500);
 }
 
 /**
@@ -1408,42 +1428,6 @@ app.post("/chat", requireAuth, async (req, res) => {
     });
   }
 
-  // Credit authorization — only for platform keys (BYOK orgs pay their provider directly)
-  if (resolvedKey.keySource === "platform") {
-    // Estimate token quantities: input from message length (~4 chars/token, min 500),
-    // output from MAX_TOKENS budget (64 000)
-    const estimatedInputTokens = Math.max(Math.ceil(message.length / 4), 500);
-    const estimatedOutputTokens = 64_000;
-    try {
-      const authResult = await authorizeCredits({
-        items: [
-          { costName: `${resolvedModelInfo.costPrefix}-tokens-input`, quantity: estimatedInputTokens },
-          { costName: `${resolvedModelInfo.costPrefix}-tokens-output`, quantity: estimatedOutputTokens },
-        ],
-        description: `chat — ${resolvedModelInfo.apiModelId}`,
-        orgId,
-        userId,
-        runId: parentRunId,
-        trackingHeaders: Object.keys(trackingHeaders).length > 0 ? trackingHeaders : undefined,
-      });
-      if (!authResult.sufficient) {
-        console.warn(
-          `[chat] insufficient credits: org="${orgId}" balance_cents=${authResult.balance_cents} required_cents=${authResult.required_cents}`,
-        );
-        return res.status(402).json({
-          error: "Insufficient credits",
-          balance_cents: authResult.balance_cents,
-          required_cents: authResult.required_cents,
-        });
-      }
-    } catch (billingErr) {
-      console.error(`[chat] billing authorization failed for org="${orgId}":`, billingErr);
-      return res.status(502).json({
-        error: "Billing service unavailable. Please try again.",
-      });
-    }
-  }
-
   // Fetch campaign context if campaignId is present (Convention 2)
   let campaignFeatureInputs: Record<string, unknown> | null = null;
   if (workflowTracking.campaignId) {
@@ -1549,32 +1533,24 @@ app.post("/chat", requireAuth, async (req, res) => {
       return;
     }
 
-    // PROVISION worst-case LLM cost (input estimate + output budget) before the model
-    // call. Authorize already ran pre-stream above; output tokens are unknown until the
-    // stream ends, so reserve the max and true up to actual in the finally. Fail loud
-    // (SSE error — the stream is already open) if the cost can't be declared.
-    try {
-      provisionedCostIds = await provisionLlmCost({
-        runId,
-        costPrefix: resolvedModelInfo.costPrefix,
-        inputTokens: Math.max(Math.ceil(message.length / 4), 500),
-        outputTokens: 64_000,
-        keySource: resolvedKey.keySource,
-        identity: { orgId, userId, runId },
-        trackingHeaders,
-      });
-    } catch (provErr) {
-      chatFailed = true;
-      console.error(`[chat] cost provision failed runId="${runId}" org="${orgId}":`, provErr);
-      sendSSE(res, {
-        type: "error",
-        code: "internal_error",
-        message: "Cost provisioning failed. Please try again.",
-      });
-      sendSSE(res, "[DONE]");
-      res.end();
-      return;
-    }
+    const authorizeChatProviderCall = async (estimatedInputTokens: number): Promise<void> => {
+      try {
+        const costIds = await provisionAndAuthorizeLlmCost({
+          runId: runId!,
+          costPrefix: resolvedModelInfo.costPrefix,
+          inputTokens: estimatedInputTokens,
+          outputTokens: 64_000,
+          keySource: resolvedKey.keySource,
+          identity: { orgId, userId, runId: runId! },
+          trackingHeaders,
+          description: `chat — ${resolvedModelInfo.apiModelId}`,
+        });
+        provisionedCostIds.push(...costIds);
+      } catch (costErr) {
+        const r = costErrorResponse(costErr, "chat", orgId);
+        throw new ChatCostGateError(String(r.body.error), r.status);
+      }
+    };
 
     // Load conversation history (shared by both providers)
     const history = await db.query.messages.findMany({
@@ -2116,6 +2092,9 @@ app.post("/chat", requireAuth, async (req, res) => {
         sendSSE,
         executeTool,
         signal: abortController.signal,
+        beforeProviderCall: async ({ requestBody }) => {
+          await authorizeChatProviderCall(estimateRequestTokens(requestBody));
+        },
       });
 
       fullResponse = geminiResult.fullResponse;
@@ -2166,6 +2145,14 @@ app.post("/chat", requireAuth, async (req, res) => {
       for (let attempt = 0; attempt <= ANTHROPIC_STREAM_MAX_RETRIES; attempt++) {
         tokensEmitted = false;
         currentBlockType = null;
+        await authorizeChatProviderCall(
+          estimateRequestTokens({
+            model: resolvedModelInfo.apiModelId,
+            systemPrompt,
+            messages: turnMessages,
+            tools: allTools,
+          }),
+        );
         stream = claude!.createStream(turnMessages, allTools, abortController.signal);
 
         try {

--- a/src/lib/gemini-chat.ts
+++ b/src/lib/gemini-chat.ts
@@ -97,6 +97,11 @@ export type ToolExecutor = (
   call: { name: string; args: Record<string, unknown> },
 ) => Promise<ToolExecutorResult>;
 
+export type BeforeGeminiProviderCall = (details: {
+  depth: number;
+  requestBody: Record<string, unknown>;
+}) => Promise<void>;
+
 export interface StreamGeminiChatOptions {
   apiKey: string;
   model: string;
@@ -108,6 +113,7 @@ export interface StreamGeminiChatOptions {
   sendSSE: SendSSE;
   executeTool: ToolExecutor;
   signal: AbortSignal;
+  beforeProviderCall?: BeforeGeminiProviderCall;
 }
 
 export interface StreamGeminiChatResult {
@@ -350,6 +356,7 @@ export async function streamGeminiChat(
     sendSSE: sse,
     executeTool,
     signal,
+    beforeProviderCall,
   } = options;
 
   let totalTokensInput = 0;
@@ -401,6 +408,10 @@ export async function streamGeminiChat(
     };
 
     const url = `${GEMINI_API_BASE}/models/${encodeURIComponent(model)}:streamGenerateContent?alt=sse&key=${encodeURIComponent(apiKey)}`;
+
+    if (beforeProviderCall) {
+      await beforeProviderCall({ depth, requestBody: body });
+    }
 
     let response: Response;
     try {
@@ -503,7 +514,7 @@ export async function streamGeminiChat(
       sse(res, { type: "thinking_stop" });
     }
 
-    totalTokensInput = chunkTokensInput;
+    totalTokensInput += chunkTokensInput;
     totalTokensOutput += chunkTokensOutput;
 
     // No function calls — we're done

--- a/tests/integration/chat-cost.test.ts
+++ b/tests/integration/chat-cost.test.ts
@@ -1,0 +1,338 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import request from "supertest";
+
+process.env.NODE_ENV = "test";
+process.env.KEY_SERVICE_API_KEY = process.env.KEY_SERVICE_API_KEY || "test-key-svc-key";
+process.env.KEY_SERVICE_URL = process.env.KEY_SERVICE_URL || "https://key.test.local";
+process.env.ADMIN_DISTRIBUTE_API_KEY = process.env.ADMIN_DISTRIBUTE_API_KEY || "test-api-svc-key";
+process.env.API_SERVICE_URL = process.env.API_SERVICE_URL || "https://api.test.local";
+process.env.RUNS_SERVICE_API_KEY = process.env.RUNS_SERVICE_API_KEY || "test-runs-key";
+process.env.RUNS_SERVICE_URL = process.env.RUNS_SERVICE_URL || "https://runs.test.local";
+process.env.BILLING_SERVICE_API_KEY = process.env.BILLING_SERVICE_API_KEY || "test-billing-key";
+process.env.BILLING_SERVICE_URL = process.env.BILLING_SERVICE_URL || "https://billing.test.local";
+
+interface MockRoute {
+  match: (url: string, init?: RequestInit) => boolean;
+  respond: (url: string, init?: RequestInit) => { ok: boolean; status?: number; body: unknown; text?: string };
+}
+
+let routes: MockRoute[] = [];
+let fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
+
+const sessionId = "00000000-0000-4000-8000-000000000001";
+const runId = "00000000-0000-4000-8000-000000000002";
+
+vi.mock("../../src/db/index.js", () => {
+  const appConfig = {
+    id: "cfg-1",
+    orgId: "org-1",
+    key: "test-chat",
+    systemPrompt: "Be useful.",
+    allowedTools: ["list_workflows"],
+    provider: "google",
+    model: "flash",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  return {
+    db: {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => Promise.resolve([appConfig])),
+          limit: vi.fn(() => Promise.resolve([appConfig])),
+        })),
+      })),
+      insert: vi.fn(() => ({
+        values: vi.fn(() => ({
+          returning: vi.fn(() => Promise.resolve([{ id: sessionId }])),
+        })),
+      })),
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({
+          where: vi.fn(() => Promise.resolve()),
+        })),
+      })),
+      query: {
+        messages: {
+          findMany: vi.fn(() => Promise.resolve([])),
+        },
+      },
+    },
+  };
+});
+
+function buildResponse(out: { ok: boolean; status?: number; body: unknown; text?: string }): Response {
+  const text = out.text ?? (typeof out.body === "string" ? out.body : JSON.stringify(out.body));
+  return {
+    ok: out.ok,
+    status: out.status ?? (out.ok ? 200 : 500),
+    json: () => Promise.resolve(out.body),
+    text: () => Promise.resolve(text),
+    headers: new Headers(),
+    body: out.body instanceof ReadableStream ? out.body : undefined,
+  } as unknown as Response;
+}
+
+function sseResponse(chunks: unknown[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  const payload = chunks.map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`).join("");
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(payload));
+      controller.close();
+    },
+  });
+}
+
+function installFetchMock() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      fetchCalls.push({ url, init });
+      for (const route of routes) {
+        if (route.match(url, init)) return buildResponse(route.respond(url, init));
+      }
+      throw new Error(`[test] Unmocked fetch: ${url}`);
+    }),
+  );
+}
+
+function mockKeyDecrypt() {
+  return {
+    match: (url: string) => url.includes("/keys/google/decrypt"),
+    respond: () => ({ ok: true, body: { provider: "google", key: "fake-google-key", keySource: "platform" } }),
+  } satisfies MockRoute;
+}
+
+function mockRunCreate() {
+  return {
+    match: (url: string, init?: RequestInit) => url.endsWith("/v1/runs") && (init?.method ?? "GET") === "POST",
+    respond: () => ({ ok: true, status: 201, body: { id: runId, status: "running" } }),
+  } satisfies MockRoute;
+}
+
+function mockRunPatch() {
+  return {
+    match: (url: string, init?: RequestInit) => /\/v1\/runs\/[^/]+$/.test(url) && (init?.method ?? "GET") === "PATCH",
+    respond: () => ({ ok: true, body: { id: runId, status: "completed" } }),
+  } satisfies MockRoute;
+}
+
+function mockTraceEvents() {
+  return {
+    match: (url: string, init?: RequestInit) => /\/v1\/runs\/[^/]+\/events$/.test(url) && (init?.method ?? "GET") === "POST",
+    respond: () => ({ ok: true, status: 201, body: { id: "evt-1" } }),
+  } satisfies MockRoute;
+}
+
+function mockRunCosts(
+  capture: {
+    provisionCalls: number;
+    actualCalls: number;
+    actualItems?: Array<{ costName: string; quantity: number }>;
+  },
+  opts?: { provisionStatus?: number },
+) {
+  return {
+    match: (url: string, init?: RequestInit) => /\/v1\/runs\/[^/]+\/costs$/.test(url) && (init?.method ?? "GET") === "POST",
+    respond: (_url: string, init?: RequestInit) => {
+      const body = init?.body ? (JSON.parse(init.body as string) as { items: Array<{ status?: string }> }) : { items: [] };
+      const provisioned = body.items.some((item) => item.status === "provisioned");
+      if (provisioned) {
+        capture.provisionCalls += 1;
+        if (opts?.provisionStatus && opts.provisionStatus >= 400) {
+          return { ok: false, status: opts.provisionStatus, body: { error: "Unknown cost name" } };
+        }
+      } else {
+        capture.actualCalls += 1;
+        capture.actualItems = body.items as Array<{ costName: string; quantity: number }>;
+      }
+      return { ok: true, status: 201, body: { costs: body.items.map((item, i) => ({ id: `cost-${capture.provisionCalls}-${i}`, ...item })) } };
+    },
+  } satisfies MockRoute;
+}
+
+function mockCostPatch() {
+  return {
+    match: (url: string, init?: RequestInit) => /\/v1\/runs\/[^/]+\/costs\/[^/]+$/.test(url) && (init?.method ?? "GET") === "PATCH",
+    respond: () => ({ ok: true, body: { id: "cost-1", status: "cancelled" } }),
+  } satisfies MockRoute;
+}
+
+function mockBilling(capture: { calls: number }, opts?: { sufficient?: boolean }) {
+  return {
+    match: (url: string, init?: RequestInit) => url.includes("/v1/customer_balance/authorize") && (init?.method ?? "GET") === "POST",
+    respond: () => {
+      capture.calls += 1;
+      return {
+        ok: true,
+        body: { sufficient: opts?.sufficient ?? true, balance_cents: "100000", required_cents: "1" },
+      };
+    },
+  } satisfies MockRoute;
+}
+
+function mockWorkflowList() {
+  return {
+    match: (url: string, init?: RequestInit) => url.includes("/v1/workflows") && (init?.method ?? "GET") === "GET",
+    respond: () => ({ ok: true, body: { workflows: [{ id: "wf-1", name: "Workflow" }] } }),
+  } satisfies MockRoute;
+}
+
+function mockGeminiToolThenText(capture: { calls: number }) {
+  return {
+    match: (url: string, init?: RequestInit) => url.includes(":streamGenerateContent") && (init?.method ?? "GET") === "POST",
+    respond: () => {
+      capture.calls += 1;
+      if (capture.calls === 1) {
+        return {
+          ok: true,
+          body: sseResponse([
+            {
+              candidates: [{ content: { parts: [{ functionCall: { name: "list_workflows", args: {} } }] } }],
+              usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 3 },
+            },
+          ]),
+        };
+      }
+      return {
+        ok: true,
+        body: sseResponse([
+          {
+            candidates: [{ content: { parts: [{ text: "Done." }] } }],
+            usageMetadata: { promptTokenCount: 20, candidatesTokenCount: 5 },
+          },
+        ]),
+      };
+    },
+  } satisfies MockRoute;
+}
+
+const AUTH = {
+  "x-api-key": "test-key",
+  "x-org-id": "org-1",
+  "x-user-id": "user-1",
+  "x-run-id": "parent-run-1",
+};
+
+describe("POST /chat — provider-call credit gates", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    routes = [];
+    fetchCalls = [];
+    installFetchMock();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function loadApp() {
+    return (await import("../../src/index.js")).default;
+  }
+
+  it("provisions and authorizes before each Gemini provider call in the tool loop", async () => {
+    const app = await loadApp();
+    const gemini = { calls: 0 };
+    const costs = { provisionCalls: 0, actualCalls: 0 };
+    const billing = { calls: 0 };
+    routes.push(
+      mockKeyDecrypt(),
+      mockRunCreate(),
+      mockRunCosts(costs),
+      mockCostPatch(),
+      mockRunPatch(),
+      mockTraceEvents(),
+      mockBilling(billing),
+      mockWorkflowList(),
+      mockGeminiToolThenText(gemini),
+    );
+
+    const res = await request(app)
+      .post("/chat")
+      .set(AUTH)
+      .send({ configKey: "test-chat", message: "Use a tool then answer." });
+
+    expect(res.status).toBe(200);
+    expect(gemini.calls).toBe(2);
+    expect(costs.provisionCalls).toBe(2);
+    expect(billing.calls).toBe(2);
+    expect(costs.actualItems?.find((item) => item.costName.endsWith("-tokens-input"))?.quantity).toBe(30);
+
+    const providerCallIndexes = fetchCalls
+      .map((call, index) => ({ call, index }))
+      .filter(({ call }) => call.url.includes(":streamGenerateContent"))
+      .map(({ index }) => index);
+    const provisionIndexes = fetchCalls
+      .map((call, index) => ({ call, index }))
+      .filter(({ call }) => /\/v1\/runs\/[^/]+\/costs$/.test(call.url) && (call.init?.method ?? "GET") === "POST")
+      .map(({ index }) => index);
+    const billingIndexes = fetchCalls
+      .map((call, index) => ({ call, index }))
+      .filter(({ call }) => call.url.includes("/v1/customer_balance/authorize"))
+      .map(({ index }) => index);
+
+    expect(provisionIndexes[0]).toBeLessThan(providerCallIndexes[0]);
+    expect(billingIndexes[0]).toBeLessThan(providerCallIndexes[0]);
+    expect(provisionIndexes[1]).toBeLessThan(providerCallIndexes[1]);
+    expect(billingIndexes[1]).toBeLessThan(providerCallIndexes[1]);
+  });
+
+  it("does not call Gemini when provision is rejected", async () => {
+    const app = await loadApp();
+    const gemini = { calls: 0 };
+    const costs = { provisionCalls: 0, actualCalls: 0 };
+    const billing = { calls: 0 };
+    routes.push(
+      mockKeyDecrypt(),
+      mockRunCreate(),
+      mockRunCosts(costs, { provisionStatus: 422 }),
+      mockCostPatch(),
+      mockRunPatch(),
+      mockTraceEvents(),
+      mockBilling(billing),
+      mockWorkflowList(),
+      mockGeminiToolThenText(gemini),
+    );
+
+    const res = await request(app)
+      .post("/chat")
+      .set(AUTH)
+      .send({ configKey: "test-chat", message: "hello" });
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain("Cost authorization failed");
+    expect(gemini.calls).toBe(0);
+    expect(billing.calls).toBe(0);
+  });
+
+  it("does not call Gemini when billing reports insufficient credits", async () => {
+    const app = await loadApp();
+    const gemini = { calls: 0 };
+    const costs = { provisionCalls: 0, actualCalls: 0 };
+    const billing = { calls: 0 };
+    routes.push(
+      mockKeyDecrypt(),
+      mockRunCreate(),
+      mockRunCosts(costs),
+      mockCostPatch(),
+      mockRunPatch(),
+      mockTraceEvents(),
+      mockBilling(billing, { sufficient: false }),
+      mockWorkflowList(),
+      mockGeminiToolThenText(gemini),
+    );
+
+    const res = await request(app)
+      .post("/chat")
+      .set(AUTH)
+      .send({ configKey: "test-chat", message: "hello" });
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain("Insufficient credits");
+    expect(gemini.calls).toBe(0);
+    expect(billing.calls).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- move /chat credit gating to run immediately before each Anthropic/Gemini provider request
- provision + authorize every chat provider call, including tool-loop follow-up calls
- aggregate Gemini input usage across multiple provider calls for actual cost reconciliation
- add integration coverage for multi-call credit gating and no-provider-call failures

## Verification
- npm run build
- npm test -- tests/integration/chat-cost.test.ts tests/unit/gemini-chat.test.ts
- npm test -- tests/unit/gemini-chat.test.ts tests/integration/chat-cost.test.ts tests/integration/complete-cost.test.ts
- npm test (fails only on db-backed integration suites because CHAT_SERVICE_DATABASE_URL is not configured in this workspace: tests/integration/db.test.ts, tests/integration/rag-score.test.ts)