### PR TITLE
feat(chat): add audience-editor self-seeded config (CRUD audiences via AI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,14 +130,15 @@ Fields: same as `PUT /config` — `key`, `systemPrompt`, `allowedTools` (all req
 
 This endpoint is **idempotent** (upsert on `key`). Called on every cold start by api-service.
 
-**Self-seeded configs.** Two platform configs are owned by chat-service itself and seeded at boot (in `src/lib/seed-platform-configs.ts`, run from the migrate→listen path) — they do not need any external registrar:
+**Self-seeded configs.** Three platform configs are owned by chat-service itself and seeded at boot (in `src/lib/seed-platform-configs.ts`, run from the migrate→listen path) — they do not need any external registrar:
 
 | configKey | Tools | Purpose |
 |---|---|---|
-| `persona-editor` | `list_personas`, `create_persona`, `duplicate_persona`, `set_persona_status`, `request_user_input` | Read + curate a brand's customer personas via NL. |
+| `persona-editor` | `list_personas`, `create_persona`, `duplicate_persona`, `set_persona_status`, `request_user_input` | Read + curate a brand's customer personas via NL (brand-service). |
 | `brand-profile-editor` | `get_brand_profile`, `save_brand_profile_version`, `refresh_brand_profile_from_website`, `request_user_input` | Read, refresh from website, and version a brand's brand profile via NL. |
+| `audience-editor` | `list_audiences`, `suggest_audiences`, `set_audience_status`, `rename_audience`, `refresh_audience_count`, `request_user_input` | Create + curate a brand's customer audiences via NL (human-service, via the api-service gateway `/v1/orgs/audiences/*`). Creation is suggest→activate: `suggest_audiences` persists candidates at status `suggested`; `set_audience_status … active` makes one live. Filters are immutable; archive (never delete) and rename only. |
 
-Both default to `google`/`flash-pro`. The dashboard selects them by `configKey` and passes `context: { brandId }`; the tools act on that brand under the caller's org. The boot seed only upserts these two keys, so it never clobbers a dashboard-registered config.
+All default to `google`/`flash-pro`. The dashboard selects them by `configKey` and passes `context: { brandId }`; the tools act on that brand under the caller's org. The boot seed only upserts these keys, so it never clobbers a dashboard-registered config.
 
 **Config resolution in POST /chat:**
 1. Per-org config `(orgId, configKey)` → if found, use it
@@ -657,6 +658,16 @@ Read-only and supporting workflow tools:
 | `get_brand_profile` | Gets the current profile fields + version list. Read-only. `GET /v1/brands/:id/brand-profile` |
 | `save_brand_profile_version` | Saves a NEW immutable version. Supplies only `changes` (`set`/`setList`/`add`/`remove`); the tool reads current, merges, and POSTs the full field map, so prior versions are untouched and unchanged fields are preserved. `POST /v1/brands/:id/brand-profile` |
 | `refresh_brand_profile_from_website` | Handles explicit latest/current website refresh requests end to end: reads current profile, forces fresh website field extraction via `POST /v1/brands/extract-fields` with `resetCache: true`, saves the full merged field map as a NEW immutable version, and returns the new version plus changed fields. Read-only questions never use this path. |
+
+**Audience-editor tools** (operate on the brand from `context.brandId`; via human-service through the api-service gateway `/v1/orgs/audiences/*`, org-scoped by the forwarded `x-org-id`):
+
+| Tool | Description |
+|---|---|
+| `list_audiences` | Lists the brand's audiences, optional `status` filter (`suggested`/`active`/`paused`/`archived`). Read-only. `GET /v1/orgs/audiences?brandId=` |
+| `suggest_audiences` | Creates candidate audiences from a natural-language `nlPrompt`. Each candidate is ALREADY persisted as an inactive `suggested` audience (with generated name, rationale, live match count, winning provider). The model presents them; activation is a separate step. `POST /v1/orgs/audiences/suggest` |
+| `set_audience_status` | Flips lifecycle status (activate/resume/restore→active, pause→paused, archive→archived). Activating a `suggested` candidate makes it live. Archiving never deletes; there is no hard delete. `PATCH /v1/orgs/audiences/:id/status` |
+| `rename_audience` | Renames an audience (the only editable metadata; filters are immutable). `PATCH /v1/orgs/audiences/:id` |
+| `refresh_audience_count` | Re-snapshots apollo + apify match counts via the free live dry-run. `POST /v1/orgs/audiences/:id/refresh-count` |
 
 **UI tools:**
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,14 @@ import {
   type BrandProfileChange,
 } from "./lib/brand-content-client.js";
 import {
+  listAudiences,
+  suggestAudiences,
+  setAudienceStatus,
+  renameAudience,
+  refreshAudienceCount,
+  type AudienceStatus,
+} from "./lib/audience-client.js";
+import {
   formatBrandProfileWebsiteRefreshErrorMessage,
   formatBrandProfileWebsiteRefreshMessage,
   isBrandProfileWebsiteRefreshIntent,
@@ -2453,6 +2461,62 @@ app.post("/chat", requireAuth, async (req, res) => {
           context,
           featureCallParams,
           args.fields,
+        );
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
+      if (call.name === "list_audiences") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const brandId = requireSingleBrandId("list_audiences");
+        const result = await listAudiences(
+          brandId,
+          args.status as AudienceStatus | undefined,
+          featureCallParams,
+        );
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
+      if (call.name === "suggest_audiences") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const brandId = requireSingleBrandId("suggest_audiences");
+        const result = await suggestAudiences(
+          brandId,
+          String(args.nlPrompt ?? ""),
+          featureCallParams,
+        );
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
+      if (call.name === "set_audience_status") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const result = await setAudienceStatus(
+          String(args.audienceId ?? ""),
+          args.status as AudienceStatus,
+          featureCallParams,
+        );
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
+      if (call.name === "rename_audience") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const result = await renameAudience(
+          String(args.audienceId ?? ""),
+          String(args.name ?? ""),
+          featureCallParams,
+        );
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
+      if (call.name === "refresh_audience_count") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const result = await refreshAudienceCount(
+          String(args.audienceId ?? ""),
+          featureCallParams,
         );
         toolCalls.push({ name: call.name, args, result });
         return { name: call.name, result };

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -1195,6 +1195,105 @@ export const REFRESH_BRAND_PROFILE_FROM_WEBSITE_TOOL: Anthropic.Tool = {
 };
 
 // ---------------------------------------------------------------------------
+// Audience-editor tools (audience-editor config) — act on the brand from
+// context.brandId, scoped to the caller's org by the forwarded identity. An
+// audience is a saved filter-set; creation is suggest -> activate (no raw
+// create tool — /suggest persists candidates the model then activates).
+// ---------------------------------------------------------------------------
+
+export const LIST_AUDIENCES_TOOL: Anthropic.Tool = {
+  name: "list_audiences",
+  description:
+    "List the customer audiences for the current brand (the brand from context.brandId — no brandId parameter needed). Optionally filter by lifecycle status. Read-only — never modifies anything. Use this to summarize audiences, and to look up an audience's id before renaming it, changing its status, or refreshing its counts.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      status: {
+        type: "string",
+        enum: ["suggested", "active", "paused", "archived"],
+        description:
+          "Optional. Filter to audiences with this lifecycle status. Omit to list all statuses. 'suggested' audiences are inactive candidates awaiting activation.",
+      },
+    },
+  },
+};
+
+export const SUGGEST_AUDIENCES_TOOL: Anthropic.Tool = {
+  name: "suggest_audiences",
+  description:
+    "Create candidate audiences for the current brand from a natural-language description (e.g. 'heads of marketing at Series A SaaS in the US'). Each returned candidate is ALREADY PERSISTED as an inactive audience at status 'suggested', with a generated name, a one-sentence rationale, a live match count, and a winning provider. Present the candidates to the user; to turn a chosen candidate into a live audience, call set_audience_status with its audienceId and status 'active'. The text drives the granularity — say 'split by country' etc. in the prompt to get one candidate per segment.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      nlPrompt: {
+        type: "string",
+        description:
+          "Natural-language description of the audience(s) to target. Express any segmentation intent (e.g. 'founders in FR and DE separately') directly in this text.",
+      },
+    },
+    required: ["nlPrompt"],
+  },
+};
+
+export const SET_AUDIENCE_STATUS_TOOL: Anthropic.Tool = {
+  name: "set_audience_status",
+  description:
+    "Change an audience's lifecycle status. Map the user's intent: ACTIVATE a suggested candidate / RESUME / REACTIVATE / RESTORE → active, PAUSE → paused, ARCHIVE → archived. Activating a 'suggested' candidate (status 'active') is how a candidate becomes a real, live audience. Archiving NEVER deletes the audience; it can always be restored by setting it back to active. Look up the audience id with list_audiences (or use the audienceId returned by suggest_audiences).",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      audienceId: {
+        type: "string",
+        description:
+          "The id of the audience to update (from list_audiences, or the audienceId of a suggest_audiences candidate).",
+      },
+      status: {
+        type: "string",
+        enum: ["active", "paused", "archived"],
+        description: "The new lifecycle status.",
+      },
+    },
+    required: ["audienceId", "status"],
+  },
+};
+
+export const RENAME_AUDIENCE_TOOL: Anthropic.Tool = {
+  name: "rename_audience",
+  description:
+    "Rename an audience of the current brand. Only the name is editable — an audience's targeting filters are immutable. Look up the audience id with list_audiences first.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      audienceId: {
+        type: "string",
+        description: "The id of the audience to rename (from list_audiences).",
+      },
+      name: {
+        type: "string",
+        description: "The new audience name.",
+      },
+    },
+    required: ["audienceId", "name"],
+  },
+};
+
+export const REFRESH_AUDIENCE_COUNT_TOOL: Anthropic.Tool = {
+  name: "refresh_audience_count",
+  description:
+    "Re-snapshot an audience's match counts (apollo + apify) using the free live dry-run. Use this when the user asks to refresh, recompute, or update the size/count of an audience. Returns the updated audience with fresh apolloCount / apifyCount. Look up the audience id with list_audiences first.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      audienceId: {
+        type: "string",
+        description: "The id of the audience to refresh (from list_audiences).",
+      },
+    },
+    required: ["audienceId"],
+  },
+};
+
+// ---------------------------------------------------------------------------
 // Tool registry — every tool the service knows how to execute.
 // Clients choose which subset to enable via allowedTools in their config.
 // ---------------------------------------------------------------------------
