### PR TITLE
fix(chat): refresh brand profile from website

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ This endpoint is **idempotent** (upsert on `key`). Called on every cold start by
 | configKey | Tools | Purpose |
 |---|---|---|
 | `persona-editor` | `list_personas`, `create_persona`, `duplicate_persona`, `set_persona_status`, `request_user_input` | Read + curate a brand's customer personas via NL. |
-| `brand-profile-editor` | `get_brand_profile`, `save_brand_profile_version`, `request_user_input` | Read + version a brand's brand profile via NL. |
+| `brand-profile-editor` | `get_brand_profile`, `save_brand_profile_version`, `refresh_brand_profile_from_website`, `request_user_input` | Read, refresh from website, and version a brand's brand profile via NL. |
 
 Both default to `google`/`flash-pro`. The dashboard selects them by `configKey` and passes `context: { brandId }`; the tools act on that brand under the caller's org. The boot seed only upserts these two keys, so it never clobbers a dashboard-registered config.
 
@@ -623,6 +623,7 @@ Read-only and supporting workflow tools:
 |---|---|
 | `get_brand_profile` | Gets the current profile fields + version list. Read-only. `GET /v1/brands/:id/brand-profile` |
 | `save_brand_profile_version` | Saves a NEW immutable version. Supplies only `changes` (`set`/`setList`/`add`/`remove`); the tool reads current, merges, and POSTs the full field map, so prior versions are untouched and unchanged fields are preserved. `POST /v1/brands/:id/brand-profile` |
+| `refresh_brand_profile_from_website` | Handles explicit latest/current website refresh requests end to end: reads current profile, forces fresh website field extraction via `POST /v1/brands/extract-fields` with `resetCache: true`, saves the full merged field map as a NEW immutable version, and returns the new version plus changed fields. Read-only questions never use this path. |
 
 **UI tools:**
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,12 @@ import {
   type PersonaStatus,
   type BrandProfileChange,
 } from "./lib/brand-content-client.js";
