### PR TITLE
feat(whatsapp): full-funnel tools + Distribute.you WhatsApp chat config

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,17 +133,18 @@ Fields: same as `PUT /config` — `key`, `systemPrompt`, `allowedTools` (all req
 
 This endpoint is **idempotent** (upsert on `key`). Called on every cold start by api-service.
 
-**Self-seeded configs.** Three platform configs are owned by chat-service itself and seeded at boot (in `src/lib/seed-platform-configs.ts`, run from the migrate→listen path) — they do not need any external registrar:
+**Self-seeded configs.** Four platform configs are owned by chat-service itself and seeded at boot (in `src/lib/seed-platform-configs.ts`, run from the migrate→listen path) — they do not need any external registrar:
 
 | configKey | Tools | Purpose |
 |---|---|---|
 | `persona-editor` | `list_personas`, `create_persona`, `duplicate_persona`, `set_persona_status`, `request_user_input` | Read + curate a brand's customer personas via NL (brand-service). |
 | `brand-profile-editor` | `get_brand_profile`, `save_brand_profile_version`, `refresh_brand_profile_from_website`, `request_user_input` | Read, refresh from website, and version a brand's brand profile via NL. |
 | `audience-editor` | `list_audiences`, `suggest_audiences`, `set_audience_status`, `rename_audience`, `refresh_audience_count`, `request_user_input` | Create + curate a brand's customer audiences via NL (human-service, via the api-service gateway `/v1/orgs/audiences/*`). Creation is suggest→activate: `suggest_audiences` persists candidates at status `suggested`; `set_audience_status … active` makes one live. Filters are immutable; archive (never delete) and rename only. |
+| `whatsapp` | Full funnel (`create_brand_from_url`, `list_brands`, `launch_campaign`, `list_campaigns`, `stop_campaign`, `get_daily_budget`, `set_daily_budget`, `get_brand_pause`, `set_brand_pause`) + `browse_url` + feature/workflow reads + the brand-profile / audience / persona curation tools. | The public "Distribute.you" WhatsApp assistant — lets a user operate the WHOLE platform by chat, exactly like the dashboard: from a bare URL through brand setup, campaign launch, budget, and pause/resume, on top of the curation tools. A Twilio-based channel service (not chat-service) forwards each inbound WhatsApp message here, scoped to the sender's org/user (the account is provisioned by client-service before the message lands). The funnel tools take the brand/campaign id explicitly, so the assistant can go from nothing to a running campaign purely by chat. LLM cost stays in chat-service exactly as for dashboard chat (the WhatsApp org is billed for its own usage). |
 
-All default to `google`/`flash-pro` and boot at `thinkingLevel: "medium"` (raised above the global `/chat` default of `"low"` for richer tool-calling reasoning on the curation flows). The dashboard selects them by `configKey` and passes `context: { brandId }`; the tools act on that brand under the caller's org. The boot seed only upserts these keys, so it never clobbers a dashboard-registered config.
+All default to `google`/`flash-pro` and boot at `thinkingLevel: "medium"` (raised above the global `/chat` default of `"low"` for richer tool-calling reasoning). The dashboard selects the editor configs by `configKey` and passes `context: { brandId }`; the channel service selects `whatsapp` and forwards the sender's identity. The boot seed only upserts these keys, so it never clobbers a dashboard-registered config.
 
-All three prompts share a **voice + ground-truth guardrail block** (`VOICE_AND_GROUND_TRUTH_RULES`, appended to each prompt in `seed-platform-configs.ts`): the assistant must never surface internal plumbing in user-facing prose (entity/provider ids, raw filter JSON or field names, tool names, tool errors / HTTP status / 404s, raw count fields — filters become plain language, counts a single rounded number); it may only state an action as done **after** the corresponding tool call returns success (no pre-announcing avatars/creation/activation); and it must reuse only ids returned verbatim by a prior tool result (never construct or guess one — re-list on a not-found). This exists because real sessions leaked UUIDs/`apolloAudienceId`/filter JSON into the prose and fabricated completion before the tools ran.
+All four prompts share a **voice + ground-truth guardrail block** (`VOICE_AND_GROUND_TRUTH_RULES`, appended to each prompt in `seed-platform-configs.ts`): the assistant must never surface internal plumbing in user-facing prose (entity/provider ids, raw filter JSON or field names, tool names, tool errors / HTTP status / 404s, raw count fields — filters become plain language, counts a single rounded number); it may only state an action as done **after** the corresponding tool call returns success (no pre-announcing avatars/creation/activation); and it must reuse only ids returned verbatim by a prior tool result (never construct or guess one — re-list on a not-found). This exists because real sessions leaked UUIDs/`apolloAudienceId`/filter JSON into the prose and fabricated completion before the tools ran.
 
 **Config resolution in POST /chat:**
 1. Per-org config `(orgId, configKey)` → if found, use it
@@ -690,6 +691,20 @@ Read-only and supporting workflow tools:
 | `rename_audience` | Renames an audience (the only editable metadata; filters are immutable). `PATCH /v1/orgs/audiences/:id` |
 | `refresh_audience_count` | Re-snapshots apollo + apify match counts via the free live dry-run. `POST /v1/orgs/audiences/:id/refresh-count` |
 | `generate_audience_avatar` | (Re)generates the audience's avatar image. Optional `prompt` steers the image; omit to derive it from the audience's descriptors. ORG-BILLED (forwards `x-user-id` like `refresh_audience_count`). Returns the updated audience with its new `avatarUrl`. `POST /v1/orgs/audiences/:id/avatar` |
+
+**Funnel tools** (full end-to-end platform operation — take the brand/campaign id explicitly, so they work in a brand-less onboarding session; all route through api-service with the forwarded identity, so the underlying op is org-billed by the owning service — chat-service adds no cost of its own):
+
+| Tool | Description |
+|---|---|
+| `create_brand_from_url` | Creates/upserts a brand from its website `url` (onboarding-equivalent) and returns the brandId. `POST /v1/brands` |
+| `list_brands` | Lists the org's brands (id, name, URL). Read-only. `GET /v1/brands` |
+| `launch_campaign` | Launches a campaign: `name` + `brandUrls` + `featureInputs` + a feature (`featureDynastySlug` preferred) + a workflow (`workflowDynastySlug` preferred); optional budget caps / `maxLeads` / `endDate`. `POST /v1/campaigns` |
+| `list_campaigns` | Lists the org's campaigns (id, name, status, brands, budgets); optional `brandId` / `status` filter. Read-only. `GET /v1/campaigns` |
+| `stop_campaign` | Stops a running campaign by `campaignId`. `POST /v1/campaigns/:id/stop` |
+| `get_daily_budget` | Reads a brand's current daily budget (`dailyBudgetCents`, null = unset). Read-only. `GET /v1/brands/:brandId/daily-budget` |
+| `set_daily_budget` | Sets a brand's daily spend ceiling — `dailyBudgetCents` (IN CENTS; 0 = pause spend). `PATCH /v1/brands/:brandId/daily-budget` |
+| `get_brand_pause` | Reads whether a brand is paused. Read-only. `GET /v1/brands/:brandId/pause` |
+| `set_brand_pause` | Pauses (`paused: true`) or resumes (`paused: false`) a brand's activity. `PATCH /v1/brands/:brandId/pause` |
 
 **UI tools:**
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,6 +101,18 @@ import {
 } from "./lib/key-client.js";
 import { authorizeCredits, BillingError } from "./lib/billing-client.js";
 import { getCampaignFeatureInputs } from "./lib/campaign-client.js";
+import {
+  createBrandFromUrl,
+  listBrands,
+  launchCampaign,
+  listCampaigns,
+  stopCampaign,
+  getBrandDailyBudget,
+  setBrandDailyBudget,
+  getBrandPauseState,
+  setBrandPauseState,
+  type LaunchCampaignBody,
+} from "./lib/funnel-client.js";
 import { ChatRequestSchema, CompleteRequestSchema, GenerateImageRequestSchema, InternalPlatformCompleteRequestSchema, AppConfigRequestSchema, PlatformConfigRequestSchema, TransferBrandRequestSchema, RagScoreRequestSchema, RagEmbedRequestSchema, GetSessionParamsSchema } from "./schemas.js";
 import { requireAuth, requireInternalAuth, buildTrackingHeaders, type AuthLocals } from "./middleware/auth.js";
 import { resolveOutputBudget, estimateInputTokens, estimateOutputTokens } from "./lib/provision-estimate.js";
@@ -2603,6 +2615,93 @@ app.post("/chat", requireAuth, async (req, res) => {
         const result = await generateAudienceAvatar(
           String(args.audienceId ?? ""),
           prompt,
+          featureCallParams,
+        );
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
+      // ---------------------------------------------------------------------
+      // Funnel tools — full end-to-end platform operation (create brand from a
+      // URL, launch, set daily budget, pause/resume). These take the brand /
+      // campaign identifier explicitly (agent-resolved via list_brands /
+      // create_brand_from_url / list_campaigns), so they work in a brand-less
+      // onboarding session. All route through api-service with forwarded
+      // identity — org-billed by the downstream service, no chat-service cost.
+      // ---------------------------------------------------------------------
+      if (call.name === "create_brand_from_url") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const result = await createBrandFromUrl(String(args.url ?? ""), featureCallParams);
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
+      if (call.name === "list_brands") {
+        const result = await listBrands(featureCallParams);
+        toolCalls.push({ name: call.name, args: {}, result });
+        return { name: call.name, result };
+      }
+
+      if (call.name === "launch_campaign") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const result = await launchCampaign(
+          args as unknown as LaunchCampaignBody,
+          featureCallParams,
+        );
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
+      if (call.name === "list_campaigns") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const result = await listCampaigns(
+          {
+            brandId: args.brandId as string | undefined,
+            status: args.status as string | undefined,
+          },
+          featureCallParams,
+        );
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
+      if (call.name === "stop_campaign") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const result = await stopCampaign(String(args.campaignId ?? ""), featureCallParams);
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
+      if (call.name === "get_daily_budget") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const result = await getBrandDailyBudget(String(args.brandId ?? ""), featureCallParams);
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
+      if (call.name === "set_daily_budget") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const result = await setBrandDailyBudget(
+          String(args.brandId ?? ""),
+          args.dailyBudgetCents as number | string,
+          featureCallParams,
+        );
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
+      if (call.name === "get_brand_pause") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const result = await getBrandPauseState(String(args.brandId ?? ""), featureCallParams);
+        toolCalls.push({ name: call.name, args, result });
+        return { name: call.name, result };
+      }
+
+      if (call.name === "set_brand_pause") {
+        const args = (call.args as Record<string, unknown>) || {};
+        const result = await setBrandPauseState(
+          String(args.brandId ?? ""),
+          Boolean(args.paused),
           featureCallParams,
         );
         toolCalls.push({ name: call.name, args, result });

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -1318,6 +1318,215 @@ export const GENERATE_AUDIENCE_AVATAR_TOOL: Anthropic.Tool = {
 };
 
 // ---------------------------------------------------------------------------
+// Funnel tools — the end-to-end "operate the platform" surface a dashboard user
+// drives: create a brand from a URL (onboarding-equivalent), launch a campaign,
+// set the daily budget, and pause/resume a brand. These let a chat agent (e.g.
+// the WhatsApp "Distribute.you" assistant) take an org from nothing to a running,
+// managed campaign. Every call routes through api-service with the caller's
+// forwarded identity, so the underlying operation is metered against the caller's
+// org by the downstream service (chat-service adds no cost of its own here).
+//
+// Unlike the brand-scoped editor tools (which act on a single context.brandId),
+// these take the brandId / brandUrl explicitly, so they work in a brand-less
+// onboarding session where the agent creates or selects the brand mid-conversation.
+// ---------------------------------------------------------------------------
+
+export const CREATE_BRAND_FROM_URL_TOOL: Anthropic.Tool = {
+  name: "create_brand_from_url",
+  description:
+    "Create (or upsert) a brand from its website URL — the onboarding step. Give the brand's homepage URL; the platform scrapes it and provisions the brand, returning its brandId. This is the first step to set up a new brand from scratch. If the org already has this brand, it is upserted (not duplicated). Use list_brands first if you are unsure whether the brand already exists. Save the returned brandId to set its daily budget, pause/resume it, or reference it later.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      url: {
+        type: "string",
+        description: "The brand's website URL (e.g. 'https://acme.com').",
+      },
+    },
+    required: ["url"],
+  },
+};
+
+export const LIST_BRANDS_TOOL: Anthropic.Tool = {
+  name: "list_brands",
+  description:
+    "List every brand in the caller's org, with each brand's id, name, and URL. Read-only. Use it to find an existing brand's id/URL before launching a campaign, setting a budget, or pausing/resuming it — and to check whether a brand already exists before creating one.",
+  input_schema: {
+    type: "object" as const,
+    properties: {},
+  },
+};
+
+export const LAUNCH_CAMPAIGN_TOOL: Anthropic.Tool = {
+  name: "launch_campaign",
+  description:
+    "Launch a new campaign for a brand — this is how the brand starts running. Requires: a campaign `name`; `brandUrls` (one or more brand website URLs — the first is the primary brand; use the URL from create_brand_from_url or list_brands); `featureInputs` (the free-form inputs the chosen feature needs — discover the required keys with get_feature_inputs); and a feature + a workflow to run. Prefer the stable dynasty slugs: pass `featureDynastySlug` (from list_features) and `workflowDynastySlug` (from list_workflows) so the latest version is used automatically. Optionally cap spend with `maxBudgetDailyUsd` / `maxBudgetTotalUsd`, limit `maxLeads`, or set an `endDate`. On success the campaign is created and starts; report the campaign name and status to the user.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      name: { type: "string", description: "Campaign name." },
+      brandUrls: {
+        type: "array",
+        items: { type: "string" },
+        description:
+          "Brand website URLs. The first URL is the primary brand; additional URLs are secondary brands.",
+      },
+      featureInputs: {
+        type: "object",
+        description:
+          "The feature's free-form inputs (key → value). Discover the expected keys with get_feature_inputs for the chosen feature.",
+      },
+      featureDynastySlug: {
+        type: "string",
+        description:
+          "Stable feature dynasty slug (from list_features), e.g. 'pr-cold-email-outreach'. Resolves to the latest version. Preferred. Provide this OR featureSlug.",
+      },
+      featureSlug: {
+        type: "string",
+        description:
+          "Exact versioned feature slug — use only to pin a specific version. Provide this OR featureDynastySlug.",
+      },
+      workflowDynastySlug: {
+        type: "string",
+        description:
+          "Stable workflow dynasty slug (from list_workflows), e.g. 'sales-email-cold-outreach-sienna'. Resolves to the latest version. Preferred. Provide this OR workflowSlug.",
+      },
+      workflowSlug: {
+        type: "string",
+        description:
+          "Exact versioned workflow slug — use only to pin a specific version. Provide this OR workflowDynastySlug.",
+      },
+      maxBudgetDailyUsd: {
+        type: "string",
+        description: "Optional max daily budget in USD (e.g. '20').",
+      },
+      maxBudgetTotalUsd: {
+        type: "string",
+        description: "Optional max total budget in USD (e.g. '500').",
+      },
+      maxLeads: {
+        type: "integer",
+        description: "Optional cap on the number of leads to contact.",
+      },
+      endDate: {
+        type: "string",
+        description: "Optional campaign end date (ISO date string).",
+      },
+    },
+    required: ["name", "brandUrls", "featureInputs"],
+  },
+};
+
+export const LIST_CAMPAIGNS_TOOL: Anthropic.Tool = {
+  name: "list_campaigns",
+  description:
+    "List the org's campaigns, with each campaign's id, name, status (e.g. 'active', 'stopped'), brand(s), and budgets. Read-only. Optionally filter by `brandId` or `status`. Use it to find a campaign's id before stopping it, or to report what is currently running.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      brandId: {
+        type: "string",
+        description: "Optional. Filter to campaigns for this brand id.",
+      },
+      status: {
+        type: "string",
+        description:
+          "Optional. Filter by status (e.g. 'active', 'stopped', 'all').",
+      },
+    },
+  },
+};
+
+export const STOP_CAMPAIGN_TOOL: Anthropic.Tool = {
+  name: "stop_campaign",
+  description:
+    "Stop a running campaign. Look up the campaign id with list_campaigns first. This halts the campaign's execution. To pause a whole brand's activity instead of a single campaign, use set_brand_pause.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      campaignId: {
+        type: "string",
+        description: "The id of the campaign to stop (from list_campaigns).",
+      },
+    },
+    required: ["campaignId"],
+  },
+};
+
+export const GET_DAILY_BUDGET_TOOL: Anthropic.Tool = {
+  name: "get_daily_budget",
+  description:
+    "Read a brand's current daily budget (its per-day spend ceiling, in cents; null means unset). Read-only. Look up the brand id with list_brands (or use the id from create_brand_from_url).",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      brandId: {
+        type: "string",
+        description: "The brand id (from list_brands or create_brand_from_url).",
+      },
+    },
+    required: ["brandId"],
+  },
+};
+
+export const SET_DAILY_BUDGET_TOOL: Anthropic.Tool = {
+  name: "set_daily_budget",
+  description:
+    "Set a brand's daily budget — its per-day spend ceiling. `dailyBudgetCents` is IN CENTS (e.g. $20/day = 2000). Convert the user's dollar amount to cents yourself. Setting 0 pauses spend. Look up the brand id with list_brands (or use the id from create_brand_from_url). Confirm the new budget in dollars to the user after it succeeds.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      brandId: {
+        type: "string",
+        description: "The brand id (from list_brands or create_brand_from_url).",
+      },
+      dailyBudgetCents: {
+        type: "integer",
+        description:
+          "The daily spend ceiling in CENTS (e.g. $25/day = 2500). 0 = pause spend.",
+      },
+    },
+    required: ["brandId", "dailyBudgetCents"],
+  },
+};
+
+export const GET_BRAND_PAUSE_TOOL: Anthropic.Tool = {
+  name: "get_brand_pause",
+  description:
+    "Read whether a brand is currently paused. Read-only. Look up the brand id with list_brands (or use the id from create_brand_from_url).",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      brandId: {
+        type: "string",
+        description: "The brand id (from list_brands or create_brand_from_url).",
+      },
+    },
+    required: ["brandId"],
+  },
+};
+
+export const SET_BRAND_PAUSE_TOOL: Anthropic.Tool = {
+  name: "set_brand_pause",
+  description:
+    "Pause or resume a brand's activity. Pass `paused: true` to PAUSE the brand (halt all its campaigns) or `paused: false` to RESUME it. Map the user's intent: 'pause'/'stop my brand'/'hold' → true; 'resume'/'restart'/'unpause'/'go live again' → false. Look up the brand id with list_brands (or use the id from create_brand_from_url). Confirm the new state to the user after it succeeds.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      brandId: {
+        type: "string",
+        description: "The brand id (from list_brands or create_brand_from_url).",
+      },
+      paused: {
+        type: "boolean",
+        description: "true to pause the brand, false to resume it.",
+      },
+    },
+    required: ["brandId", "paused"],
+  },
+};
+
+// ---------------------------------------------------------------------------
 // Tool registry — every tool the service knows how to execute.
 // Clients choose which subset to enable via allowedTools in their config.
 // ---------------------------------------------------------------------------