@@ -1233,6 +1332,11 @@ export const TOOL_REGISTRY: Record<string, Anthropic.Tool> = {
   get_brand_profile: GET_BRAND_PROFILE_TOOL,
   save_brand_profile_version: SAVE_BRAND_PROFILE_VERSION_TOOL,
   refresh_brand_profile_from_website: REFRESH_BRAND_PROFILE_FROM_WEBSITE_TOOL,
+  list_audiences: LIST_AUDIENCES_TOOL,
+  suggest_audiences: SUGGEST_AUDIENCES_TOOL,
+  set_audience_status: SET_AUDIENCE_STATUS_TOOL,
+  rename_audience: RENAME_AUDIENCE_TOOL,
+  refresh_audience_count: REFRESH_AUDIENCE_COUNT_TOOL,
 };
 
 /** All tool names available for use in allowedTools config. */

--- a/src/lib/audience-client.ts
+++ b/src/lib/audience-client.ts
@@ -1,0 +1,166 @@
+import { apiServiceFetch, type ApiCallParams } from "./api-client.js";
+
+// ---------------------------------------------------------------------------
+// Client for a brand's customer audiences, via api-service.
+//
+// All client-facing backend calls route through api-service as the single
+// gateway (same pattern as brand-content-client.ts). The downstream owner is
+// human-service; api-service proxies /v1/orgs/audiences/* untransformed.
+//
+// An audience is a SAVED filter-set (+ optional provider count snapshot) scoped
+// to one brand inside the caller's org. The org is derived from the forwarded
+// identity headers (x-org-id) — never a body/query param — so every call acts
+// on the caller's org only. Lifecycle status is the only freely-mutable field
+// besides name; filters are immutable after creation.
+//
+// Creation flow is suggest -> activate, NOT a raw create: POST /suggest emits
+// LLM-generated candidates, each PERSISTED as an inactive `suggested` row; the
+// caller activates a chosen one via PATCH /:id/status { status: "active" }.
+// ---------------------------------------------------------------------------
+
+export type AudienceCallParams = ApiCallParams;
+
+export class AudienceError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly upstreamBody: string,
+    public readonly operation: string,
+  ) {
+    super(`[audience-client] ${operation} failed (${status}): ${upstreamBody}`);
+    this.name = "AudienceError";
+  }
+}
+
+async function failLoud(res: Response, operation: string): Promise<never> {
+  const text = await res.text().catch(() => "unknown error");
+  throw new AudienceError(res.status, text, operation);
+}
+
+export type AudienceStatus = "suggested" | "active" | "paused" | "archived";
+export type AudienceProvider = "apollo" | "apify";
+
+/** A saved audience (filter-set + count snapshot), as returned by human-service. */
+export interface Audience {
+  id: string;
+  orgId: string;
+  brandId: string;
+  name: string;
+  nlPrompt: string | null;
+  provider: AudienceProvider | null;
+  status: AudienceStatus;
+  source: string | null;
+  filters: Record<string, unknown> | null;
+  avatarUrl: string | null;
+  apolloCount: number | null;
+  apifyCount: number | null;
+  countedAt: string | null;
+  createdByUserId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** One candidate from POST /suggest — already persisted as an inactive `suggested` row. */
+export interface AudienceCandidate {
+  audienceId: string;
+  name: string;
+  rationale: string;
+  provider: AudienceProvider;
+  filters: Record<string, unknown>;
+  count: number;
+  status: AudienceStatus;
+  validationError: string | null;
+  truncated: boolean;
+}
+
+/** GET /v1/orgs/audiences?brandId=&status= — list one brand's audiences. */
+export async function listAudiences(
+  brandId: string,
+  status: AudienceStatus | undefined,
+  params: AudienceCallParams,
+): Promise<{ audiences: Audience[]; total: number }> {
+  const qs = new URLSearchParams({ brandId });
+  if (status) qs.set("status", status);
+  const res = await apiServiceFetch(
+    `/v1/orgs/audiences?${qs.toString()}`,
+    "GET",
+    params,
+  );
+  if (!res.ok) return failLoud(res, "list audiences");
+  return res.json() as Promise<{ audiences: Audience[]; total: number }>;
+}
+
+/**
+ * POST /v1/orgs/audiences/suggest — natural-language prompt -> candidate
+ * audiences. Each candidate is PERSISTED at status `suggested`; the caller
+ * activates a chosen one via setAudienceStatus(..., "active").
+ */
+export async function suggestAudiences(
+  brandId: string,
+  nlPrompt: string,
+  params: AudienceCallParams,
+): Promise<{ candidates: AudienceCandidate[] }> {
+  const res = await apiServiceFetch(
+    `/v1/orgs/audiences/suggest`,
+    "POST",
+    params,
+    { brandId, nlPrompt },
+  );
+  if (!res.ok) return failLoud(res, "suggest audiences");
+  return res.json() as Promise<{ candidates: AudienceCandidate[] }>;
+}
+
+/**
+ * PATCH /v1/orgs/audiences/:id/status — flip lifecycle status. Activating a
+ * `suggested` candidate (status: "active") is how a candidate becomes a real
+ * audience. Archiving never deletes; an archived audience can be re-activated.
+ */
+export async function setAudienceStatus(
+  audienceId: string,
+  status: AudienceStatus,
+  params: AudienceCallParams,
+): Promise<{ audience: Audience }> {
+  const res = await apiServiceFetch(
+    `/v1/orgs/audiences/${audienceId}/status`,
+    "PATCH",
+    params,
+    { status },
+  );
+  if (!res.ok) return failLoud(res, "set audience status");
+  return res.json() as Promise<{ audience: Audience }>;
+}
+
+/**
+ * PATCH /v1/orgs/audiences/:id — update metadata. Only `name` is mutable here
+ * (filters/provider/counts are immutable; status has its own endpoint).
+ */
+export async function renameAudience(
+  audienceId: string,
+  name: string,
+  params: AudienceCallParams,
+): Promise<{ audience: Audience }> {
+  const res = await apiServiceFetch(
+    `/v1/orgs/audiences/${audienceId}`,
+    "PATCH",
+    params,
+    { name },
+  );
+  if (!res.ok) return failLoud(res, "rename audience");
+  return res.json() as Promise<{ audience: Audience }>;
+}
+
+/**
+ * POST /v1/orgs/audiences/:id/refresh-count — re-snapshot apollo + apify match
+ * counts via the free dry-run. Returns the updated audience.
+ */
+export async function refreshAudienceCount(
+  audienceId: string,
+  params: AudienceCallParams,
+): Promise<{ audience: Audience }> {
+  const res = await apiServiceFetch(
+    `/v1/orgs/audiences/${audienceId}/refresh-count`,
+    "POST",
+    params,
+  );
+  if (!res.ok) return failLoud(res, "refresh audience count");
+  return res.json() as Promise<{ audience: Audience }>;
+}

--- a/src/lib/seed-platform-configs.ts
+++ b/src/lib/seed-platform-configs.ts
@@ -5,13 +5,14 @@ import { platformConfigs } from "../db/schema.js";
 // Self-seeded platform chat configs.
 //
 // Most platform configs (workflow, feature, campaign-prefill, press-kit) are
-// registered by the dashboard at its boot via PUT /platform-config. These two —
-// persona-editor + brand-profile-editor — are owned BY chat-service: their tools,
-// prompts, provider/model all live here, so chat-service seeds them itself at
-// boot. This keeps configKey resolution decoupled from the dashboard (the panel
-// gates on these being live) and makes chat-service the single source of truth.
+// registered by the dashboard at its boot via PUT /platform-config. These three —
+// persona-editor + brand-profile-editor + audience-editor — are owned BY
+// chat-service: their tools, prompts, provider/model all live here, so
+// chat-service seeds them itself at boot. This keeps configKey resolution
+// decoupled from the dashboard (the panel gates on these being live) and makes
+// chat-service the single source of truth.
 //
-// We only ever upsert these two keys, so we never clobber a dashboard-owned key.
+// We only ever upsert these keys, so we never clobber a dashboard-owned key.
 // provider/model are set explicitly (google/flash-pro — the documented default;
 // flash-pro handles tool-calling, see config-defaults.ts) since we fully own them.
 // ---------------------------------------------------------------------------
@@ -49,6 +50,42 @@ Your tools:
 
 Be concise. After saving, tell the user which new version number was created and what changed. When asked only to read, summarize, or give an opinion, never save a new version.`;
 
+const AUDIENCE_EDITOR_SYSTEM_PROMPT = `You are the Audiences assistant for a brand inside the distribute platform. You help the user create and curate the brand's customer audiences through natural-language requests.
+
+You operate ONLY on the brand identified by this request's context (context.brandId). Never ask the user for a brand id — it is already scoped for you.
+
+What an audience is:
+- An audience is a SAVED targeting filter-set (job titles, seniorities, industries, locations, company size, etc.) with a NAME, a lifecycle STATUS (suggested | active | paused | archived), a winning data PROVIDER (apollo or apify), and live match COUNTS.
+- An audience's filters are IMMUTABLE once created. Only its name (rename) and its status are editable. There is no hard delete — archive instead.
+
+Your tools:
+- list_audiences — read the brand's audiences (optionally filtered by status). Use it to summarize, and to look up an audience's id before renaming it, changing its status, or refreshing its counts.
+- suggest_audiences — create candidate audiences from a natural-language description. Each candidate is ALREADY SAVED as an inactive 'suggested' audience (with a generated name, rationale, live count, and provider). This is how you create audiences: describe what the user wants, present the candidates, then ACTIVATE the chosen one(s).
+- set_audience_status — change an audience's status. To turn a suggested candidate into a real, live audience, set its status to 'active'. Map the user's intent: "activate"/"resume"/"reactivate"/"restore" → active, "pause" → paused, "archive" → archived. Archiving never deletes the audience — it can always be restored by setting it active again.
+- rename_audience — change an audience's name (the only editable metadata besides status).
+- refresh_audience_count — re-snapshot an audience's apollo + apify match counts when the user asks to refresh/recompute its size.
+
+How to create an audience: call suggest_audiences with the user's description, show the returned candidates (name, who they target, count), and when the user picks one, call set_audience_status with its audienceId and status 'active'. Do not stop at suggest_audiences when the user clearly wants the audience created — activate it.
+
+How to "edit" an audience's filters: filters can't be edited in place. When the user wants different targeting, suggest a new audience with the corrected description and (if they want the old one gone) archive the original with set_audience_status.
+
+Be concise. Confirm what you changed after each action. When asked only to read or summarize, never mutate.`;
+
+export const AUDIENCE_EDITOR_CONFIG = {
+  key: "audience-editor",
+  systemPrompt: AUDIENCE_EDITOR_SYSTEM_PROMPT,
+  allowedTools: [
+    "request_user_input",
+    "list_audiences",
+    "suggest_audiences",
+    "set_audience_status",
+    "rename_audience",
+    "refresh_audience_count",
+  ],
+  provider: "google" as const,
+  model: "flash-pro",
+};
+
 export const PERSONA_EDITOR_CONFIG = {
   key: "persona-editor",
   systemPrompt: PERSONA_EDITOR_SYSTEM_PROMPT,
@@ -79,6 +116,7 @@ export const BRAND_PROFILE_EDITOR_CONFIG = {
 export const SELF_SEEDED_CONFIGS = [
   PERSONA_EDITOR_CONFIG,
   BRAND_PROFILE_EDITOR_CONFIG,
+  AUDIENCE_EDITOR_CONFIG,
 ] as const;
 
 /**

--- a/tests/unit/persona-brand-profile-configs.test.ts
+++ b/tests/unit/persona-brand-profile-configs.test.ts
@@ -4,6 +4,7 @@ import {
   SELF_SEEDED_CONFIGS,
   PERSONA_EDITOR_CONFIG,
   BRAND_PROFILE_EDITOR_CONFIG,
+  AUDIENCE_EDITOR_CONFIG,
   seedPlatformConfigs,
 } from "../../src/lib/seed-platform-configs.js";
 
@@ -15,6 +16,11 @@ const NEW_TOOLS = [
   "get_brand_profile",
   "save_brand_profile_version",
   "refresh_brand_profile_from_website",
+  "list_audiences",
+  "suggest_audiences",
+  "set_audience_status",
+  "rename_audience",
+  "refresh_audience_count",
 ];
 
 describe("persona / brand-profile tool registry", () => {
@@ -34,11 +40,17 @@ describe("persona / brand-profile tool registry", () => {
     const tools = resolveToolSet([...BRAND_PROFILE_EDITOR_CONFIG.allowedTools]);
     expect(tools.map((t) => t.name)).toEqual([...BRAND_PROFILE_EDITOR_CONFIG.allowedTools]);
   });
+
+  it("resolveToolSet resolves every tool in audience-editor's allowedTools", () => {
+    const tools = resolveToolSet([...AUDIENCE_EDITOR_CONFIG.allowedTools]);
+    expect(tools.map((t) => t.name)).toEqual([...AUDIENCE_EDITOR_CONFIG.allowedTools]);
+  });
 });
 
 describe("self-seeded platform configs", () => {
-  it("declares both expected keys", () => {
+  it("declares all expected keys", () => {
     expect(SELF_SEEDED_CONFIGS.map((c) => c.key).sort()).toEqual([
+      "audience-editor",
       "brand-profile-editor",
       "persona-editor",
     ]);
@@ -69,6 +81,36 @@ describe("self-seeded platform configs", () => {
     expect(everyTool.some((t) => /delete|destroy|remove_persona/.test(t))).toBe(false);
   });
 
+  it("audience-editor is isolated from persona / brand-profile tools and vice-versa (scoping)", () => {
+    const audienceTools = [
+      "list_audiences",
+      "suggest_audiences",
+      "set_audience_status",
+      "rename_audience",
+      "refresh_audience_count",
+    ];
+    // audience-editor exposes ONLY audience tools (+ request_user_input).
+    for (const tool of AUDIENCE_EDITOR_CONFIG.allowedTools) {
+      if (tool === "request_user_input") continue;
+      expect(audienceTools, `audience-editor leaks ${tool}`).toContain(tool);
+    }
+    // persona / brand-profile editors cannot reach any audience tool.
+    for (const tool of audienceTools) {
+      expect(PERSONA_EDITOR_CONFIG.allowedTools).not.toContain(tool);
+      expect(BRAND_PROFILE_EDITOR_CONFIG.allowedTools).not.toContain(tool);
+    }
+    // audience-editor cannot reach persona / brand-profile tools.
+    for (const tool of [
+      ...PERSONA_EDITOR_CONFIG.allowedTools,
+      ...BRAND_PROFILE_EDITOR_CONFIG.allowedTools,
+    ]) {
+      if (tool === "request_user_input") continue;
+      expect(AUDIENCE_EDITOR_CONFIG.allowedTools).not.toContain(tool);
+    }
+    // No audience tool grants a hard-delete capability — none exists (archive only).
+    expect(audienceTools.some((t) => /delete|destroy|remove/.test(t))).toBe(false);
+  });
+
   it("brand-profile-editor exposes the website refresh tool and prompt guard", () => {
     expect(BRAND_PROFILE_EDITOR_CONFIG.allowedTools).toContain(
       "refresh_brand_profile_from_website",
@@ -95,7 +137,11 @@ describe("seedPlatformConfigs", () => {
     expect(onConflictDoUpdate).toHaveBeenCalledTimes(SELF_SEEDED_CONFIGS.length);
 
     const seededKeys = values.mock.calls.map((c) => (c[0] as { key: string }).key);
-    expect(seededKeys.sort()).toEqual(["brand-profile-editor", "persona-editor"]);
+    expect(seededKeys.sort()).toEqual([
+      "audience-editor",
+      "brand-profile-editor",
+      "persona-editor",
+    ]);
 
     for (const call of values.mock.calls) {
       const v = call[0] as { provider: string; model: string; allowedTools: string[] };


### PR DESCRIPTION
## What
Adds a third self-seeded platform config, **`audience-editor`**, restoring the AI-chat CRUD surface for the Wave 2 persona→audience unification. Its tools operate on the caller's **human-service audiences** via the **api-service gateway** `/v1/orgs/audiences/*`.

Closes the chat-service half of #300 (dashboard chat-panel re-enable is a separate, owned-elsewhere PR gated on this deploy).

## KEY design answer (the flagged question)
**How does persona-editor reach its backend?** Via the **api-service gateway** (`apiServiceFetch`, forwarding `x-org-id`/`x-user-id`/`x-run-id`). `audience-editor` mirrors this exactly — **route (1)**. 
- **No new env var** — `API_SERVICE_URL` + `ADMIN_DISTRIBUTE_API_KEY` are already wired for persona-editor.
- **Org-scoping correct** — human-service derives the org from the forwarded `x-org-id`; tools only ever touch the caller's org. brandId comes from `context.brandId` (existing `requireSingleBrandId`) for `list`/`suggest`; the by-id mutators are org-scoped by id via headers.

## Tool surface (creation = suggest→activate, no raw-create tool)
| Tool | Gateway call |
|---|---|
| `list_audiences` | `GET /v1/orgs/audiences?brandId=&status=` |
| `suggest_audiences` | `POST /v1/orgs/audiences/suggest` `{nlPrompt, brandId}` → `candidates[]` (each persisted @ `suggested`) |
| `set_audience_status` | `PATCH /v1/orgs/audiences/:id/status` `{status}` (activate suggested = `active`) |
| `rename_audience` | `PATCH /v1/orgs/audiences/:id` `{name}` |
| `refresh_audience_count` | `POST /v1/orgs/audiences/:id/refresh-count` |

**Why no raw `POST /orgs/audiences` create tool:** direct create requires the LLM to hand-author a full provider-specific filter set (`titles/seniorities/industries/...`) + count snapshots — exactly what `/suggest` does for it with live dry-run counting, then persists for activation. Suggest→activate is the locked product path.

## Files
- `src/lib/audience-client.ts` (new) — typed client, 5 fns via `apiServiceFetch`, all **fail-loud**.
- `src/lib/anthropic.ts` — 5 tool defs + `TOOL_REGISTRY` registration.
- `src/lib/seed-platform-configs.ts` — `AUDIENCE_EDITOR_CONFIG` + `SELF_SEEDED_CONFIGS` (google/flash-pro).
- `src/index.ts` — 5 `executeTool` dispatch blocks.
- `tests/unit/persona-brand-profile-configs.test.ts` — seeded-keys (now 3 keys), resolveToolSet parity, 3-way scoping isolation.
- `README.md` — self-seeded configs table + audience-editor tools table.

## No-gos respected
persona-editor + brand-profile-editor untouched · fail-loud throughout (no `?? fallback`, no swallowed errors) · dashboard untouched.

## Verification
- `npm run build` — tsc + openapi regen clean.
- `npm run test:unit` — **690 passed**.
- Deploy-ordering: api-service **staging** already serves `/v1/orgs/audiences/*` (PRs api-service#579/#584/#586 merged; verified via staging registry direct probe) — tools resolve on staging.

## Triage
Feature → **staging** (promote later).

Refs #300, distribute.you#1968, distribute.you#1978.

🤖 Generated with [Claude Code](https://claude.com/claude-code)