### PR TITLE
feat(chat): propagate x-audience-id for per-audience cost attribution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,18 @@ CI will warn if source files change without corresponding test changes. Do not s
 - `tests/` — Test files (`*.test.ts`)
 - `openapi.json` — Auto-generated, do NOT edit manually
 
+## Tracking headers — allowlist-driven forward, NEVER per-field, NEVER to a vendor
+
+Inbound tracking headers (`x-campaign-id`, `x-brand-id`, `x-workflow-slug`, `x-feature-slug`, `x-audience-id`) are extracted in `src/middleware/auth.ts:extractWorkflowTracking` into `res.locals.workflowTracking`, then turned into the downstream header map by the **single allowlist helper `buildTrackingHeaders(workflowTracking)`** (same file). Every endpoint uses that helper — do NOT re-introduce the old per-field `if (workflowTracking.x) trackingHeaders["x-x"] = …` blocks at each route (they drifted: a new header had to be added in ~5 places and got missed). Add a new tracking header in exactly TWO spots: `extractWorkflowTracking` (read) + `buildTrackingHeaders` (forward), plus the `TrackingHeaders` types in `runs-client.ts`/`key-client.ts` and the `traceEvent` header builder. runs-client/key-client forward the map **generically** (`Object.entries` loop), so once a key is in the map it flows to runs-service + key-service automatically.
+
+**`x-audience-id`** = the priority audience campaign-service picks at the start of a campaign run; carried for **per-audience cost attribution** (runs-service does a flat `SUM(cost) GROUP BY COALESCE(runs_costs.audience_id, runs.audience_id)`, no hierarchy rollup — so every run AND every cost row must carry it itself). It is forwarded on `createRun` + `addRunCosts` and stamped on the `sessions` row (`audience_id` column). Optional — absent outside the campaign flow; omit, never throw.
+
+**Egress guardrail (security): tracking headers go to INTERNAL services ONLY, never to a third-party vendor.** The Gemini/Anthropic provider clients (`gemini.ts`, `gemini-chat.ts`, `anthropic.ts`) build their own vendor headers and contain ZERO tracking-header keys — keep it that way. `buildTrackingHeaders` is the only forward path and its output is asserted to be a strict subset of the internal allowlist (`tests/unit/workflow-tracking.test.ts`). Never pass `trackingHeaders` into a provider SDK call. (Standard OTel/DoorDash egress hygiene: drop everything but the vendor's own auth at the external boundary.)
+
+## Drizzle migrations are HAND-AUTHORED here — `db:generate` is corrupted, do NOT trust its output
+
+`drizzle/meta/` snapshots stop at `0009`; migrations `0010`–onward were hand-authored without snapshot updates. So `npm run db:generate` diffs against a ~0009 snapshot and emits a BOGUS full migration that re-creates tables and **DROPS** existing columns (it tried to drop `messages.run_id`/`campaign_id`/… and re-add already-live `sessions`/`app_configs` columns). NEVER ship `db:generate` output. To add a column: hand-author `drizzle/NNNN_<name>.sql` with an **idempotent** statement (`ALTER TABLE … ADD COLUMN IF NOT EXISTS …`) and add the matching `_journal.json` entry by hand (the runtime migrator keys on the journal `when` only; the snapshot JSON is not validated at runtime). Reference: `0015_add_audience_id_to_sessions.sql`.
+
 ## Chat provider/model default — Gemini, in code (not the DB)
 
 The default LLM for `/chat` is **Gemini `google`/`flash-pro`** (Gemini 3.5 Flash, mid-tier), resolved in code by `resolveChatProviderModel` (`src/lib/config-defaults.ts`). A config row (`app_configs` / `platform_configs`) with `provider`/`model` NULL resolves to `google`/`flash-pro` — **NOT** `anthropic`/`sonnet`. The Anthropic platform key has no credit balance; defaulting to it 400s every chat that uses a default config.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ All endpoints (except `/health` and `/openapi.json`) require these headers:
 | `x-brand-id` | _(optional)_ Brand ID(s) — injected automatically by workflow-service. May be a single UUID or a comma-separated list of UUIDs for multi-brand campaigns (e.g. `uuid1,uuid2,uuid3`). |
 | `x-workflow-slug` | _(optional)_ Workflow slug — injected automatically by workflow-service |
 | `x-feature-slug` | _(optional)_ Feature slug — propagated through the entire service chain |
+| `x-audience-id` | _(optional)_ Priority audience ID for the campaign run — injected by campaign-service. Propagated through the chain and stamped on every runs-service run + cost (and the `sessions` row) for per-audience cost attribution. Absent outside the campaign flow. |
 
 ## App Config Registration
 

--- a/drizzle/0015_add_audience_id_to_sessions.sql
+++ b/drizzle/0015_add_audience_id_to_sessions.sql
@@ -1,0 +1,3 @@
+-- Add audience_id to sessions for per-audience cost attribution.
+-- Idempotent: ADD COLUMN IF NOT EXISTS is safe on partial-apply replay.
+ALTER TABLE "sessions" ADD COLUMN IF NOT EXISTS "audience_id" text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1776009600000,
       "tag": "0014_add_brand_profile_embeddings",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1782050021108,
+      "tag": "0015_add_audience_id_to_sessions",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -1354,6 +1354,16 @@
             "description": "Feature slug — propagated through the entire service chain",
             "name": "x-feature-slug",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Priority audience ID for the campaign run — injected by campaign-service and propagated through the chain for per-audience cost attribution. Optional outside the campaign flow."
+            },
+            "required": false,
+            "description": "Priority audience ID for the campaign run — injected by campaign-service and propagated through the chain for per-audience cost attribution. Optional outside the campaign flow.",
+            "name": "x-audience-id",
+            "in": "header"
           }
         ],
         "requestBody": {
@@ -1550,6 +1560,16 @@
             "description": "Feature slug — propagated through the entire service chain",
             "name": "x-feature-slug",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Priority audience ID for the campaign run — injected by campaign-service and propagated through the chain for per-audience cost attribution. Optional outside the campaign flow."
+            },
+            "required": false,
+            "description": "Priority audience ID for the campaign run — injected by campaign-service and propagated through the chain for per-audience cost attribution. Optional outside the campaign flow.",
+            "name": "x-audience-id",
+            "in": "header"
           }
         ],
         "requestBody": {
@@ -1703,6 +1723,16 @@
             "required": false,
             "description": "Feature slug — propagated through the entire service chain",
             "name": "x-feature-slug",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Priority audience ID for the campaign run — injected by campaign-service and propagated through the chain for per-audience cost attribution. Optional outside the campaign flow."
+            },
+            "required": false,
+            "description": "Priority audience ID for the campaign run — injected by campaign-service and propagated through the chain for per-audience cost attribution. Optional outside the campaign flow.",
+            "name": "x-audience-id",
             "in": "header"
           }
         ],