+import {
+  formatBrandProfileWebsiteRefreshErrorMessage,
+  formatBrandProfileWebsiteRefreshMessage,
+  isBrandProfileWebsiteRefreshIntent,
+  refreshBrandProfileFromWebsite,
+} from "./lib/brand-profile-refresh.js";
 import { seedPlatformConfigs } from "./lib/seed-platform-configs.js";
 import {
   embedText,
@@ -1629,6 +1635,34 @@ app.post("/chat", requireAuth, async (req, res) => {
 
     const allTools = resolveToolSet(allowedToolNames);
     const allowedToolSet = new Set(allowedToolNames);
+    const downstreamTrackingHeaders = Object.keys(trackingHeaders).length > 0
+      ? trackingHeaders as Record<string, string>
+      : undefined;
+    const featureCallParams = {
+      orgId,
+      userId,
+      runId: runId!,
+      trackingHeaders: downstreamTrackingHeaders,
+    };
+    const brandProfileWebsiteRefreshIntent =
+      configKey === "brand-profile-editor" &&
+      isBrandProfileWebsiteRefreshIntent(message);
+
+    // Persona-editor + brand-profile-editor tools act on a SINGLE brand from
+    // context.brandId — require exactly one resolved brandId.
+    const requireSingleBrandId = (toolName: string): string => {
+      if (brandIds.length === 0) {
+        throw new Error(
+          `[chat] ${toolName} requires a brand — provide context.brandId`,
+        );
+      }
+      if (brandIds.length > 1) {
+        throw new Error(
+          `[chat] ${toolName} operates on a single brand, but ${brandIds.length} were provided`,
+        );
+      }
+      return brandIds[0];
+    };
 
     // Detect client disconnect to abort in-flight streams
     const abortController = new AbortController();
@@ -1937,12 +1971,6 @@ app.post("/chat", requireAuth, async (req, res) => {
       }
 
       // Built-in feature tools (feature-creator context only)
-      const featureCallParams = {
-        orgId,
-        userId,
-        runId: runId!,
-        trackingHeaders: Object.keys(trackingHeaders).length > 0 ? trackingHeaders as Record<string, string> : undefined,
-      };
 
       if (call.name === "create_feature") {
         const args = (call.args as Record<string, unknown>) || {};
@@ -2059,22 +2087,6 @@ app.post("/chat", requireAuth, async (req, res) => {
         return { name: call.name, result };
       }
 
-      // Persona-editor + brand-profile-editor tools. These act on a SINGLE
-      // brand from context.brandId — require exactly one resolved brandId.
-      const requireSingleBrandId = (toolName: string): string => {
-        if (brandIds.length === 0) {
-          throw new Error(
-            `[chat] ${toolName} requires a brand — provide context.brandId`,
-          );
-        }
-        if (brandIds.length > 1) {
-          throw new Error(
-            `[chat] ${toolName} operates on a single brand, but ${brandIds.length} were provided`,
-          );
-        }
-        return brandIds[0];
-      };
-
       if (call.name === "list_personas") {
         const args = (call.args as Record<string, unknown>) || {};
         const brandId = requireSingleBrandId("list_personas");
@@ -2157,7 +2169,71 @@ app.post("/chat", requireAuth, async (req, res) => {
         return { name: call.name, result };
       }
 
+      if (call.name === "refresh_brand_profile_from_website") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const brandId = requireSingleBrandId("refresh_brand_profile_from_website");
+        const result = await refreshBrandProfileFromWebsite(
+          brandId,
+          context,
+          featureCallParams,
+          args.fields,
+        );
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
       return null;
+    }
+
+    async function handleBrandProfileWebsiteRefreshIntent(): Promise<boolean> {
+      if (
+        !brandProfileWebsiteRefreshIntent ||
+        !allowedToolSet.has("refresh_brand_profile_from_website")
+      ) {
+        return false;
+      }
+
+      const args: Record<string, unknown> = {};
+      const toolCallId = `tc_${crypto.randomUUID()}`;
+      sendSSE(res, {
+        type: "tool_call",
+        id: toolCallId,
+        name: "refresh_brand_profile_from_website",
+        args,
+      });
+
+      try {
+        const brandId = requireSingleBrandId("refresh_brand_profile_from_website");
+        const result = await refreshBrandProfileFromWebsite(
+          brandId,
+          context,
+          featureCallParams,
+        );
+        toolCalls.push({ name: "refresh_brand_profile_from_website", args, result });
+        sendSSE(res, {
+          type: "tool_result",
+          id: toolCallId,
+          name: "refresh_brand_profile_from_website",
+          result,
+        });
+        fullResponse = formatBrandProfileWebsiteRefreshMessage(result);
+        sendSSE(res, { type: "token", content: fullResponse });
+      } catch (refreshErr) {
+        chatFailed = true;
+        const errorMessage = formatBrandProfileWebsiteRefreshErrorMessage(refreshErr);
+        const result = { error: errorMessage };
+        toolCalls.push({ name: "refresh_brand_profile_from_website", args, result });
+        sendSSE(res, {
+          type: "tool_result",
+          id: toolCallId,
+          name: "refresh_brand_profile_from_website",
+          result,
+        });
+        fullResponse = errorMessage;
+        sendSSE(res, { type: "token", content: fullResponse });
+      }
+
+      return true;
     }
 
     // -----------------------------------------------------------------------
@@ -2165,7 +2241,9 @@ app.post("/chat", requireAuth, async (req, res) => {
     // Provider-specific: Gemini uses streamGeminiChat(), Anthropic uses SDK
     // -----------------------------------------------------------------------
 
-    if (runId) {
+    const handledBrandProfileRefresh = await handleBrandProfileWebsiteRefreshIntent();
+
+    if (!handledBrandProfileRefresh && runId) {
       traceEvent(runId, "stream-start", { orgId, userId }, workflowTracking, {
         data: {
           provider: chatProvider,
@@ -2176,7 +2254,10 @@ app.post("/chat", requireAuth, async (req, res) => {
       });
     }
 
-    if (isGeminiChat) {
+    if (handledBrandProfileRefresh) {
+      // The deterministic brand-profile refresh already streamed its concise
+      // confirmation and populated fullResponse/toolCalls for persistence.
+    } else if (isGeminiChat) {
       // --- Gemini streaming path ---
       const geminiToolDefs: ToolDefinition[] = allTools.map((t) => ({
         name: t.name,

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -1123,6 +1123,40 @@ export const SAVE_BRAND_PROFILE_VERSION_TOOL: Anthropic.Tool = {
   },
 };
 
+export const REFRESH_BRAND_PROFILE_FROM_WEBSITE_TOOL: Anthropic.Tool = {
+  name: "refresh_brand_profile_from_website",
+  description:
+    "Refresh the current brand's profile from the latest/current website and save a NEW immutable version. Use this when the user asks to update, refresh, sync, regenerate, or save the brand profile from the latest/current website (including French requests like 'mets à jour avec mon dernier site web'). This tool reads the current profile, forces fresh website field extraction using context.fieldDefinitions when available, saves the full merged profile as a new version, and returns the new version plus changed fields. Do NOT call this for read-only questions or opinions.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      fields: {
+        type: "array",
+        description:
+          "Optional field definitions to extract if context.fieldDefinitions is unavailable. Each field needs a key and description.",
+        items: {
+          type: "object",
+          properties: {
+            key: {
+              type: "string",
+              description: "Machine-readable brand profile field key.",
+            },
+            description: {
+              type: "string",
+              description: "What to extract from the current website for this field.",
+            },
+            type: {
+              type: "string",
+              description: "Optional field type hint, e.g. text or list.",
+            },
+          },
+          required: ["key", "description"],
+        },
+      },
+    },
+  },
+};
+
 // ---------------------------------------------------------------------------
 // Tool registry — every tool the service knows how to execute.
 // Clients choose which subset to enable via allowedTools in their config.
@@ -1161,6 +1195,7 @@ export const TOOL_REGISTRY: Record<string, Anthropic.Tool> = {
   set_persona_status: SET_PERSONA_STATUS_TOOL,
   get_brand_profile: GET_BRAND_PROFILE_TOOL,
   save_brand_profile_version: SAVE_BRAND_PROFILE_VERSION_TOOL,
+  refresh_brand_profile_from_website: REFRESH_BRAND_PROFILE_FROM_WEBSITE_TOOL,
 };
 
 /** All tool names available for use in allowedTools config. */

--- a/src/lib/brand-client.ts
+++ b/src/lib/brand-client.ts
@@ -48,16 +48,21 @@ export interface ExtractFieldsResponse {
   fields: Record<string, ExtractFieldEntry>;
 }
 
+export interface ExtractBrandFieldsOptions {
+  resetCache?: boolean;
+}
+
 export async function extractBrandFields(
   fields: ExtractFieldDef[],
   brandIds: string[],
   params: BrandCallParams,
+  options: ExtractBrandFieldsOptions = {},
 ): Promise<ExtractFieldsResponse> {
   const res = await apiServiceFetch(
     `/v1/brands/extract-fields`,
     "POST",
     params,
-    { brandIds, fields },
+    { brandIds, fields, ...(options.resetCache ? { resetCache: true } : {}) },
   );
 
   if (!res.ok) {

--- a/src/lib/brand-profile-refresh.ts
+++ b/src/lib/brand-profile-refresh.ts
@@ -1,0 +1,317 @@
+import { extractBrandFields, type ExtractFieldDef } from "./brand-client.js";
+import {
+  getBrandProfile,
+  saveBrandProfileVersion,
+  type BrandContentCallParams,
+  type BrandProfileFieldValue,
+  type BrandProfileFields,
+  type BrandProfileVersion,
+} from "./brand-content-client.js";
+
+export interface BrandProfileFieldDefinition {
+  key: string;
+  description: string;
+  type?: string;
+}
+
+export interface BrandProfileChangedField {
+  field: string;
+  before: BrandProfileFieldValue | null;
+  after: BrandProfileFieldValue;
+}
+
+export interface BrandProfileWebsiteRefreshResult {
+  saved: true;
+  version: BrandProfileVersion;
+  extractedFields: BrandProfileFields;
+  changedFields: BrandProfileChangedField[];
+  sourceUrlsByField: Record<string, string[]>;
+}
+
+export class BrandProfileRefreshError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BrandProfileRefreshError";
+  }
+}
+
+const UPDATE_RE =
+  /\b(update|refresh|sync|revise|regenerate|replace|save|mettre|mets|met|actualise|actualiser|rafraichis|rafraichir|maj|màj)\b/i;
+const WEBSITE_RE =
+  /\b(website|web\s*site|homepage|site\s*web|site\s*internet|dernier\s*site|site\s*actuel|current\s*site|latest\s*site)\b/i;
+const READ_ONLY_OPINION_RE =
+  /\b(should\s+i|dois-je|devrais-je|est\s*ce\s*que\s*je\s*(dois|devrais)|what\s*do\s*you\s*think|que\s*penses|penses-tu|avis|opinion)\b/i;
+
+function normalizeIntentText(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase();
+}
+
+export function isBrandProfileWebsiteRefreshIntent(message: string): boolean {
+  const text = normalizeIntentText(message);
+  return UPDATE_RE.test(text) && WEBSITE_RE.test(text) && !READ_ONLY_OPINION_RE.test(text);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function fieldKeyFromDefinition(definition: Record<string, unknown>): string | undefined {
+  return firstString(
+    definition.key,
+    definition.field,
+    definition.name,
+    definition.id,
+    definition.slug,
+  );
+}
+
+function fieldDescriptionFromDefinition(
+  key: string,
+  definition: Record<string, unknown>,
+): string {
+  return firstString(
+    definition.description,
+    definition.extractDescription,
+    definition.extractionDescription,
+    definition.prompt,
+    definition.label,
+    definition.title,
+  ) ?? `Brand profile field "${key}" from the brand's current website.`;
+}
+
+function definitionType(definition: Record<string, unknown>): string | undefined {
+  return firstString(definition.type, definition.kind, definition.inputType);
+}
+
+function addDefinition(
+  definitions: Map<string, BrandProfileFieldDefinition>,
+  key: string | undefined,
+  description: string | undefined,
+  type?: string,
+): void {
+  if (!key || definitions.has(key)) return;
+  definitions.set(key, {
+    key,
+    description: description ?? `Brand profile field "${key}" from the brand's current website.`,
+    ...(type ? { type } : {}),
+  });
+}
+
+function collectDefinitionsFromUnknown(
+  value: unknown,
+  definitions: Map<string, BrandProfileFieldDefinition>,
+): void {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      if (!isPlainObject(item)) continue;
+      const key = fieldKeyFromDefinition(item);
+      addDefinition(
+        definitions,
+        key,
+        key ? fieldDescriptionFromDefinition(key, item) : undefined,
+        definitionType(item),
+      );
+    }
+    return;
+  }
+
+  if (!isPlainObject(value)) return;
+  for (const [key, rawDefinition] of Object.entries(value)) {
+    if (isPlainObject(rawDefinition)) {
+      addDefinition(
+        definitions,
+        key,
+        fieldDescriptionFromDefinition(key, rawDefinition),
+        definitionType(rawDefinition),
+      );
+    } else if (typeof rawDefinition === "string") {
+      addDefinition(definitions, key, rawDefinition);
+    }
+  }
+}
+
+function extractFieldsMap(value: unknown): BrandProfileFields | null {
+  if (!isPlainObject(value)) return null;
+  if (isPlainObject(value.fields)) return value.fields as BrandProfileFields;
+  return value as BrandProfileFields;
+}
+
+function collectFallbackKeys(
+  fields: BrandProfileFields | null | undefined,
+  definitions: Map<string, BrandProfileFieldDefinition>,
+): void {
+  if (!fields) return;
+  for (const [key, value] of Object.entries(fields)) {
+    addDefinition(
+      definitions,
+      key,
+      `Brand profile field "${key}" from the brand's current website.`,
+      Array.isArray(value) ? "list" : undefined,
+    );
+  }
+}
+
+export function buildBrandProfileExtractionFields(
+  context: Record<string, unknown> | undefined,
+  currentFields: BrandProfileFields,
+  overrideDefinitions?: unknown,
+): BrandProfileFieldDefinition[] {
+  const definitions = new Map<string, BrandProfileFieldDefinition>();
+
+  collectDefinitionsFromUnknown(overrideDefinitions, definitions);
+  collectDefinitionsFromUnknown(context?.fieldDefinitions, definitions);
+  collectDefinitionsFromUnknown(context?.brandProfileFieldDefinitions, definitions);
+
+  collectFallbackKeys(currentFields, definitions);
+  collectFallbackKeys(extractFieldsMap(context?.currentBrandProfile), definitions);
+  collectFallbackKeys(extractFieldsMap(context?.savedBrandProfile), definitions);
+
+  return [...definitions.values()];
+}
+
+function wantsListField(
+  field: string,
+  currentFields: BrandProfileFields,
+  definitions: BrandProfileFieldDefinition[],
+): boolean {
+  if (Array.isArray(currentFields[field])) return true;
+  const definition = definitions.find((item) => item.key === field);
+  const type = definition?.type?.toLowerCase();
+  return type === "list" || type === "array" || type === "multi-select" || type === "multiselect";
+}
+
+function normalizeExtractedValue(
+  value: unknown,
+  wantsList: boolean,
+): BrandProfileFieldValue | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return undefined;
+    return wantsList ? [trimmed] : trimmed;
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    const stringValue = String(value);
+    return wantsList ? [stringValue] : stringValue;
+  }
+
+  if (Array.isArray(value)) {
+    const values = value
+      .map((item) => (typeof item === "string" ? item.trim() : undefined))
+      .filter((item): item is string => Boolean(item));
+    return values.length > 0 ? values : undefined;
+  }
+
+  return undefined;
+}
+
+function valuesEqual(a: BrandProfileFieldValue | undefined, b: BrandProfileFieldValue): boolean {
+  return JSON.stringify(a ?? null) === JSON.stringify(b);
+}
+
+function sourceUrlsForEntry(entry: { byBrand?: Record<string, { sourceUrls?: string[] | null }> }): string[] {
+  const urls = new Set<string>();
+  for (const byBrand of Object.values(entry.byBrand ?? {})) {
+    for (const url of byBrand.sourceUrls ?? []) {
+      if (url) urls.add(url);
+    }
+  }
+  return [...urls];
+}
+
+export async function refreshBrandProfileFromWebsite(
+  brandId: string,
+  context: Record<string, unknown> | undefined,
+  params: BrandContentCallParams,
+  overrideDefinitions?: unknown,
+): Promise<BrandProfileWebsiteRefreshResult> {
+  const profile = await getBrandProfile(brandId, params);
+  const currentFields = profile.current?.fields ?? {};
+  const fieldDefinitions = buildBrandProfileExtractionFields(
+    context,
+    currentFields,
+    overrideDefinitions,
+  );
+
+  if (fieldDefinitions.length === 0) {
+    throw new BrandProfileRefreshError(
+      "No brand profile field definitions were available, so I could not decide which website fields to extract.",
+    );
+  }
+
+  const extractionFields: ExtractFieldDef[] = fieldDefinitions.map((field) => ({
+    key: field.key,
+    description: field.description,
+  }));
+  const extracted = await extractBrandFields(
+    extractionFields,
+    [brandId],
+    params,
+    { resetCache: true },
+  );
+
+  const extractedFields: BrandProfileFields = {};
+  const sourceUrlsByField: Record<string, string[]> = {};
+
+  for (const [field, entry] of Object.entries(extracted.fields)) {
+    const normalized = normalizeExtractedValue(
+      entry.value,
+      wantsListField(field, currentFields, fieldDefinitions),
+    );
+    if (normalized === undefined) continue;
+    extractedFields[field] = normalized;
+    const sourceUrls = sourceUrlsForEntry(entry);
+    if (sourceUrls.length > 0) sourceUrlsByField[field] = sourceUrls;
+  }
+
+  if (Object.keys(extractedFields).length === 0) {
+    throw new BrandProfileRefreshError(
+      "Website extraction completed but returned no usable brand profile values to save.",
+    );
+  }
+
+  const mergedFields: BrandProfileFields = { ...currentFields, ...extractedFields };
+  const changedFields = Object.entries(extractedFields)
+    .filter(([field, value]) => !valuesEqual(currentFields[field], value))
+    .map(([field, after]) => ({
+      field,
+      before: currentFields[field] ?? null,
+      after,
+    }));
+
+  const saved = await saveBrandProfileVersion(brandId, mergedFields, params);
+  return {
+    saved: true,
+    version: saved.version,
+    extractedFields,
+    changedFields,
+    sourceUrlsByField,
+  };
+}
+
+export function formatBrandProfileWebsiteRefreshMessage(
+  result: BrandProfileWebsiteRefreshResult,
+): string {
+  const changed = result.changedFields.map((field) => field.field);
+  const summary = changed.length > 0
+    ? `Updated fields: ${changed.slice(0, 8).join(", ")}${changed.length > 8 ? ", ..." : ""}.`
+    : "No field values changed after the fresh extraction.";
+  return `Saved brand profile v${result.version.version} from the latest website extraction. ${summary}`;
+}
+
+export function formatBrandProfileWebsiteRefreshErrorMessage(error: unknown): string {
+  const detail = error instanceof Error ? error.message : String(error);
+  return `I couldn't refresh the brand profile from the website: ${detail}`;
+}

--- a/src/lib/seed-platform-configs.ts
+++ b/src/lib/seed-platform-configs.ts
@@ -45,8 +45,9 @@ What a brand profile is:
 Your tools:
 - get_brand_profile — read the current profile fields + the list of saved versions. ALWAYS call this first when the user wants to change something, so you edit from the current values.
 - save_brand_profile_version — save a NEW version. You only supply the CHANGES; the tool reads the current version, applies your changes on top, and saves the full merged result, so unchanged fields are preserved automatically. Operations: "set" replaces a free-text field; "setList" replaces a list field; "add" appends one item to a list field; "remove" deletes one item from a list field.
+- refresh_brand_profile_from_website — complete a website refresh end to end. Use this when the user asks to update/refresh/sync/regenerate/save the profile from the latest/current website (for example "Mets à jour avec mon dernier site web"). It reads the current profile, obtains fresh website-derived values, saves a NEW immutable version, and returns the new version plus changed fields. Do not stop after get_brand_profile for these requests.
 
-Be concise. After saving, tell the user which new version number was created and what changed. When asked only to read, never save a new version.`;
+Be concise. After saving, tell the user which new version number was created and what changed. When asked only to read, summarize, or give an opinion, never save a new version.`;
 
 export const PERSONA_EDITOR_CONFIG = {
   key: "persona-editor",
@@ -69,6 +70,7 @@ export const BRAND_PROFILE_EDITOR_CONFIG = {
     "request_user_input",
     "get_brand_profile",
     "save_brand_profile_version",
+    "refresh_brand_profile_from_website",
   ],
   provider: "google" as const,
   model: "flash-pro",

--- a/tests/integration/brand-profile-editor-chat.test.ts
+++ b/tests/integration/brand-profile-editor-chat.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import request from "supertest";
+
+process.env.NODE_ENV = "test";
+process.env.KEY_SERVICE_API_KEY = process.env.KEY_SERVICE_API_KEY || "test-key-svc-key";
+process.env.KEY_SERVICE_URL = process.env.KEY_SERVICE_URL || "https://key.test.local";
+process.env.ADMIN_DISTRIBUTE_API_KEY = process.env.ADMIN_DISTRIBUTE_API_KEY || "test-api-svc-key";
+process.env.API_SERVICE_URL = process.env.API_SERVICE_URL || "https://api.test.local";
+process.env.RUNS_SERVICE_API_KEY = process.env.RUNS_SERVICE_API_KEY || "test-runs-key";
+process.env.RUNS_SERVICE_URL = process.env.RUNS_SERVICE_URL || "https://runs.test.local";
+
+interface MockRoute {
+  match: (url: string, init?: RequestInit) => boolean;
+  respond: (url: string, init?: RequestInit) => { ok: boolean; status?: number; body: unknown; text?: string };
+}
+
+let routes: MockRoute[] = [];
+let fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
+
+const sessionId = "00000000-0000-4000-8000-000000000101";
+const runId = "00000000-0000-4000-8000-000000000102";
+const brandId = "f4d73dab-1f9d-49b2-b16e-63ecde76a5eb";
+
+vi.mock("../../src/db/index.js", () => {
+  const brandProfileConfig = {
+    id: "cfg-brand-profile",
+    orgId: "org-1",
+    key: "brand-profile-editor",
+    systemPrompt: "Brand profile editor.",
+    allowedTools: [
+      "request_user_input",
+      "get_brand_profile",
+      "save_brand_profile_version",
+      "refresh_brand_profile_from_website",
+    ],
+    provider: "google",
+    model: "flash-pro",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  return {
+    db: {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => Promise.resolve([brandProfileConfig])),
+          limit: vi.fn(() => Promise.resolve([brandProfileConfig])),
+        })),
+      })),
+      insert: vi.fn(() => ({
+        values: vi.fn(() => ({
+          returning: vi.fn(() => Promise.resolve([{ id: sessionId }])),
+        })),
+      })),
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({
+          where: vi.fn(() => Promise.resolve()),
+        })),
+      })),
+      query: {
+        messages: {
+          findMany: vi.fn(() => Promise.resolve([])),
+        },
+      },
+    },
+  };
+});
+
+function buildResponse(out: { ok: boolean; status?: number; body: unknown; text?: string }): Response {
+  const text = out.text ?? (typeof out.body === "string" ? out.body : JSON.stringify(out.body));
+  return {
+    ok: out.ok,
+    status: out.status ?? (out.ok ? 200 : 500),
+    json: () => Promise.resolve(out.body),
+    text: () => Promise.resolve(text),
+    headers: new Headers(),
+  } as unknown as Response;
+}
+
+function installFetchMock() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      fetchCalls.push({ url, init });
+      for (const route of routes) {
+        if (route.match(url, init)) return buildResponse(route.respond(url, init));
+      }
+      throw new Error(`[test] Unmocked fetch: ${url}`);
+    }),
+  );
+}
+
+function mockKeyDecrypt() {
+  return {
+    match: (url: string) => url.includes("/keys/google/decrypt"),
+    respond: () => ({ ok: true, body: { provider: "google", key: "fake-google-key", keySource: "platform" } }),
+  } satisfies MockRoute;
+}
+
+function mockRunCreate() {
+  return {
+    match: (url: string, init?: RequestInit) => url.endsWith("/v1/runs") && (init?.method ?? "GET") === "POST",
+    respond: () => ({ ok: true, status: 201, body: { id: runId, status: "running" } }),
+  } satisfies MockRoute;
+}
+
+function mockRunPatch() {
+  return {
+    match: (url: string, init?: RequestInit) => /\/v1\/runs\/[^/]+$/.test(url) && (init?.method ?? "GET") === "PATCH",
+    respond: () => ({ ok: true, body: { id: runId, status: "completed" } }),
+  } satisfies MockRoute;
+}
+
+function mockTraceEvents() {
+  return {
+    match: (url: string, init?: RequestInit) => /\/v1\/runs\/[^/]+\/events$/.test(url) && (init?.method ?? "GET") === "POST",
+    respond: () => ({ ok: true, status: 201, body: { id: "evt-1" } }),
+  } satisfies MockRoute;
+}
+
+function mockBrandProfileGet() {
+  return {
+    match: (url: string, init?: RequestInit) =>
+      url === `https://api.test.local/v1/brands/${brandId}/brand-profile` &&
+      (init?.method ?? "GET") === "GET",
+    respond: () => ({
+      ok: true,
+      body: {
+        current: {
+          id: "v2",
+          brandId,
+          version: 2,
+          fields: {
+            valueProposition: "Old value",
+            differentiators: ["Old diff"],
+            tone: "Clear",
+          },
+          createdAt: "2026-06-01T00:00:00Z",
+        },
+        versions: [{ id: "v2", version: 2, createdAt: "2026-06-01T00:00:00Z" }],
+      },
+    }),
+  } satisfies MockRoute;
+}
+
+function mockExtractFields() {
+  return {
+    match: (url: string, init?: RequestInit) =>
+      url === "https://api.test.local/v1/brands/extract-fields" &&
+      (init?.method ?? "GET") === "POST",
+    respond: () => ({
+      ok: true,
+      body: {
+        brands: [{ brandId, domain: "example.com", name: "Example", brandUrl: "https://example.com" }],
+        fields: {
+          valueProposition: {
+            value: "New value from website",
+            byBrand: {
+              "example.com": {
+                value: "New value from website",
+                cached: false,
+                extractedAt: "2026-06-17T00:00:00Z",
+                expiresAt: null,
+                sourceUrls: ["https://example.com"],
+              },
+            },
+          },
+          differentiators: {
+            value: ["Faster setup", "Better analytics"],
+            byBrand: {},
+          },
+        },
+      },
+    }),
+  } satisfies MockRoute;
+}
+
+function mockBrandProfileSave() {
+  return {
+    match: (url: string, init?: RequestInit) =>
+      url === `https://api.test.local/v1/brands/${brandId}/brand-profile` &&
+      (init?.method ?? "GET") === "POST",
+    respond: (_url: string, init?: RequestInit) => ({
+      ok: true,
+      status: 201,
+      body: {
+        version: {
+          id: "v3",
+          brandId,
+          version: 3,
+          fields: JSON.parse(init?.body as string).fields,
+          createdAt: "2026-06-17T00:00:00Z",
+        },
+      },
+    }),
+  } satisfies MockRoute;
+}
+
+const AUTH = {
+  "x-api-key": "test-key",
+  "x-org-id": "org-1",
+  "x-user-id": "user-1",
+  "x-run-id": "parent-run-1",
+};
+
+describe("POST /chat — brand-profile-editor website refresh", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    routes = [];
+    fetchCalls = [];
+    installFetchMock();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function loadApp() {
+    return (await import("../../src/index.js")).default;
+  }
+
+  it("saves a new brand-profile version for a latest-website update intent", async () => {
+    const app = await loadApp();
+    routes.push(
+      mockKeyDecrypt(),
+      mockRunCreate(),
+      mockRunPatch(),
+      mockTraceEvents(),
+      mockBrandProfileGet(),
+      mockExtractFields(),
+      mockBrandProfileSave(),
+    );
+
+    const res = await request(app)
+      .post("/chat")
+      .set(AUTH)
+      .send({
+        configKey: "brand-profile-editor",
+        message: "Mets a jour avec mon dernier site web",
+        context: {
+          brandId,
+          fieldDefinitions: [
+            { key: "valueProposition", description: "The brand value proposition" },
+            { key: "differentiators", description: "List of differentiators", type: "list" },
+          ],
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain("refresh_brand_profile_from_website");
+    expect(res.text).toContain("Saved brand profile v3");
+    expect(res.text).toContain("Updated fields: valueProposition, differentiators.");
+
+    const extractCall = fetchCalls.find((call) => call.url.endsWith("/v1/brands/extract-fields"));
+    expect(JSON.parse(extractCall?.init?.body as string)).toEqual({
+      brandIds: [brandId],
+      fields: [
+        { key: "valueProposition", description: "The brand value proposition" },
+        { key: "differentiators", description: "List of differentiators" },
+        { key: "tone", description: 'Brand profile field "tone" from the brand\'s current website.' },
+      ],
+      resetCache: true,
+    });
+
+    const saveCall = fetchCalls.find(
+      (call) =>
+        call.url === `https://api.test.local/v1/brands/${brandId}/brand-profile` &&
+        call.init?.method === "POST",
+    );
+    expect(JSON.parse(saveCall?.init?.body as string)).toEqual({
+      fields: {
+        valueProposition: "New value from website",
+        differentiators: ["Faster setup", "Better analytics"],
+        tone: "Clear",
+      },
+    });
+  });
+});

--- a/tests/unit/brand-client.test.ts
+++ b/tests/unit/brand-client.test.ts
@@ -102,6 +102,30 @@ describe("extractBrandFields", () => {
     expect(sentBody.fields).toEqual([{ key: "x", description: "y" }]);
   });
 
+  it("can force a fresh website extraction with resetCache", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ brands: [], fields: {} }),
+    });
+
+    const { extractBrandFields } = await loadModule();
+    await extractBrandFields(
+      [{ key: "valueProposition", description: "Value proposition" }],
+      ["b-1"],
+      baseParams,
+      { resetCache: true },
+    );
+
+    const sentBody = JSON.parse(
+      (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body,
+    );
+    expect(sentBody).toEqual({
+      brandIds: ["b-1"],
+      fields: [{ key: "valueProposition", description: "Value proposition" }],
+      resetCache: true,
+    });
+  });
+
   it("throws BrandError on non-OK response", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: false,

--- a/tests/unit/brand-profile-refresh.test.ts
+++ b/tests/unit/brand-profile-refresh.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  buildBrandProfileExtractionFields,
+  formatBrandProfileWebsiteRefreshMessage,
+  isBrandProfileWebsiteRefreshIntent,
+  refreshBrandProfileFromWebsite,
+} from "../../src/lib/brand-profile-refresh.js";
+
+vi.mock("../../src/lib/brand-content-client.js", () => ({
+  getBrandProfile: vi.fn(),
+  saveBrandProfileVersion: vi.fn(),
+}));
+
+vi.mock("../../src/lib/brand-client.js", () => ({
+  extractBrandFields: vi.fn(),
+}));
+
+const brandContent = await import("../../src/lib/brand-content-client.js");
+const brandClient = await import("../../src/lib/brand-client.js");
+
+const baseParams = {
+  orgId: "org-1",
+  userId: "user-1",
+  runId: "run-1",
+};
+
+describe("isBrandProfileWebsiteRefreshIntent", () => {
+  it("detects French latest-website update requests", () => {
+    expect(isBrandProfileWebsiteRefreshIntent("Mets a jour avec mon dernier site web")).toBe(true);
+    expect(isBrandProfileWebsiteRefreshIntent("Mets à jour avec mon dernier site web")).toBe(true);
+  });
+
+  it("does not classify read-only opinion requests as saves", () => {
+    expect(isBrandProfileWebsiteRefreshIntent("Que penses-tu de mon dernier site web ?")).toBe(false);
+    expect(isBrandProfileWebsiteRefreshIntent("Dois-je mettre à jour avec mon dernier site web ?")).toBe(false);
+  });
+});
+
+describe("buildBrandProfileExtractionFields", () => {
+  it("prefers context fieldDefinitions and falls back to current profile keys", () => {
+    expect(
+      buildBrandProfileExtractionFields(
+        {
+          fieldDefinitions: [
+            { key: "valueProposition", label: "Value proposition", type: "text" },
+          ],
+        },
+        { differentiators: ["old"] },
+      ),
+    ).toEqual([
+      {
+        key: "valueProposition",
+        description: "Value proposition",
+        type: "text",
+      },
+      {
+        key: "differentiators",
+        description: 'Brand profile field "differentiators" from the brand\'s current website.',
+        type: "list",
+      },
+    ]);
+  });
+});
+
+describe("refreshBrandProfileFromWebsite", () => {
+  beforeEach(() => {
+    vi.mocked(brandContent.getBrandProfile).mockReset();
+    vi.mocked(brandContent.saveBrandProfileVersion).mockReset();
+    vi.mocked(brandClient.extractBrandFields).mockReset();
+  });
+
+  it("gets current profile, extracts fresh website values, and saves a new full version", async () => {
+    vi.mocked(brandContent.getBrandProfile).mockResolvedValue({
+      current: {
+        id: "v2",
+        brandId: "brand-1",
+        version: 2,
+        fields: {
+          valueProposition: "Old value",
+          differentiators: ["Old differentiator"],
+          tone: "Direct",
+        },
+        createdAt: "2026-06-01T00:00:00Z",
+      },
+      versions: [{ id: "v2", version: 2, createdAt: "2026-06-01T00:00:00Z" }],
+    });
+    vi.mocked(brandClient.extractBrandFields).mockResolvedValue({
+      brands: [],
+      fields: {
+        valueProposition: {
+          value: "New website value",
+          byBrand: {
+            "example.com": {
+              value: "New website value",
+              cached: false,
+              extractedAt: "2026-06-17T00:00:00Z",
+              expiresAt: null,
+              sourceUrls: ["https://example.com"],
+            },
+          },
+        },
+        differentiators: {
+          value: ["Fast setup", "Clean reporting"],
+          byBrand: {},
+        },
+      },
+    });
+    vi.mocked(brandContent.saveBrandProfileVersion).mockResolvedValue({
+      version: {
+        id: "v3",
+        brandId: "brand-1",
+        version: 3,
+        fields: {},
+        createdAt: "2026-06-17T00:00:00Z",
+      },
+    });
+
+    const result = await refreshBrandProfileFromWebsite(
+      "brand-1",
+      {
+        fieldDefinitions: [
+          { key: "valueProposition", description: "The brand value proposition" },
+          { key: "differentiators", description: "List of differentiators", type: "list" },
+        ],
+      },
+      baseParams,
+    );
+
+    expect(brandContent.getBrandProfile).toHaveBeenCalledWith("brand-1", baseParams);
+    expect(brandClient.extractBrandFields).toHaveBeenCalledWith(
+      [
+        { key: "valueProposition", description: "The brand value proposition" },
+        { key: "differentiators", description: "List of differentiators" },
+        { key: "tone", description: 'Brand profile field "tone" from the brand\'s current website.' },
+      ],
+      ["brand-1"],
+      baseParams,
+      { resetCache: true },
+    );
+    expect(brandContent.saveBrandProfileVersion).toHaveBeenCalledWith(
+      "brand-1",
+      {
+        valueProposition: "New website value",
+        differentiators: ["Fast setup", "Clean reporting"],
+        tone: "Direct",
+      },
+      baseParams,
+    );
+    expect(result.version.version).toBe(3);
+    expect(result.changedFields.map((field) => field.field)).toEqual([
+      "valueProposition",
+      "differentiators",
+    ]);
+    expect(formatBrandProfileWebsiteRefreshMessage(result)).toContain("Saved brand profile v3");
+  });
+});

