### PR TITLE
fix(chat): surface workflow tool validation errors to the model + guard DAG config

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,7 +582,7 @@ data: {"type":"tool_result","id":"tc_550e8400-e29b-41d4-a716-446655440000","name
 - `id` — unique identifier matching a `tool_call` to its `tool_result`
 - `name` — the tool name
 - `args` — input arguments as an object
-- `result` — the tool output (string or object)
+- `result` — the tool output (string or object). On a tool **failure**, both the Anthropic and Gemini agentic loops emit a structured `result` of shape `{ error, tool, suggestion }` (parsed from the downstream error via `formatToolError`) rather than a raw error blob — this is also what is fed back to the model so it can self-correct. Field-level validation errors (Zod `issues[].path` or workflow-service DAG `details[].field`) are extracted even when api-service double-encodes a downstream 400 as a 500.
 
 After a tool result, more `token` events follow with the AI's continuation.
 

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -308,7 +308,7 @@ export const UPGRADE_WORKFLOW_TOOL: Anthropic.Tool = {
       dag: {
         type: "object",
         description:
-          "Full corrected DAG (nodes + edges). When supplied, workflow-service skips LLM regeneration and applies this DAG verbatim — REQUIRED for surgical fixes (broken $ref paths, miswired edges, wrong field on one node, template-version bump). Must be the COMPLETE DAG (call get_workflow_details first, modify, pass the full result). Partial DAGs are not supported.",
+          "Full corrected DAG (nodes + edges). When supplied, workflow-service skips LLM regeneration and applies this DAG verbatim — REQUIRED for surgical fixes (broken $ref paths, miswired edges, wrong field on one node, template-version bump). Must be the COMPLETE DAG (call get_workflow_details first, modify, pass the full result). Partial DAGs are not supported. Every node must carry its FULL `config` for its type — e.g. a `script` node requires a non-empty `config.code` (inline JS string). Omitting a required config field fails validation (e.g. `nodes[<id>].config.code missing required config field \"code\"`); never emit a node with an empty or partial config.",
       },
     },
     required: ["workflowDynastySlug"],
@@ -333,7 +333,7 @@ export const FORK_WORKFLOW_TOOL: Anthropic.Tool = {
       dag: {
         type: "object",
         description:
-          "Full DAG definition with nodes and edges. Must include the complete DAG — partial updates are not supported. Use get_workflow_details first to read the current DAG, then modify and pass the full result.",
+          "Full DAG definition with nodes and edges. Must include the complete DAG — partial updates are not supported. Use get_workflow_details first to read the current DAG, then modify and pass the full result. Every node must carry its FULL `config` for its type — e.g. a `script` node requires a non-empty `config.code` (inline JS string); omitting a required config field fails validation.",
       },
     },
     required: ["workflowId", "dag"],

--- a/src/lib/gemini-chat.ts
+++ b/src/lib/gemini-chat.ts
@@ -8,6 +8,7 @@ import type { ToolCallRecord } from "../db/schema.js";
 import { trimGeminiHistoryToBudget } from "./gemini-trim.js";
 import { sanitizeGeminiSchema, buildThinkingConfig, type GeminiThinkingLevel } from "./gemini.js";
 import { buildToolResultFallback } from "./tool-fallback.js";
+import { formatToolError } from "./tool-errors.js";
 
 const GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta";
 
@@ -613,7 +614,11 @@ export async function streamGeminiChat(
       } catch (toolErr: unknown) {
         const rawMsg = toolErr instanceof Error ? toolErr.message : String(toolErr);
         console.error(`[gemini-chat] Tool call ${fc.name} failed:`, rawMsg);
-        const errorResult = { error: rawMsg };
+        // Parse the raw client error into a structured {error, tool, suggestion}
+        // so the model can self-correct — parity with the Anthropic path
+        // (src/index.ts). Raw double-encoded blobs (api-service wrapping a
+        // workflow-service 400 as a 500) are hard for the model to act on.
+        const errorResult = formatToolError(fc.name, rawMsg);
         sse(res, { type: "tool_result", id: toolCallId, name: fc.name, result: errorResult });
         responseParts.push({
           functionResponse: {

--- a/src/lib/tool-errors.ts
+++ b/src/lib/tool-errors.ts
@@ -9,23 +9,85 @@ interface ToolErrorResult {
   suggestion: string;
 }
 
-/**
- * Parse a Zod validation error from a downstream service response.
- * Returns a list of human-readable field errors.
- */
-function parseZodErrors(raw: string): string[] | null {
+function tryParse(s: string): unknown {
   try {
-    const match = raw.match(/\{.*"issues":\[.*\].*\}/s);
-    if (!match) return null;
-    const parsed = JSON.parse(match[0]);
-    const issues = parsed.details?.issues ?? parsed.issues;
-    if (!Array.isArray(issues)) return null;
-    return issues.map((i: { path?: string[]; message?: string }) =>
-      `${(i.path ?? []).join(".")}: ${i.message ?? "invalid"}`,
-    );
+    return JSON.parse(s);
   } catch {
     return null;
   }
+}
+
+/**
+ * Extract field-level validation errors from a single parsed error node, in
+ * either dialect we receive:
+ *   - Zod:              { issues: [{ path: string[], message }] }
+ *                       (also nested as { details: { issues: [...] } })
+ *   - workflow-service: { details: [{ field: string, message }] }  (DAG validation)
+ */
+function extractFieldErrors(node: unknown): string[] | null {
+  if (!node || typeof node !== "object") return null;
+  const obj = node as { issues?: unknown; details?: unknown };
+
+  // Zod: top-level `issues`, or `details.issues`.
+  const detailsIssues =
+    obj.details && typeof obj.details === "object" && !Array.isArray(obj.details)
+      ? (obj.details as { issues?: unknown }).issues
+      : undefined;
+  const issues = Array.isArray(obj.issues)
+    ? obj.issues
+    : Array.isArray(detailsIssues)
+      ? detailsIssues
+      : null;
+  if (Array.isArray(issues)) {
+    return (issues as Array<{ path?: string[]; message?: string }>).map(
+      (i) => `${(i.path ?? []).join(".")}: ${i.message ?? "invalid"}`,
+    );
+  }
+
+  // workflow-service DAG validation: `details` is an array of {field, message}.
+  if (Array.isArray(obj.details)) {
+    return (obj.details as Array<{ field?: string; message?: string }>).map((d) =>
+      d.field ? `${d.field}: ${d.message ?? "invalid"}` : d.message ?? "invalid",
+    );
+  }
+  return null;
+}
+
+/**
+ * Parse field-level validation errors from a downstream service response.
+ *
+ * Handles two complications beyond a plain Zod parse:
+ *   1. The message is prefixed by the client wrapper
+ *      (`[workflow-client] POST /... returned NNN: <body>`) — we strip to the body.
+ *   2. api-service wraps a downstream service's error as
+ *      `{ "error": "<stringified downstream JSON>" }`, sometimes turning a
+ *      workflow-service 400 into a 500 in the process. We peel nested `.error`
+ *      string wrappers until we find the `issues`/`details` payload.
+ */
+function parseValidationErrors(raw: string): string[] | null {
+  const bodyMatch = raw.match(/returned \d{3}: ?([\s\S]*)$/);
+  const candidate = bodyMatch ? bodyMatch[1] : raw;
+
+  let node = tryParse(candidate);
+  if (node == null) return null;
+
+  for (let depth = 0; depth < 5; depth++) {
+    const found = extractFieldErrors(node);
+    if (found) return found;
+    // Unwrap `{ error: "<json string>" }` (api-service double-encode).
+    if (
+      node &&
+      typeof node === "object" &&
+      typeof (node as { error?: unknown }).error === "string"
+    ) {
+      const inner = tryParse((node as { error: string }).error);
+      if (inner == null) return null;
+      node = inner;
+      continue;
+    }
+    return null;
+  }
+  return null;
 }
 
 /**
@@ -69,14 +131,17 @@ const TOOL_HINTS: Record<string, string> = {
 
 export function formatToolError(toolName: string, rawError: string): ToolErrorResult {
   const status = parseStatusCode(rawError);
-  const zodErrors = parseZodErrors(rawError);
+  const fieldErrors = parseValidationErrors(rawError);
 
   let error: string;
   let suggestion: string;
 
-  if (zodErrors && zodErrors.length > 0) {
-    const fieldList = zodErrors.slice(0, 5).join("; ");
-    error = `Validation failed: ${fieldList}${zodErrors.length > 5 ? ` (and ${zodErrors.length - 5} more)` : ""}`;
+  // Field-level validation errors are checked BEFORE status, because
+  // api-service can surface a downstream 400 wrapped in a 500 — the actionable
+  // detail is in the body regardless of the outer status code.
+  if (fieldErrors && fieldErrors.length > 0) {
+    const fieldList = fieldErrors.slice(0, 5).join("; ");
+    error = `Validation failed: ${fieldList}${fieldErrors.length > 5 ? ` (and ${fieldErrors.length - 5} more)` : ""}`;
     suggestion = `Fix the invalid fields listed above. ${TOOL_HINTS[toolName] ?? ""}`;
   } else if (status === 404) {
     error = "Resource not found. Check that the ID exists and is correct.";

--- a/tests/unit/anthropic.test.ts
+++ b/tests/unit/anthropic.test.ts
@@ -556,6 +556,14 @@ describe("UPGRADE_WORKFLOW_TOOL", () => {
     expect(UPGRADE_WORKFLOW_TOOL.description).toMatch(/at least one of/i);
   });
 
+  it("dag param warns that every node needs its full config (script → config.code)", () => {
+    const schema = UPGRADE_WORKFLOW_TOOL.input_schema as {
+      properties: { dag: { description: string } };
+    };
+    expect(schema.properties.dag.description).toMatch(/config\.code/);
+    expect(schema.properties.dag.description).toMatch(/script/i);
+  });
+
   it("description steers the LLM to `dag` for surgical $ref / wiring / template-version fixes (no regen drift)", () => {
     const desc = UPGRADE_WORKFLOW_TOOL.description ?? "";
     expect(desc).toMatch(/\$ref/i);
@@ -607,6 +615,14 @@ describe("FORK_WORKFLOW_TOOL", () => {
     expect(schema.required).toEqual(
       expect.arrayContaining(["workflowId", "dag"]),
     );
+  });
+
+  it("dag param warns that every node needs its full config (script → config.code)", () => {
+    const schema = FORK_WORKFLOW_TOOL.input_schema as {
+      properties: { dag: { description: string } };
+    };
+    expect(schema.properties.dag.description).toMatch(/config\.code/);
+    expect(schema.properties.dag.description).toMatch(/script/i);
   });
 
   it("description scopes fork to NEW behavior/scope/intent/audience, not topology changes", () => {

--- a/tests/unit/gemini-chat.test.ts
+++ b/tests/unit/gemini-chat.test.ts
@@ -349,4 +349,76 @@ describe("streamGeminiChat tool-then-empty guard", () => {
     const { opts } = baseOptions({ tools: [] });
     await expect(streamGeminiChat(opts)).rejects.toThrow(/empty response/);
   });
+
+  // A failing tool call must reach the model as a STRUCTURED, parsed error
+  // (parity with the Anthropic path) — not a raw double-encoded blob — so it
+  // can self-correct. Regression for the upgrade_workflow config.code incident.
+  it("surfaces a tool failure through formatToolError (structured, not raw)", async () => {
+    const rawErr =
+      "[workflow-client] POST /v1/workflows/upgrade returned 500: " +
+      JSON.stringify({
+        error: JSON.stringify({
+          error: "Invalid DAG",
+          details: [
+            {
+              field: "nodes[ensure-brand-name].config.code",
+              message:
+                'script node "ensure-brand-name" is missing required config field "code" (non-empty string of inline JS).',
+            },
+          ],
+        }),
+      });
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        sseResponse({
+          candidates: [
+            {
+              content: {
+                parts: [
+                  { functionCall: { name: "upgrade_workflow", args: {} }, thoughtSignature: "sig-1" },
+                ],
+              },
+            },
+          ],
+          usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5 },
+        }),
+      )
+      .mockResolvedValueOnce(
+        sseResponse({
+          candidates: [
+            { content: { parts: [{ text: "Let me fix that." }] }, finishReason: "STOP" },
+          ],
+          usageMetadata: { promptTokenCount: 20, candidatesTokenCount: 4 },
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { opts, events } = baseOptions({
+      tools: [
+        {
+          name: "upgrade_workflow",
+          description: "Upgrade a workflow",
+          input_schema: { type: "object" as const, properties: {} },
+        },
+      ] as ToolDefinition[],
+      executeTool: async () => {
+        throw new Error(rawErr);
+      },
+    });
+    await streamGeminiChat(opts);
+
+    const toolResult = events.find(
+      (e): e is { type: string; name: string; result: { error: string; tool: string; suggestion: string } } =>
+        typeof e === "object" &&
+        e !== null &&
+        (e as { type?: string }).type === "tool_result",
+    );
+    expect(toolResult).toBeDefined();
+    expect(toolResult!.result.tool).toBe("upgrade_workflow");
+    expect(toolResult!.result.error).toContain("nodes[ensure-brand-name].config.code");
+    expect(toolResult!.result.error).toContain("missing required config field");
+    expect(toolResult!.result.suggestion).toBeTruthy();
+  });
 });

--- a/tests/unit/tool-errors.test.ts
+++ b/tests/unit/tool-errors.test.ts
@@ -110,4 +110,43 @@ describe("formatToolError", () => {
     expect(result).toHaveProperty("tool", "get_prompt_template");
     expect(result).toHaveProperty("suggestion");
   });
+
+  // Regression: workflow-service DAG validation surfaces as a double-encoded
+  // body — api-service wraps the workflow-service 400 as { error: "<json>" } and
+  // returns it as a 500. The actionable field detail must still be extracted.
+  it("parses a double-encoded workflow-service DAG error wrapped in a 500", () => {
+    const raw =
+      "[workflow-client] POST /v1/workflows/upgrade returned 500: " +
+      JSON.stringify({
+        error: JSON.stringify({
+          error: "Invalid DAG",
+          details: [
+            {
+              field: "nodes[ensure-brand-name].config.code",
+              message:
+                'script node "ensure-brand-name" is missing required config field "code" (non-empty string of inline JS).',
+            },
+          ],
+        }),
+      });
+
+    const result = formatToolError("upgrade_workflow", raw);
+
+    expect(result.error).toContain("Validation failed");
+    expect(result.error).toContain("nodes[ensure-brand-name].config.code");
+    expect(result.error).toContain("missing required config field");
+    expect(result.suggestion).toMatch(/workflowDynastySlug/);
+    expect(result.tool).toBe("upgrade_workflow");
+  });
+
+  // Same shape but NOT double-wrapped and returned as a plain 400 (direct
+  // workflow-service surface). Field/message array must still parse.
+  it("parses a single-level workflow-service details array (400)", () => {
+    const raw =
+      '[workflow-client] POST /v1/workflows/create returned 400: {"error":"Invalid DAG","details":[{"field":"nodes[x].config.url","message":"http node missing url"}]}';
+
+    const result = formatToolError("create_workflow", raw);
+
+    expect(result.error).toContain("nodes[x].config.url: http node missing url");
+  });
 });


### PR DESCRIPTION
## What

The Gemini agentic `/chat` loop handed **raw** client error strings back to the model on a tool failure, while the Anthropic loop ran them through `formatToolError`. When the model hand-authored an invalid DAG for `upgrade_workflow` (a `script` node missing `config.code`), workflow-service rejected it and api-service double-encoded that 400 as a 500:

```
[workflow-client] POST /v1/workflows/upgrade returned 500: {"error":"{\"error\":\"Invalid DAG\",\"details\":[{\"field\":\"nodes[ensure-brand-name].config.code\",\"message\":\"script node ... missing required config field \\\"code\\\"\"}]}"}
```

Two problems: the model on the Gemini path got that ugly blob verbatim (harder to self-correct), and even `formatToolError` couldn't parse it — the status is 500 (not 400) and the shape is `details[].field/message` (not Zod `issues[].path/message`), nested inside a stringified `error`.

## Changes

- **`tool-errors.ts`** — `parseValidationErrors` peels api-service's nested `{error:"<json>"}` wrapping and extracts **both** Zod `issues[].path` and workflow-service `details[].field` field errors, checked before the status branch so a downstream 400-wrapped-as-500 still yields the actionable detail.
- **`gemini-chat.ts`** — tool failures now flow through `formatToolError` (parity with the Anthropic path); the model receives `{error, tool, suggestion}` and can self-correct.
- **`anthropic.ts`** — `upgrade_workflow` + `fork_workflow` `dag` param descriptions warn that every node must carry its full `config` (script → non-empty `config.code`), preventing the empty-node authoring mistake up front (reaches Gemini declarations too, via `toGeminiFunctionDeclarations`).

## Tests

- `tool-errors.test.ts`: double-encoded 500 + single-level 400 field parsing (existing Zod cases unchanged).
- `gemini-chat.test.ts`: a failing tool call surfaces a structured `{error, tool, suggestion}` on the SSE `tool_result`, not a raw blob.
- `anthropic.test.ts`: `dag` description guards for both tools.
- Full unit suite: **753 green**. Build clean.

## Docs

README SSE `tool_result` section documents the structured error-result shape on tool failure.

## Triage

Bugfix → staging. The model already gets the error back and can retry (masked, not prod-down), but touches existing handlers → staging is the safer gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