@@ -2002,6 +2032,16 @@
             "description": "Feature slug — propagated through the entire service chain",
             "name": "x-feature-slug",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Priority audience ID for the campaign run — injected by campaign-service and propagated through the chain for per-audience cost attribution. Optional outside the campaign flow."
+            },
+            "required": false,
+            "description": "Priority audience ID for the campaign run — injected by campaign-service and propagated through the chain for per-audience cost attribution. Optional outside the campaign flow.",
+            "name": "x-audience-id",
+            "in": "header"
           }
         ],
         "requestBody": {
@@ -2218,6 +2258,16 @@
             "description": "Feature slug — propagated through the entire service chain",
             "name": "x-feature-slug",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Priority audience ID for the campaign run — injected by campaign-service and propagated through the chain for per-audience cost attribution. Optional outside the campaign flow."
+            },
+            "required": false,
+            "description": "Priority audience ID for the campaign run — injected by campaign-service and propagated through the chain for per-audience cost attribution. Optional outside the campaign flow.",
+            "name": "x-audience-id",
+            "in": "header"
           }
         ],
         "requestBody": {
@@ -2371,6 +2421,16 @@
             "required": false,
             "description": "Feature slug — propagated through the entire service chain",
             "name": "x-feature-slug",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Priority audience ID for the campaign run — injected by campaign-service and propagated through the chain for per-audience cost attribution. Optional outside the campaign flow."
+            },
+            "required": false,
+            "description": "Priority audience ID for the campaign run — injected by campaign-service and propagated through the chain for per-audience cost attribution. Optional outside the campaign flow.",
+            "name": "x-audience-id",
             "in": "header"
           }
         ],

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -10,6 +10,7 @@ export const sessions = pgTable("sessions", {
   brandIds: text("brand_ids").array(),
   workflowSlug: text("workflow_slug"),
   featureSlug: text("feature_slug"),
+  audienceId: text("audience_id"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,7 +99,7 @@ import {
 import { authorizeCredits, BillingError } from "./lib/billing-client.js";
 import { getCampaignFeatureInputs } from "./lib/campaign-client.js";
 import { ChatRequestSchema, CompleteRequestSchema, GenerateImageRequestSchema, InternalPlatformCompleteRequestSchema, AppConfigRequestSchema, PlatformConfigRequestSchema, TransferBrandRequestSchema, RagScoreRequestSchema, RagEmbedRequestSchema } from "./schemas.js";
-import { requireAuth, requireInternalAuth, type AuthLocals } from "./middleware/auth.js";
+import { requireAuth, requireInternalAuth, buildTrackingHeaders, type AuthLocals } from "./middleware/auth.js";
 import type { ButtonRecord, ToolCallRecord } from "./db/schema.js";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
 
@@ -299,11 +299,7 @@ app.put("/platform-config", requireInternalAuth, async (req, res) => {
 app.post("/complete", requireAuth, async (req, res) => {
   const { orgId, userId, parentRunId, workflowTracking } = res.locals as AuthLocals;
 
-  const trackingHeaders: Record<string, string> = {};
-  if (workflowTracking.campaignId) trackingHeaders["x-campaign-id"] = workflowTracking.campaignId;
-  if (workflowTracking.brandId) trackingHeaders["x-brand-id"] = workflowTracking.brandId;
-  if (workflowTracking.workflowSlug) trackingHeaders["x-workflow-slug"] = workflowTracking.workflowSlug;
-  if (workflowTracking.featureSlug) trackingHeaders["x-feature-slug"] = workflowTracking.featureSlug;
+  const trackingHeaders = buildTrackingHeaders(workflowTracking);
 
   const parsed = CompleteRequestSchema.safeParse(req.body);
   if (!parsed.success) {
@@ -531,11 +527,7 @@ app.post("/complete", requireAuth, async (req, res) => {
 app.post("/orgs/images/generate", requireAuth, async (req, res) => {
   const { orgId, userId, parentRunId, workflowTracking } = res.locals as AuthLocals;
 
-  const trackingHeaders: Record<string, string> = {};
-  if (workflowTracking.campaignId) trackingHeaders["x-campaign-id"] = workflowTracking.campaignId;
-  if (workflowTracking.brandId) trackingHeaders["x-brand-id"] = workflowTracking.brandId;
-  if (workflowTracking.workflowSlug) trackingHeaders["x-workflow-slug"] = workflowTracking.workflowSlug;
-  if (workflowTracking.featureSlug) trackingHeaders["x-feature-slug"] = workflowTracking.featureSlug;
+  const trackingHeaders = buildTrackingHeaders(workflowTracking);
 
   const parsed = GenerateImageRequestSchema.safeParse(req.body);
   if (!parsed.success) {
@@ -964,10 +956,11 @@ async function provisionAndAuthorizeLlmCost(args: {
 app.post("/orgs/rag/score", requireAuth, async (req, res) => {
   const { orgId, userId, parentRunId, workflowTracking } = res.locals as AuthLocals;
 
-  const baseTrackingHeaders: Record<string, string> = {};
-  if (workflowTracking.campaignId) baseTrackingHeaders["x-campaign-id"] = workflowTracking.campaignId;
-  if (workflowTracking.workflowSlug) baseTrackingHeaders["x-workflow-slug"] = workflowTracking.workflowSlug;
-  if (workflowTracking.featureSlug) baseTrackingHeaders["x-feature-slug"] = workflowTracking.featureSlug;
+  // Body brandIds is the authoritative cache target, so drop any forwarded
+  // x-brand-id from the base block — it is re-set below from brandCacheKey.
+  // Every other tracking header (incl. x-audience-id) flows through unchanged.
+  const baseTrackingHeaders = buildTrackingHeaders(workflowTracking);
+  delete baseTrackingHeaders["x-brand-id"];
 
   const parsed = RagScoreRequestSchema.safeParse(req.body);
   if (!parsed.success) {
@@ -1268,11 +1261,7 @@ app.post("/orgs/rag/score", requireAuth, async (req, res) => {
 app.post("/orgs/rag/embed", requireAuth, async (req, res) => {
   const { orgId, userId, parentRunId, workflowTracking } = res.locals as AuthLocals;
 
-  const trackingHeaders: Record<string, string> = {};
-  if (workflowTracking.campaignId) trackingHeaders["x-campaign-id"] = workflowTracking.campaignId;
-  if (workflowTracking.brandId) trackingHeaders["x-brand-id"] = workflowTracking.brandId;
-  if (workflowTracking.workflowSlug) trackingHeaders["x-workflow-slug"] = workflowTracking.workflowSlug;
-  if (workflowTracking.featureSlug) trackingHeaders["x-feature-slug"] = workflowTracking.featureSlug;
+  const trackingHeaders = buildTrackingHeaders(workflowTracking);
 
   const parsed = RagEmbedRequestSchema.safeParse(req.body);
   if (!parsed.success) {
@@ -1674,11 +1663,7 @@ app.post("/chat", requireAuth, async (req, res) => {
   const { orgId, userId, parentRunId, workflowTracking } = res.locals as AuthLocals;
 
   // Build tracking headers to forward to downstream services
-  const trackingHeaders: Record<string, string> = {};
-  if (workflowTracking.campaignId) trackingHeaders["x-campaign-id"] = workflowTracking.campaignId;
-  if (workflowTracking.brandId) trackingHeaders["x-brand-id"] = workflowTracking.brandId;
-  if (workflowTracking.workflowSlug) trackingHeaders["x-workflow-slug"] = workflowTracking.workflowSlug;
-  if (workflowTracking.featureSlug) trackingHeaders["x-feature-slug"] = workflowTracking.featureSlug;
+  const trackingHeaders = buildTrackingHeaders(workflowTracking);
 
   const parsed = ChatRequestSchema.safeParse(req.body);
   if (!parsed.success) {
@@ -1783,6 +1768,7 @@ app.post("/chat", requireAuth, async (req, res) => {
           brandIds: brandIds.length > 0 ? brandIds : null,
           workflowSlug: workflowTracking.workflowSlug ?? null,
           featureSlug: workflowTracking.featureSlug ?? null,
+          audienceId: workflowTracking.audienceId ?? null,
         })
         .returning();
       currentSessionId = session.id;

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -49,6 +49,7 @@ export interface TrackingHeaders {
   "x-brand-id"?: string;
   "x-workflow-slug"?: string;
   "x-feature-slug"?: string;
+  "x-audience-id"?: string;
 }
 
 function buildHeaders(

--- a/src/lib/trace-event.ts
+++ b/src/lib/trace-event.ts
@@ -41,6 +41,7 @@ function buildTraceHeaders(
   if (tracking.campaignId) headers["x-campaign-id"] = tracking.campaignId;
   if (tracking.workflowSlug) headers["x-workflow-slug"] = tracking.workflowSlug;
   if (tracking.featureSlug) headers["x-feature-slug"] = tracking.featureSlug;
+  if (tracking.audienceId) headers["x-audience-id"] = tracking.audienceId;
   return headers;
 }
 

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -5,6 +5,32 @@ export interface WorkflowTrackingHeaders {
   brandId?: string;
   workflowSlug?: string;
   featureSlug?: string;
+  /**
+   * Priority audience chosen by campaign-service at the start of a campaign run.
+   * Propagated through the whole service chain for per-audience cost attribution.
+   * Optional — absent outside the campaign flow; omit, never throw.
+   */
+  audienceId?: string;
+}
+
+/**
+ * Build the downstream tracking-header map from the inbound tracking block —
+ * allowlist-driven, NOT field-by-field at each call site. Adding a new tracking
+ * header here propagates it to every internal call (runs-service, key-service,
+ * trace events) at once. Only forward this to INTERNAL services — never to a
+ * third-party vendor (Anthropic/Gemini/etc.); the provider clients build their
+ * own vendor headers and must stay free of these keys.
+ */
+export function buildTrackingHeaders(
+  tracking: WorkflowTrackingHeaders,
+): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (tracking.campaignId) headers["x-campaign-id"] = tracking.campaignId;
+  if (tracking.brandId) headers["x-brand-id"] = tracking.brandId;
+  if (tracking.workflowSlug) headers["x-workflow-slug"] = tracking.workflowSlug;
+  if (tracking.featureSlug) headers["x-feature-slug"] = tracking.featureSlug;
+  if (tracking.audienceId) headers["x-audience-id"] = tracking.audienceId;
+  return headers;
 }
 
 export interface AuthLocals {
@@ -60,6 +86,8 @@ function extractWorkflowTracking(req: Request): WorkflowTrackingHeaders {
   if (typeof workflowSlug === "string") tracking.workflowSlug = workflowSlug;
   const featureSlug = req.headers["x-feature-slug"];
   if (typeof featureSlug === "string") tracking.featureSlug = featureSlug;
+  const audienceId = req.headers["x-audience-id"];
+  if (typeof audienceId === "string") tracking.audienceId = audienceId;
   return tracking;
 }
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -24,6 +24,10 @@ const workflowTrackingHeaders = {
   "x-feature-slug": z.string().optional().openapi({
     description: "Feature slug — propagated through the entire service chain",
   }),
+  "x-audience-id": z.string().optional().openapi({
+    description:
+      "Priority audience ID for the campaign run — injected by campaign-service and propagated through the chain for per-audience cost attribution. Optional outside the campaign flow.",
+  }),
 };
 
 // --- Shared schemas ---

--- a/tests/unit/trace-event.test.ts
+++ b/tests/unit/trace-event.test.ts
@@ -24,6 +24,7 @@ const tracking = {
   campaignId: "camp-1",
   workflowSlug: "wf-1",
   featureSlug: "ft-1",
+  audienceId: "aud-1",
 };
 
 function flushAsync() {
@@ -99,6 +100,7 @@ describe("traceEvent — header forwarding", () => {
     expect(headers["x-campaign-id"]).toBe("camp-1");
     expect(headers["x-workflow-slug"]).toBe("wf-1");
     expect(headers["x-feature-slug"]).toBe("ft-1");
+    expect(headers["x-audience-id"]).toBe("aud-1");
   });
 
   it("omits tracking headers that are absent", async () => {
@@ -116,6 +118,7 @@ describe("traceEvent — header forwarding", () => {
     expect(headers).not.toHaveProperty("x-campaign-id");
     expect(headers).not.toHaveProperty("x-workflow-slug");
     expect(headers).not.toHaveProperty("x-feature-slug");
+    expect(headers).not.toHaveProperty("x-audience-id");
   });
 });
 

--- a/tests/unit/workflow-tracking.test.ts
+++ b/tests/unit/workflow-tracking.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import type { Request, Response, NextFunction } from "express";
-import { requireAuth, type AuthLocals } from "../../src/middleware/auth.js";
+import { requireAuth, buildTrackingHeaders, type AuthLocals } from "../../src/middleware/auth.js";
 
 function mockReqRes(headers: Record<string, string> = {}) {
   const req = { headers } as unknown as Request;
@@ -28,6 +28,7 @@ describe("workflow tracking headers in auth middleware", () => {
       "x-brand-id": "brand-xyz",
       "x-workflow-slug": "outreach-v2",
       "x-feature-slug": "pr-outreach",
+      "x-audience-id": "aud-001",
     });
     requireAuth(req, res, next);
     expect(next).toHaveBeenCalled();
@@ -37,7 +38,27 @@ describe("workflow tracking headers in auth middleware", () => {
       brandId: "brand-xyz",
       workflowSlug: "outreach-v2",
       featureSlug: "pr-outreach",
+      audienceId: "aud-001",
     });
+  });
+
+  it("extracts audience-id when present alone", () => {
+    const { req, res, next } = mockReqRes({
+      ...BASE_HEADERS,
+      "x-audience-id": "aud-solo",
+    });
+    requireAuth(req, res, next);
+    expect(next).toHaveBeenCalled();
+    const locals = res.locals as unknown as AuthLocals;
+    expect(locals.workflowTracking).toEqual({ audienceId: "aud-solo" });
+  });
+
+  it("omits audience-id when absent (optional — never throws)", () => {
+    const { req, res, next } = mockReqRes(BASE_HEADERS);
+    requireAuth(req, res, next);
+    expect(next).toHaveBeenCalled();
+    const locals = res.locals as unknown as AuthLocals;
+    expect(locals.workflowTracking.audienceId).toBeUndefined();
   });
 
   it("preserves CSV x-brand-id header as-is for multi-brand campaigns", () => {
@@ -99,6 +120,60 @@ describe("workflow tracking headers in auth middleware", () => {
   });
 });
 
+describe("buildTrackingHeaders allowlist helper", () => {
+  // The full set of tracking headers chat-service may forward to INTERNAL
+  // services. The egress guardrail asserts the helper can never emit anything
+  // outside this set (so a vendor secret / arbitrary header cannot leak).
+  const INTERNAL_ALLOWLIST = [
+    "x-campaign-id",
+    "x-brand-id",
+    "x-workflow-slug",
+    "x-feature-slug",
+    "x-audience-id",
+  ];
+
+  it("maps the full tracking block to downstream headers incl. x-audience-id", () => {
+    expect(
+      buildTrackingHeaders({
+        campaignId: "camp-1",
+        brandId: "brand-1",
+        workflowSlug: "flow-1",
+        featureSlug: "feat-1",
+        audienceId: "aud-1",
+      }),
+    ).toEqual({
+      "x-campaign-id": "camp-1",
+      "x-brand-id": "brand-1",
+      "x-workflow-slug": "flow-1",
+      "x-feature-slug": "feat-1",
+      "x-audience-id": "aud-1",
+    });
+  });
+
+  it("forwards x-audience-id when it is the only field set", () => {
+    expect(buildTrackingHeaders({ audienceId: "aud-only" })).toEqual({
+      "x-audience-id": "aud-only",
+    });
+  });
+
+  it("omits absent fields (empty tracking -> empty map)", () => {
+    expect(buildTrackingHeaders({})).toEqual({});
+  });
+
+  it("egress guardrail: output keys are a strict subset of the internal allowlist", () => {
+    const headers = buildTrackingHeaders({
+      campaignId: "c",
+      brandId: "b",
+      workflowSlug: "w",
+      featureSlug: "f",
+      audienceId: "a",
+    });
+    for (const key of Object.keys(headers)) {
+      expect(INTERNAL_ALLOWLIST).toContain(key);
+    }
+  });
+});
+
 describe("runs-client forwards tracking headers", () => {
   const originalEnv = { ...process.env };
 
@@ -130,7 +205,7 @@ describe("runs-client forwards tracking headers", () => {
     await createRun(
       { serviceName: "chat-service", taskName: "chat" },
       identity,
-      { "x-campaign-id": "camp-1", "x-brand-id": "brand-1", "x-workflow-slug": "flow-1", "x-feature-slug": "feat-1" },
+      { "x-campaign-id": "camp-1", "x-brand-id": "brand-1", "x-workflow-slug": "flow-1", "x-feature-slug": "feat-1", "x-audience-id": "aud-1" },
     );
 
     expect(fetch).toHaveBeenCalledWith(
@@ -144,6 +219,7 @@ describe("runs-client forwards tracking headers", () => {
           "x-brand-id": "brand-1",
           "x-workflow-slug": "flow-1",
           "x-feature-slug": "feat-1",
+          "x-audience-id": "aud-1",
         }),
       }),
     );
@@ -195,7 +271,7 @@ describe("runs-client forwards tracking headers", () => {
       "run-1",
       [{ costName: "claude-sonnet-4-6-tokens-input", quantity: 100, costSource: "platform" as const }],
       identity,
-      { "x-brand-id": "brand-3" },
+      { "x-brand-id": "brand-3", "x-audience-id": "aud-cost" },
     );
 
     expect(fetch).toHaveBeenCalledWith(
@@ -203,6 +279,7 @@ describe("runs-client forwards tracking headers", () => {
       expect.objectContaining({
         headers: expect.objectContaining({
           "x-brand-id": "brand-3",
+          "x-audience-id": "aud-cost",
         }),
       }),
     );


### PR DESCRIPTION
## What

chat-service drops the inbound `x-audience-id` header → its LLM cost rows (the biggest campaign spend, via content-generation-service → `/complete`) land in the runs-service **unattributed** bucket. runs-service attributes per audience via a flat `SUM(cost) GROUP BY COALESCE(runs_costs.audience_id, runs.audience_id)` (no hierarchy rollup), so every run + cost row must carry `audience_id` itself. Result today: ~97% of a campaign's spend unattributed → per-audience CPC 20-30× too low.

This makes chat-service read, forward, and stamp `x-audience-id` — the same treatment as `x-feature-slug`. Mirrors the instantly-service pattern.

## Changes
- **`auth.ts`** — extract `x-audience-id` into `workflowTracking`; add shared **allowlist helper `buildTrackingHeaders()`** replacing 5 drift-prone per-field blocks across `/complete`, `/orgs/images/generate`, `/orgs/rag/score`, `/orgs/rag/embed`, `/chat`.
- **`runs-client.ts` / `trace-event.ts`** — forward `x-audience-id`. The runs-client/key-client map loop is generic, so the key flows to runs-service (run create + cost) + key-service automatically.
- **`sessions` table** — new `audience_id` column. Hand-authored idempotent migration `0015` (this repo's `db:generate` is corrupted — snapshots stop at 0009; documented in CLAUDE.md).
- **`schemas.ts` / `openapi.json`** — document `x-audience-id` on the tracking-header set.
- **Egress guardrail (security)** — Gemini/Anthropic provider clients never receive tracking headers; `buildTrackingHeaders` output asserted to be a strict subset of the internal allowlist.

## Tests
- inbound extraction (full + audience-only + absent)
- `buildTrackingHeaders` allowlist mapping incl. `x-audience-id`
- egress-subset guardrail
- runs-client `createRun` + `addRunCosts` forward `x-audience-id`
- trace-event forwards `x-audience-id`

707 logic tests pass (`graceful-shutdown` socket test is a pre-existing parallel-load flake — passes isolated). Build + openapi regen green. No new env vars.

## Verify (post-deploy, runs-service)
```sql
SELECT service_name, task_name,
       count(*) FILTER (WHERE audience_id IS NOT NULL) AS tagged, count(*) AS total
FROM runs
WHERE feature_slug='sales-cold-email-outreach' AND started_at > '<DEPLOY_TIME>'
GROUP BY 1,2;
```
chat-service rows go 0% → ~100% tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)