@@ -1362,6 +1571,15 @@ export const TOOL_REGISTRY: Record<string, Anthropic.Tool> = {
   rename_audience: RENAME_AUDIENCE_TOOL,
   refresh_audience_count: REFRESH_AUDIENCE_COUNT_TOOL,
   generate_audience_avatar: GENERATE_AUDIENCE_AVATAR_TOOL,
+  create_brand_from_url: CREATE_BRAND_FROM_URL_TOOL,
+  list_brands: LIST_BRANDS_TOOL,
+  launch_campaign: LAUNCH_CAMPAIGN_TOOL,
+  list_campaigns: LIST_CAMPAIGNS_TOOL,
+  stop_campaign: STOP_CAMPAIGN_TOOL,
+  get_daily_budget: GET_DAILY_BUDGET_TOOL,
+  set_daily_budget: SET_DAILY_BUDGET_TOOL,
+  get_brand_pause: GET_BRAND_PAUSE_TOOL,
+  set_brand_pause: SET_BRAND_PAUSE_TOOL,
 };
 
 /** All tool names available for use in allowedTools config. */

--- a/src/lib/funnel-client.ts
+++ b/src/lib/funnel-client.ts
@@ -1,0 +1,181 @@
+import { apiServiceFetch, type ApiCallParams } from "./api-client.js";
+
+// ---------------------------------------------------------------------------
+// Funnel client — the end-to-end "operate the platform" surface a dashboard
+// user drives, exposed to the agentic chat as tools. Every call routes through
+// api-service (the single gateway) with the caller's forwarded identity, so the
+// underlying operation (brand creation, campaign launch, budget, pause) is
+// metered/owned by the downstream service against the caller's org — chat-service
+// declares no cost of its own here (its only spend is the LLM call, unchanged).
+//
+// Fail loud: every non-2xx throws with the upstream status + body so the agentic
+// loop surfaces a structured, self-correctable error via formatToolError. Response
+// shapes are owned downstream (mostly opaque in the registry), so we return the
+// parsed JSON verbatim rather than re-declaring shapes here.
+// ---------------------------------------------------------------------------
+
+export type FunnelCallParams = ApiCallParams;
+
+export class FunnelError extends Error {
+  constructor(
+    public readonly operation: string,
+    public readonly status: number,
+    public readonly upstreamBody: string,
+  ) {
+    super(`[funnel-client] ${operation} failed (${status}): ${upstreamBody}`);
+    this.name = "FunnelError";
+  }
+}
+
+async function requestJson(
+  operation: string,
+  path: string,
+  method: string,
+  params: FunnelCallParams,
+  body?: unknown,
+): Promise<unknown> {
+  const res = await apiServiceFetch(path, method, params, body);
+  if (!res.ok) {
+    const text = await res.text().catch(() => "unknown error");
+    throw new FunnelError(operation, res.status, text);
+  }
+  // Some endpoints (e.g. proxies) may return an empty body on success.
+  const raw = await res.text();
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return { raw };
+  }
+}
+
+// --- Brand creation from a URL (onboarding-equivalent) ---------------------
+
+/** POST /v1/brands { url } — upsert a brand from its website URL. Returns the brandId. */
+export function createBrandFromUrl(
+  url: string,
+  params: FunnelCallParams,
+): Promise<unknown> {
+  return requestJson("create_brand_from_url", `/v1/brands`, "POST", params, { url });
+}
+
+/** GET /v1/brands — list every brand in the caller's org. */
+export function listBrands(params: FunnelCallParams): Promise<unknown> {
+  return requestJson("list_brands", `/v1/brands`, "GET", params);
+}
+
+// --- Campaign launch / stop / list -----------------------------------------
+
+export interface LaunchCampaignBody {
+  name: string;
+  brandUrls: string[];
+  featureInputs: Record<string, unknown>;
+  featureSlug?: string;
+  featureDynastySlug?: string;
+  workflowSlug?: string;
+  workflowDynastySlug?: string;
+  maxBudgetDailyUsd?: string | number;
+  maxBudgetWeeklyUsd?: string | number;
+  maxBudgetMonthlyUsd?: string | number;
+  maxBudgetTotalUsd?: string | number;
+  maxLeads?: number;
+  endDate?: string;
+}
+
+/** POST /v1/campaigns — launch a campaign for one or more brand URLs. */
+export function launchCampaign(
+  body: LaunchCampaignBody,
+  params: FunnelCallParams,
+): Promise<unknown> {
+  return requestJson("launch_campaign", `/v1/campaigns`, "POST", params, body);
+}
+
+export interface ListCampaignsFilters {
+  brandId?: string;
+  status?: string;
+}
+
+/** GET /v1/campaigns — list the org's campaigns, optionally by brand / status. */
+export function listCampaigns(
+  filters: ListCampaignsFilters,
+  params: FunnelCallParams,
+): Promise<unknown> {
+  const qs = new URLSearchParams();
+  if (filters.brandId) qs.set("brandId", filters.brandId);
+  if (filters.status) qs.set("status", filters.status);
+  const suffix = qs.toString() ? `?${qs.toString()}` : "";
+  return requestJson("list_campaigns", `/v1/campaigns${suffix}`, "GET", params);
+}
+
+/** POST /v1/campaigns/{id}/stop — stop a running campaign. */
+export function stopCampaign(
+  campaignId: string,
+  params: FunnelCallParams,
+): Promise<unknown> {
+  return requestJson(
+    "stop_campaign",
+    `/v1/campaigns/${encodeURIComponent(campaignId)}/stop`,
+    "POST",
+    params,
+  );
+}
+
+// --- Brand daily budget -----------------------------------------------------
+
+/** GET /v1/brands/{brandId}/daily-budget — current daily spend ceiling (cents; null = unset). */
+export function getBrandDailyBudget(
+  brandId: string,
+  params: FunnelCallParams,
+): Promise<unknown> {
+  return requestJson(
+    "get_daily_budget",
+    `/v1/brands/${encodeURIComponent(brandId)}/daily-budget`,
+    "GET",
+    params,
+  );
+}
+
+/** PATCH /v1/brands/{brandId}/daily-budget { dailyBudgetCents } — set the daily spend ceiling. */
+export function setBrandDailyBudget(
+  brandId: string,
+  dailyBudgetCents: number | string,
+  params: FunnelCallParams,
+): Promise<unknown> {
+  return requestJson(
+    "set_daily_budget",
+    `/v1/brands/${encodeURIComponent(brandId)}/daily-budget`,
+    "PATCH",
+    params,
+    { dailyBudgetCents },
+  );
+}
+
+// --- Brand pause / resume ---------------------------------------------------
+
+/** GET /v1/brands/{brandId}/pause — current pause state for the brand. */
+export function getBrandPauseState(
+  brandId: string,
+  params: FunnelCallParams,
+): Promise<unknown> {
+  return requestJson(
+    "get_brand_pause",
+    `/v1/brands/${encodeURIComponent(brandId)}/pause`,
+    "GET",
+    params,
+  );
+}
+
+/** PATCH /v1/brands/{brandId}/pause { paused } — pause (true) or resume (false) a brand. */
+export function setBrandPauseState(
+  brandId: string,
+  paused: boolean,
+  params: FunnelCallParams,
+): Promise<unknown> {
+  return requestJson(
+    "set_brand_pause",
+    `/v1/brands/${encodeURIComponent(brandId)}/pause`,
+    "PATCH",
+    params,
+    { paused },
+  );
+}

