### PR TITLE
docs: update image generation response example

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Response:
 
 ```json
 {
-  "imageBase64": "iVBORw0KGgoAAAANSUhEUgAA...",
+  "url": "https://cdn.distribute.you/images/audience-avatar.png",
   "mimeType": "image/png",
   "model": "gemini-3.1-flash-image",
   "tokensInput": 120,


### PR DESCRIPTION
## Summary
- updates README image-generation response example to use hosted `url` instead of legacy `imageBase64`

## Verification
- `rg -n "imageBase64" README.md src/schemas.ts openapi.json` returns no matches
- `git diff --check`