--- a/tests/unit/persona-brand-profile-configs.test.ts
+++ b/tests/unit/persona-brand-profile-configs.test.ts
@@ -14,10 +14,11 @@ const NEW_TOOLS = [
   "set_persona_status",
   "get_brand_profile",
   "save_brand_profile_version",
+  "refresh_brand_profile_from_website",
 ];
 
 describe("persona / brand-profile tool registry", () => {
-  it("registers all six new tools with matching names", () => {
+  it("registers all persona and brand-profile tools with matching names", () => {
     for (const name of NEW_TOOLS) {
       expect(TOOL_REGISTRY[name], `missing tool ${name}`).toBeDefined();
       expect(TOOL_REGISTRY[name].name).toBe(name);
@@ -61,10 +62,23 @@ describe("self-seeded platform configs", () => {
 
   it("persona-editor cannot touch brand-profile tools and vice-versa (scoping)", () => {
     expect(PERSONA_EDITOR_CONFIG.allowedTools).not.toContain("save_brand_profile_version");
+    expect(PERSONA_EDITOR_CONFIG.allowedTools).not.toContain("refresh_brand_profile_from_website");
     expect(BRAND_PROFILE_EDITOR_CONFIG.allowedTools).not.toContain("create_persona");
     // No write tool grants a hard-delete capability — none exists.
     const everyTool = [...PERSONA_EDITOR_CONFIG.allowedTools, ...BRAND_PROFILE_EDITOR_CONFIG.allowedTools];
     expect(everyTool.some((t) => /delete|destroy|remove_persona/.test(t))).toBe(false);
+  });
+
+  it("brand-profile-editor exposes the website refresh tool and prompt guard", () => {
+    expect(BRAND_PROFILE_EDITOR_CONFIG.allowedTools).toContain(
+      "refresh_brand_profile_from_website",
+    );
+    expect(BRAND_PROFILE_EDITOR_CONFIG.systemPrompt).toContain(
+      "Do not stop after get_brand_profile",
+    );
+    expect(BRAND_PROFILE_EDITOR_CONFIG.systemPrompt).toContain(
+      "When asked only to read, summarize, or give an opinion, never save",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- add a `refresh_brand_profile_from_website` tool to `brand-profile-editor`
- handle explicit latest/current website refresh intents deterministically before provider streaming
- force fresh brand extraction with `resetCache: true`, merge into the current profile fields, and save a new immutable version
- keep read-only/opinion prompts on the normal non-mutating chat path

## Verification
- npx vitest run tests/unit/brand-profile-refresh.test.ts tests/unit/brand-client.test.ts tests/unit/persona-brand-profile-configs.test.ts tests/integration/brand-profile-editor-chat.test.ts
- npm run build

## Note
- Full `npm run test:unit` was reported by the spawned workspace as having one unrelated graceful-shutdown ECONNRESET flake; rerunning that file alone passed there.
