### PR TITLE
hotfix: Use thinkingLevel for Gemini 3.x — fixes 100% empty flash-pro /chat replies (deprecated thinkingBudget caused thinking-only output)

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,8 @@ After a tool result, more `token` events follow with the AI's continuation.
 
 **Tool-then-empty never surfaces as silence.** If one or more tools run but the model's follow-up "summarize" turn produces no text, the service emits a fallback `token` event built from the real tool results (so the user always sees what was retrieved) and logs the empty turn loudly — never a frozen tool card with a blank reply. This guards both the Gemini and Anthropic agentic loops. The `/chat` Gemini path also sets an explicit **64k** `maxOutputTokens` (Gemini-3 thinking tokens count against the output budget; without an explicit cap a post-tool summary turn can exhaust the lower default cap on thinking and emit zero answer text).
 
+**Thinking config is generation-specific.** Gemini 3.x models (`gemini-3*`, incl. `gemini-3.5-flash` = the `flash-pro` alias) use `thinkingConfig.thinkingLevel` (`"low"` here); the Gemini-2.5-era `thinkingBudget` integer is only "accepted for backwards compatibility" on Gemini 3 and produces degenerate **thinking-only / empty** replies — which is what broke every flash-pro `/chat` once Google flipped `gemini-3.5-flash` to stable. Gemini 2.5 models keep `thinkingBudget`. Selected per-model by `buildThinkingConfig(model)`.
+
 #### Tool memory across turns
 
 Tool calls and their results are persisted on the assistant message (in the `tool_calls` jsonb column) and replayed to the provider on every subsequent turn:

--- a/src/lib/gemini-chat.ts
+++ b/src/lib/gemini-chat.ts
@@ -31,6 +31,25 @@ const DEFAULT_GEMINI_TIMEOUT_MS = 10 * 60_000;
 
 const MAX_TOOL_CHAIN_DEPTH = 10;
 
+// Thinking config is GENERATION-SPECIFIC. Gemini 3.x (gemini-3*, incl
+// gemini-3.5-flash) uses `thinkingLevel` ("minimal"|"low"|"medium"|"high");
+// the Gemini-2.5-era `thinkingBudget` integer is only "accepted for backwards
+// compatibility" on Gemini 3 and produces degenerate output — the model spends
+// its whole output budget on internal thinking and emits ZERO answer text. That
+// is exactly what broke every flash-pro (gemini-3.5-flash) /chat once Google
+// flipped 3.5-flash to stable (100% empty replies, 2026-06-18→). So send
+// `thinkingLevel` to Gemini 3.x and keep `thinkingBudget` only for Gemini 2.5.
+// "low" gives enough reasoning for tool-calling while leaving budget for the
+// answer. See https://ai.google.dev/gemini-api/docs/thinking
+const GEMINI_3_THINKING_LEVEL = "low";
+const GEMINI_25_THINKING_BUDGET = 8192;
+
+export function buildThinkingConfig(model: string): Record<string, unknown> {
+  return model.startsWith("gemini-3")
+    ? { thinkingLevel: GEMINI_3_THINKING_LEVEL }
+    : { thinkingBudget: GEMINI_25_THINKING_BUDGET };
+}
+
 // Gemini 3 requires a `thoughtSignature` on every functionCall part when the
 // conversation history is replayed; omitting it returns a 400
 // (`Function call ... is missing a thought_signature`). For calls captured
@@ -410,7 +429,7 @@ export async function streamGeminiChat(
       systemInstruction: { parts: [{ text: systemPrompt }] },
       generationConfig: {
         maxOutputTokens: GEMINI_CHAT_MAX_OUTPUT_TOKENS,
-        thinkingConfig: { thinkingBudget: 8192 },
+        thinkingConfig: buildThinkingConfig(model),
       },
       ...(functionDeclarations.length > 0
         ? { tools: [{ functionDeclarations }] }

--- a/tests/unit/gemini-chat.test.ts
+++ b/tests/unit/gemini-chat.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   toGeminiFunctionDeclarations,
   streamGeminiChat,
+  buildThinkingConfig,
   type ToolDefinition,
 } from "../../src/lib/gemini-chat.js";
 
@@ -210,9 +211,44 @@ function baseOptions(overrides: Partial<Parameters<typeof streamGeminiChat>[0]> 
   return { opts, events };
 }
 
+describe("buildThinkingConfig (generation-specific thinking field)", () => {
+  // Gemini 3.x must use thinkingLevel; the deprecated thinkingBudget produces
+  // thinking-only/empty replies on gemini-3.5-flash. Gemini 2.5 keeps budget.
+  it("uses thinkingLevel for gemini-3.5-flash", () => {
+    expect(buildThinkingConfig("gemini-3.5-flash")).toEqual({ thinkingLevel: "low" });
+  });
+  it("uses thinkingLevel for gemini-3.1-pro-preview", () => {
+    expect(buildThinkingConfig("gemini-3.1-pro-preview")).toEqual({ thinkingLevel: "low" });
+  });
+  it("uses thinkingLevel for gemini-3-flash-preview", () => {
+    expect(buildThinkingConfig("gemini-3-flash-preview")).toEqual({ thinkingLevel: "low" });
+  });
+  it("keeps thinkingBudget for gemini-2.5 models", () => {
+    expect(buildThinkingConfig("gemini-2.5-flash")).toEqual({ thinkingBudget: 8192 });
+    expect(buildThinkingConfig("gemini-2.5-pro")).toEqual({ thinkingBudget: 8192 });
+  });
+});
+
 describe("streamGeminiChat tool-then-empty guard", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+  });
+
+  it("sends thinkingLevel (not thinkingBudget) for a Gemini-3 model", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      sseResponse({
+        candidates: [{ content: { parts: [{ text: "hello" }] }, finishReason: "STOP" }],
+        usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 2 },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { opts } = baseOptions({ model: "gemini-3.5-flash", tools: [] });
+    await streamGeminiChat(opts);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body.generationConfig.thinkingConfig).toEqual({ thinkingLevel: "low" });
+    expect(JSON.stringify(body.generationConfig)).not.toContain("thinkingBudget");
   });
 
   it("emits a fallback summary when the post-tool turn returns no text", async () => {


### PR DESCRIPTION
Automated by release.sh