--- a/src/lib/seed-platform-configs.ts
+++ b/src/lib/seed-platform-configs.ts
@@ -100,6 +100,46 @@ How to "edit" an audience's filters: filters can't be edited in place. When the 
 Be concise. Confirm what you changed after each action. When asked only to read or summarize, never mutate.
 ${VOICE_AND_GROUND_TRUTH_RULES}`;
 
+// ---------------------------------------------------------------------------
+// WhatsApp "Distribute.you" assistant.
+//
+// The public conversational surface: anyone can operate the WHOLE platform by
+// chatting on WhatsApp, exactly like a human on the dashboard — from a bare URL
+// through brand setup, campaign launch, budget, and day-to-day pause/resume, on
+// top of the brand-profile / audience / persona / feature curation the editors
+// expose. A Twilio-based channel service (not chat-service) forwards each inbound
+// WhatsApp message into this agentic chat, scoped to the sender's org/user (the
+// account is already provisioned by client-service before the message lands), so
+// a real org/user always exists here. chat-service owns this config — its prompt,
+// tools, provider/model live here and are self-seeded at boot.
+//
+// The funnel tools (create_brand_from_url, launch_campaign, set_daily_budget,
+// set_brand_pause, …) take the brand/campaign id explicitly, so the assistant can
+// take an org from nothing to a running, managed campaign purely by chat. LLM
+// cost stays in chat-service exactly as for dashboard chat — the WhatsApp org is
+// billed for its own usage; the funnel operations are org-billed by their owning
+// services via the forwarded identity.
+// ---------------------------------------------------------------------------
+const WHATSAPP_SYSTEM_PROMPT = `You are Distribute.you, a friendly WhatsApp assistant that lets the user run the entire distribute platform by chatting — exactly what they would do on the web dashboard, but through this conversation.
+
+This chat is already scoped to the user's account (their org and user identity are set for you). Never ask them to sign in, and never ask for an org id or user id.
+
+You can take a user from nothing to a live, managed campaign, and run day-to-day operations:
+- Set up a brand from its website: ask for the brand's URL, then create the brand from it (create_brand_from_url). Keep the returned brandId to manage the brand later.
+- Launch a campaign (launch_campaign): pick a feature (list_features) and a workflow (list_workflows), discover the feature's required inputs (get_feature_inputs), gather them from the user in plain conversation, then launch for the brand's URL.
+- Manage spend: set or change a brand's daily budget (set_daily_budget — remember the value is in CENTS, so convert the user's dollar amount), and read the current one (get_daily_budget).
+- Pause or resume a brand's activity (set_brand_pause), and stop a specific campaign (stop_campaign).
+- Inspect what's running: list the org's brands (list_brands) and campaigns (list_campaigns), and report status, budgets, and results in plain language.
+- Curate the brand: refine the brand profile, build and activate audiences, and manage personas using the brand-curation tools. These act on the brand currently in context; if the user has several brands, confirm which one before curating.
+
+How to work:
+- Be conversational and concise, like a helpful person texting back. Short messages. Ask one thing at a time. WhatsApp has no buttons or rich UI — guide the user with plain questions.
+- Always resolve real ids from tool results before acting: create or list the brand to get its brandId; list campaigns to get a campaignId. Never guess an id.
+- Before an irreversible or spend-changing action (launching a campaign, changing the budget, pausing/resuming, stopping a campaign), briefly confirm what you're about to do, then do it.
+- When a required input is missing (e.g. a feature input, a URL, a budget amount), ask for it plainly instead of failing.
+- After each action, confirm what happened in human terms (e.g. "Your campaign 'Q2 Outreach' is live" or "Daily budget set to $20"). Money to the user is in dollars, even though the budget tool takes cents.
+${VOICE_AND_GROUND_TRUTH_RULES}`;
+
 // These self-owned editor chats run at `medium` Gemini-3 thinking (the global
 // /chat default is "low") — richer tool-calling reasoning for the curation
 // flows. Only the /chat path reads this; /complete is untouched (stays "low").
@@ -151,10 +191,58 @@ export const BRAND_PROFILE_EDITOR_CONFIG = {
   thinkingLevel: EDITOR_THINKING_LEVEL,
 };
 
+export const WHATSAPP_CONFIG = {
+  key: "whatsapp",
+  systemPrompt: WHATSAPP_SYSTEM_PROMPT,
+  allowedTools: [
+    "request_user_input",
+    // Discovery + web
+    "browse_url",
+    // Full funnel: brand → launch → budget → pause/resume
+    "create_brand_from_url",
+    "list_brands",
+    "launch_campaign",
+    "list_campaigns",
+    "stop_campaign",
+    "get_daily_budget",
+    "set_daily_budget",
+    "get_brand_pause",
+    "set_brand_pause",
+    // Feature + workflow reads (to pick a feature/workflow and its inputs)
+    "list_features",
+    "get_feature",
+    "get_feature_inputs",
+    "prefill_feature",
+    "get_feature_stats",
+    "list_workflows",
+    "get_workflow_details",
+    // Brand-profile curation
+    "get_brand_profile",
+    "save_brand_profile_version",
+    "refresh_brand_profile_from_website",
+    // Audience curation
+    "list_audiences",
+    "suggest_audiences",
+    "set_audience_status",
+    "rename_audience",
+    "refresh_audience_count",
+    "generate_audience_avatar",
+    // Persona curation
+    "list_personas",
+    "create_persona",
+    "duplicate_persona",
+    "set_persona_status",
+  ],
+  provider: "google" as const,
+  model: "flash-pro",
+  thinkingLevel: EDITOR_THINKING_LEVEL,
+};
+
 export const SELF_SEEDED_CONFIGS = [
   PERSONA_EDITOR_CONFIG,
   BRAND_PROFILE_EDITOR_CONFIG,
   AUDIENCE_EDITOR_CONFIG,
+  WHATSAPP_CONFIG,
 ] as const;
 
 /**

--- a/tests/unit/funnel-client.test.ts
+++ b/tests/unit/funnel-client.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  process.env.ADMIN_DISTRIBUTE_API_KEY = "test-api-svc-key";
+  process.env.API_SERVICE_URL = "https://api.test.local";
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.restoreAllMocks();
+});
+
+async function loadModule() {
+  vi.resetModules();
+  return import("../../src/lib/funnel-client.js");
+}
+
+const baseParams = {
+  orgId: "org-1",
+  userId: "user-1",
+  runId: "run-1",
+};
+
+function okJson(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    text: () => Promise.resolve(JSON.stringify(body)),
+  };
+}
+
+describe("funnel-client — end-to-end funnel operations", () => {
+  it("create_brand_from_url POSTs /v1/brands { url } and returns the parsed body", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(okJson({ brandId: "b-9" }));
+
+    const { createBrandFromUrl } = await loadModule();
+    const result = await createBrandFromUrl("https://acme.com", baseParams);
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.test.local/v1/brands",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "X-API-Key": "test-api-svc-key",
+          "x-org-id": "org-1",
+          "x-user-id": "user-1",
+          "x-run-id": "run-1",
+        }),
+        body: JSON.stringify({ url: "https://acme.com" }),
+      }),
+    );
+    expect(result).toEqual({ brandId: "b-9" });
+  });
+
+  it("list_brands GETs /v1/brands", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(okJson({ brands: [] }));
+    const { listBrands } = await loadModule();
+    await listBrands(baseParams);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.test.local/v1/brands",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("launch_campaign POSTs /v1/campaigns with the full body", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(okJson({ campaign: { id: "c-1", status: "active" } }));
+    const { launchCampaign } = await loadModule();
+    const body = {
+      name: "Q2 Outreach",
+      brandUrls: ["https://acme.com"],
+      featureInputs: { targetAudience: "SaaS founders" },
+      featureDynastySlug: "pr-cold-email-outreach",
+      workflowDynastySlug: "sales-email-cold-outreach-sienna",
+      maxBudgetTotalUsd: "500",
+    };
+    const result = await launchCampaign(body, baseParams);
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.test.local/v1/campaigns",
+      expect.objectContaining({ method: "POST", body: JSON.stringify(body) }),
+    );
+    expect(result).toEqual({ campaign: { id: "c-1", status: "active" } });
+  });
+
+  it("list_campaigns builds the brandId + status query string", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(okJson({ campaigns: [] }));
+    const { listCampaigns } = await loadModule();
+    await listCampaigns({ brandId: "b-1", status: "active" }, baseParams);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.test.local/v1/campaigns?brandId=b-1&status=active",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("list_campaigns omits the query string when no filters", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(okJson({ campaigns: [] }));
+    const { listCampaigns } = await loadModule();
+    await listCampaigns({}, baseParams);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.test.local/v1/campaigns",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("stop_campaign POSTs /v1/campaigns/{id}/stop with an encoded id", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(okJson({ campaign: { id: "c-1", status: "stopped" } }));
+    const { stopCampaign } = await loadModule();
+    await stopCampaign("c-1", baseParams);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.test.local/v1/campaigns/c-1/stop",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("get_daily_budget GETs the brand daily-budget", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(okJson({ dailyBudgetCents: 2000 }));
+    const { getBrandDailyBudget } = await loadModule();
+    const result = await getBrandDailyBudget("b-1", baseParams);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.test.local/v1/brands/b-1/daily-budget",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(result).toEqual({ dailyBudgetCents: 2000 });
+  });
+
+  it("set_daily_budget PATCHes { dailyBudgetCents }", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(okJson({}));
+    const { setBrandDailyBudget } = await loadModule();
+    await setBrandDailyBudget("b-1", 2500, baseParams);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.test.local/v1/brands/b-1/daily-budget",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ dailyBudgetCents: 2500 }),
+      }),
+    );
+  });
+
+  it("set_brand_pause PATCHes { paused } for pause and resume", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(okJson({}));
+    const { setBrandPauseState } = await loadModule();
+
+    await setBrandPauseState("b-1", true, baseParams);
+    expect(fetch).toHaveBeenLastCalledWith(
+      "https://api.test.local/v1/brands/b-1/pause",
+      expect.objectContaining({ method: "PATCH", body: JSON.stringify({ paused: true }) }),
+    );
+
+    await setBrandPauseState("b-1", false, baseParams);
+    expect(fetch).toHaveBeenLastCalledWith(
+      "https://api.test.local/v1/brands/b-1/pause",
+      expect.objectContaining({ method: "PATCH", body: JSON.stringify({ paused: false }) }),
+    );
+  });
+
+  it("get_brand_pause GETs the brand pause state", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(okJson({ paused: false }));
+    const { getBrandPauseState } = await loadModule();
+    await getBrandPauseState("b-1", baseParams);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.test.local/v1/brands/b-1/pause",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("returns {} for an empty success body", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(""),
+    });
+    const { setBrandDailyBudget } = await loadModule();
+    const result = await setBrandDailyBudget("b-1", 0, baseParams);
+    expect(result).toEqual({});
+  });
+
+  it("fails loud (throws FunnelError) on a non-2xx response, preserving status + body", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: () => Promise.resolve("brandId required"),
+    });
+    const { launchCampaign, FunnelError } = await loadModule();
+
+    const err = await launchCampaign(
+      { name: "x", brandUrls: ["https://x.com"], featureInputs: {} },
+      baseParams,
+    ).catch((e) => e);
+
+    expect(err).toBeInstanceOf(FunnelError);
+    expect(err.status).toBe(400);
+    expect(err.operation).toBe("launch_campaign");
+    expect(String(err.message)).toContain("brandId required");
+  });
+
+  it("forwards tracking headers to api-service", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(okJson({ brands: [] }));
+    const { listBrands } = await loadModule();
+    await listBrands({ ...baseParams, trackingHeaders: { "x-brand-id": "b-1" } });
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({ "x-brand-id": "b-1" }),
+      }),
+    );
+  });
+});

--- a/tests/unit/persona-brand-profile-configs.test.ts
+++ b/tests/unit/persona-brand-profile-configs.test.ts
@@ -54,6 +54,7 @@ describe("self-seeded platform configs", () => {
       "audience-editor",
       "brand-profile-editor",
       "persona-editor",
+      "whatsapp",
     ]);
   });
 
@@ -149,6 +150,7 @@ describe("seedPlatformConfigs", () => {
       "audience-editor",
       "brand-profile-editor",
       "persona-editor",
+      "whatsapp",
     ]);
 
     for (const call of values.mock.calls) {

--- a/tests/unit/whatsapp-config.test.ts
+++ b/tests/unit/whatsapp-config.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { AVAILABLE_TOOL_NAMES, resolveToolSet } from "../../src/lib/anthropic.js";
+import { WHATSAPP_CONFIG } from "../../src/lib/seed-platform-configs.js";
+
+// The WhatsApp "Distribute.you" assistant must let a user operate the whole
+// platform end-to-end by chat: create a brand from a URL, launch a campaign, set
+// the daily budget, and pause/resume a brand — on top of the existing curation
+// tools. These tests pin the funnel tool set into the config so it can't drift.
+
+const FUNNEL_TOOLS = [
+  "create_brand_from_url",
+  "list_brands",
+  "launch_campaign",
+  "list_campaigns",
+  "stop_campaign",
+  "get_daily_budget",
+  "set_daily_budget",
+  "get_brand_pause",
+  "set_brand_pause",
+];
+
+describe("whatsapp config — full-funnel tool set", () => {
+  it("enables every funnel tool (brand → launch → budget → pause/resume)", () => {
+    for (const tool of FUNNEL_TOOLS) {
+      expect(WHATSAPP_CONFIG.allowedTools, `whatsapp missing ${tool}`).toContain(tool);
+    }
+  });
+
+  it("also enables the existing curation + discovery operations", () => {
+    for (const tool of [
+      "browse_url",
+      "list_features",
+      "get_feature_inputs",
+      "list_workflows",
+      "get_brand_profile",
+      "list_audiences",
+      "suggest_audiences",
+      "list_personas",
+      "create_persona",
+    ]) {
+      expect(WHATSAPP_CONFIG.allowedTools, `whatsapp missing ${tool}`).toContain(tool);
+    }
+  });
+
+  it("every allowedTool resolves to a registered tool", () => {
+    for (const tool of WHATSAPP_CONFIG.allowedTools) {
+      expect(AVAILABLE_TOOL_NAMES, `unknown tool ${tool}`).toContain(tool);
+    }
+    const resolved = resolveToolSet([...WHATSAPP_CONFIG.allowedTools]);
+    expect(resolved.map((t) => t.name)).toEqual([...WHATSAPP_CONFIG.allowedTools]);
+  });
+
+  it("runs on the documented Gemini default (google/flash-pro) so the WhatsApp org is billed like dashboard chat", () => {
+    expect(WHATSAPP_CONFIG.key).toBe("whatsapp");
+    expect(WHATSAPP_CONFIG.provider).toBe("google");
+    expect(WHATSAPP_CONFIG.model).toBe("flash-pro");
+  });
+
+  it("names itself Distribute.you and never asks the user to sign in", () => {
+    expect(WHATSAPP_CONFIG.systemPrompt).toContain("Distribute.you");
+    expect(WHATSAPP_CONFIG.systemPrompt).toMatch(/never ask them to sign in/i);
+  });
+
+  it("does not expose fork_workflow (new-dynasty, confirmation-gated) by default", () => {
+    expect(WHATSAPP_CONFIG.allowedTools).not.toContain("fork_workflow");
+  });
+});


### PR DESCRIPTION
## What

Adds the end-to-end **funnel** operations a dashboard user drives, so an agentic chat can take an org from nothing to a running, managed campaign purely by chat — plus a self-seeded **`whatsapp`** ("Distribute.you") chat config that enables the full tool set.

## New funnel tools

`src/lib/funnel-client.ts` (thin, fail-loud wrappers over api-service) → `anthropic.ts` `TOOL_REGISTRY` → `index.ts` `executeTool` dispatch:

| Tool | Route |
|---|---|
| `create_brand_from_url` | `POST /v1/brands { url }` (onboarding-equivalent) |
| `list_brands` | `GET /v1/brands` |
| `launch_campaign` | `POST /v1/campaigns` |
| `list_campaigns` | `GET /v1/campaigns` |
| `stop_campaign` | `POST /v1/campaigns/:id/stop` |
| `get_daily_budget` / `set_daily_budget` | `GET`/`PATCH /v1/brands/:id/daily-budget` |
| `get_brand_pause` / `set_brand_pause` | `GET`/`PATCH /v1/brands/:id/pause` |

Unlike the brand-scoped editor tools (which act on a single `context.brandId`), these take the brand/campaign id **explicitly**, so they work in a brand-less onboarding session where the agent creates/selects the brand mid-conversation.

## WhatsApp config

New self-seeded platform config `whatsapp` (in `seed-platform-configs.ts`, upserted at boot alongside the editors): a conversational **Distribute.you** assistant. `allowedTools` = the full funnel + `browse_url` + feature/workflow reads + brand-profile / audience / persona curation. `google`/`flash-pro`, `thinkingLevel: medium`, sharing the editor voice + ground-truth guardrails.

## Cost / billing

Unchanged. LLM spend stays in chat-service (the WhatsApp org is billed for its own usage, same as dashboard chat). The funnel operations are org-billed by their owning services via the forwarded `x-org-id`/`x-user-id`/`x-run-id` — chat-service declares no cost of its own for them.

## Out of scope (owned elsewhere)

WhatsApp/Twilio transport (channel service), account provisioning (client-service). No LLM spend routed outside chat-service.

## AC

An agentic chat scoped to an org/user can, purely via chat: create a brand from a URL → launch it → set its daily budget → pause/resume it, on top of existing edit ops. The `whatsapp` config enables this set. Build + tests green (794 unit).

## Tests

- `funnel-client.test.ts` — per-endpoint wiring, query-string build, empty-body, fail-loud `FunnelError`, tracking-header forward.
- `whatsapp-config.test.ts` — full funnel tool set present + all registered + provider/model.
- Updated the self-seeded key lists (now 4 configs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)