### PR TITLE
hotfix: Fix audiences chat dying silently after list_audiences (tool-then-empty turn never surfaces as silence; Gemini /chat maxOutputTokens 64k)

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,8 @@ data: {"type":"tool_result","id":"tc_550e8400-e29b-41d4-a716-446655440000","name
 
 After a tool result, more `token` events follow with the AI's continuation.
 
+**Tool-then-empty never surfaces as silence.** If one or more tools run but the model's follow-up "summarize" turn produces no text, the service emits a fallback `token` event built from the real tool results (so the user always sees what was retrieved) and logs the empty turn loudly — never a frozen tool card with a blank reply. This guards both the Gemini and Anthropic agentic loops. The `/chat` Gemini path also sets an explicit **64k** `maxOutputTokens` (Gemini-3 thinking tokens count against the output budget; without an explicit cap a post-tool summary turn can exhaust the lower default cap on thinking and emit zero answer text).
+
 #### Tool memory across turns
 
 Tool calls and their results are persisted on the assistant message (in the `tool_calls` jsonb column) and replayed to the provider on every subsequent turn:

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,6 +114,7 @@ import {
   type RebuildableMessage,
 } from "./lib/merge-messages.js";
 import { streamGeminiChat, type ToolDefinition } from "./lib/gemini-chat.js";
+import { buildToolResultFallback } from "./lib/tool-fallback.js";
 import { SESSION_NOT_FOUND_EVENT } from "./lib/session-errors.js";
 import { buildContextUsageEvent } from "./lib/context-usage.js";
 
@@ -2855,6 +2856,21 @@ app.post("/chat", requireAuth, async (req, res) => {
       : [];
     if (buttons.length > 0) {
       sendSSE(res, { type: "buttons", buttons });
+    }
+
+    // Tool(s) ran but the model produced no summary text. This must never leave
+    // a frozen tool card with no reply — build a fallback summary from the real
+    // tool results so the user always sees what was retrieved. (The Gemini path
+    // already fills fullResponse inside streamGeminiChat; this branch is the
+    // Anthropic-loop equivalent + a cross-provider backstop.) Logged loudly so
+    // the empty-turn root cause stays diagnosable.
+    if (!fullResponse && !emittedInputRequest && toolCalls.length > 0) {
+      console.error(
+        `[chat] session="${currentSessionId}" provider=${chatProvider} ran ${toolCalls.length} tool(s) ` +
+          `but produced no summary text — emitting fallback summary`,
+      );
+      fullResponse = buildToolResultFallback(toolCalls);
+      sendSSE(res, { type: "token", content: fullResponse });
     }
 
     // Detect empty stream

--- a/src/lib/gemini-chat.ts
+++ b/src/lib/gemini-chat.ts
@@ -7,8 +7,17 @@ import type { Response as ExpressResponse } from "express";
 import type { ToolCallRecord } from "../db/schema.js";
 import { trimGeminiHistoryToBudget } from "./gemini-trim.js";
 import { sanitizeGeminiSchema } from "./gemini.js";
+import { buildToolResultFallback } from "./tool-fallback.js";
 
 const GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta";
+
+// Explicit output budget for the agentic /chat path. REQUIRED — when omitted,
+// Gemini falls back to a LOWER per-model default cap, and because Gemini-3
+// thinking tokens count against the output budget, a post-tool "summarize"
+// turn can spend the entire default cap on thinking and emit ZERO answer text
+// (finishReason: MAX_TOKENS) — the silent empty follow-up that froze the
+// audiences chat after list_audiences. Mirrors the /complete path's 64k.
+const GEMINI_CHAT_MAX_OUTPUT_TOKENS = 64_000;
 
 /** Model-specific API timeouts in milliseconds. */
 const GEMINI_TIMEOUT_MS: Record<string, number> = {
@@ -400,6 +409,7 @@ export async function streamGeminiChat(
       contents: turnMessages,
       systemInstruction: { parts: [{ text: systemPrompt }] },
       generationConfig: {
+        maxOutputTokens: GEMINI_CHAT_MAX_OUTPUT_TOKENS,
         thinkingConfig: { thinkingBudget: 8192 },
       },
       ...(functionDeclarations.length > 0
@@ -602,6 +612,25 @@ export async function streamGeminiChat(
     // Append model function calls + tool results to conversation
     turnMessages.push({ role: "model", parts: modelParts });
     turnMessages.push({ role: "user", parts: responseParts });
+  }
+
+  // Tool(s) ran but the follow-up "summarize" turn produced no text. This must
+  // NEVER surface as silence (a frozen tool card with no reply) — emit a
+  // fallback assistant message built from the real tool results so the user
+  // always sees what was retrieved. Logged loudly so the empty-turn root cause
+  // (e.g. MAX_TOKENS during thinking) stays diagnosable.
+  if (
+    !signal.aborted &&
+    fullResponse === "" &&
+    !emittedInputRequest &&
+    allToolCalls.length > 0
+  ) {
+    console.error(
+      `[gemini-chat] model=${model} ran ${allToolCalls.length} tool(s) but returned no summary text — emitting fallback summary`,
+    );
+    const fallback = buildToolResultFallback(allToolCalls);
+    fullResponse = fallback;
+    sse(res, { type: "token", content: fallback });
   }
 
   // Fail loud on a wholly-empty result (no text, no tool calls, no input

--- a/src/lib/tool-fallback.ts
+++ b/src/lib/tool-fallback.ts
@@ -1,0 +1,56 @@
+// ---------------------------------------------------------------------------
+// Tool-result fallback summary
+// ---------------------------------------------------------------------------
+//
+// When an agentic chat turn runs one or more tools but the model's follow-up
+// "summarize" turn comes back with NO text, the chat must never surface to the
+// user as silence (a frozen tool card with no reply). This builds a readable
+// fallback assistant message from the raw tool results so the user always sees
+// what the tools returned — provider-agnostic (used by both the Gemini and
+// Anthropic agentic loops).
+//
+// This is a SAFETY NET, not the happy path: the model normally writes its own
+// summary. The fallback only fires when that summary is empty, and it renders
+// the REAL tool results (no fabricated data), alongside a loud server log so
+// the empty-turn root cause stays diagnosable.
+
+const MAX_RENDERED_RESULT_CHARS = 4000;
+
+/** Render a single tool result as readable markdown, truncated for safety. */
+function renderToolResult(result: unknown): string {
+  if (result === null || result === undefined) return "_(no result)_";
+  if (typeof result === "string") {
+    return result.length > MAX_RENDERED_RESULT_CHARS
+      ? result.slice(0, MAX_RENDERED_RESULT_CHARS) + "…"
+      : result;
+  }
+  let json: string;
+  try {
+    json = JSON.stringify(result, null, 2);
+  } catch {
+    json = String(result);
+  }
+  const body =
+    json.length > MAX_RENDERED_RESULT_CHARS
+      ? json.slice(0, MAX_RENDERED_RESULT_CHARS) + "\n…"
+      : json;
+  return "```json\n" + body + "\n```";
+}
+
+/**
+ * Build a fallback assistant message summarizing the tool calls that ran when
+ * the model produced no summary text of its own. Always returns a non-empty
+ * string when `toolCalls` is non-empty.
+ */
+export function buildToolResultFallback(
+  toolCalls: Array<{ name: string; result?: unknown }>,
+): string {
+  if (toolCalls.length === 0) return "";
+  const header =
+    "I retrieved the requested information, but couldn't generate a written " +
+    "summary this time. Here is what the tools returned:";
+  const blocks = toolCalls.map(
+    (tc) => `**${tc.name}**\n${renderToolResult(tc.result)}`,
+  );
+  return [header, ...blocks].join("\n\n");
+}

--- a/tests/unit/gemini-chat.test.ts
+++ b/tests/unit/gemini-chat.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from "vitest";
-import { toGeminiFunctionDeclarations, type ToolDefinition } from "../../src/lib/gemini-chat.js";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  toGeminiFunctionDeclarations,
+  streamGeminiChat,
+  type ToolDefinition,
+} from "../../src/lib/gemini-chat.js";
 
 describe("toGeminiFunctionDeclarations", () => {
   it("converts Anthropic-style tool definitions to Gemini format", () => {
@@ -155,5 +159,117 @@ describe("toGeminiFunctionDeclarations", () => {
       note: { type: "string", nullable: true },
     });
     expect(result[0].parameters.required).toEqual(["status"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// streamGeminiChat — tool-then-empty must never surface as silence
+// ---------------------------------------------------------------------------
+
+/** Build a 200 SSE Response from a single JSON chunk (one `data:` event). */
+function sseResponse(chunk: unknown): Response {
+  const payload = `data: ${JSON.stringify(chunk)}\r\n\r\n`;
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(payload));
+      controller.close();
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+function baseOptions(overrides: Partial<Parameters<typeof streamGeminiChat>[0]> = {}) {
+  const events: unknown[] = [];
+  const opts = {
+    apiKey: "test-key",
+    model: "gemini-3-flash-preview",
+    systemPrompt: "You are a helpful assistant.",
+    history: [],
+    userMessage: "Créer des audiences pour mon business",
+    tools: [
+      {
+        name: "list_audiences",
+        description: "List audiences for the current brand",
+        input_schema: { type: "object" as const, properties: {} },
+      },
+    ] as ToolDefinition[],
+    res: {} as never,
+    sendSSE: (_res: unknown, data: unknown) => {
+      events.push(data);
+    },
+    executeTool: async () => ({
+      name: "list_audiences",
+      result: { audiences: [{ id: "a1", name: "Founders" }] },
+    }),
+    signal: new AbortController().signal,
+    ...overrides,
+  };
+  return { opts, events };
+}
+
+describe("streamGeminiChat tool-then-empty guard", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("emits a fallback summary when the post-tool turn returns no text", async () => {
+    // Turn 0: the model calls list_audiences. Turn 1: empty (MAX_TOKENS during
+    // thinking) — no text parts. Without the guard this returns fullResponse:""
+    // and the dashboard freezes on the tool card.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        sseResponse({
+          candidates: [
+            {
+              content: {
+                parts: [
+                  { functionCall: { name: "list_audiences", args: {} }, thoughtSignature: "sig-1" },
+                ],
+              },
+            },
+          ],
+          usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5 },
+        }),
+      )
+      .mockResolvedValueOnce(
+        sseResponse({
+          candidates: [{ content: { parts: [] }, finishReason: "MAX_TOKENS" }],
+          usageMetadata: { promptTokenCount: 20, candidatesTokenCount: 0 },
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { opts, events } = baseOptions();
+    const result = await streamGeminiChat(opts);
+
+    // Tool ran...
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls[0].name).toBe("list_audiences");
+    // ...and the response is NOT silently empty — it summarizes the tool result.
+    expect(result.fullResponse).not.toBe("");
+    expect(result.fullResponse).toContain("list_audiences");
+    expect(result.fullResponse).toContain("Founders");
+    // The fallback text was streamed to the client as a token event.
+    const tokenText = events
+      .filter((e): e is { type: string; content: string } =>
+        typeof e === "object" && e !== null && (e as { type?: string }).type === "token",
+      )
+      .map((e) => e.content)
+      .join("");
+    expect(tokenText).toContain("Founders");
+  });
+
+  it("still fails loud on a wholly-empty stream (no tools, no usage)", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      sseResponse({ candidates: [{ content: { parts: [] } }] }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { opts } = baseOptions({ tools: [] });
+    await expect(streamGeminiChat(opts)).rejects.toThrow(/empty response/);
   });
 });

--- a/tests/unit/tool-fallback.test.ts
+++ b/tests/unit/tool-fallback.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { buildToolResultFallback } from "../../src/lib/tool-fallback.js";
+
+describe("buildToolResultFallback", () => {
+  it("returns empty string when no tools ran", () => {
+    expect(buildToolResultFallback([])).toBe("");
+  });
+
+  it("renders tool name and JSON result", () => {
+    const out = buildToolResultFallback([
+      { name: "list_audiences", result: { audiences: [{ id: "a1", name: "Founders" }] } },
+    ]);
+    expect(out).not.toBe("");
+    expect(out).toContain("list_audiences");
+    expect(out).toContain("Founders");
+  });
+
+  it("renders multiple tool calls", () => {
+    const out = buildToolResultFallback([
+      { name: "list_audiences", result: { audiences: [] } },
+      { name: "suggest_audiences", result: { candidates: [{ name: "EU founders" }] } },
+    ]);
+    expect(out).toContain("list_audiences");
+    expect(out).toContain("suggest_audiences");
+    expect(out).toContain("EU founders");
+  });
+
+  it("renders a string result verbatim", () => {
+    const out = buildToolResultFallback([{ name: "echo", result: "hello world" }]);
+    expect(out).toContain("hello world");
+  });
+});


### PR DESCRIPTION
Automated by release.sh