### PR TITLE
fix(complete): recover first complete JSON value from fenced/trailing-prose output

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Response:
 ```
 
 - `content` — raw text response (always present).
-- `json` — parsed JSON object (present when `responseFormat: "json"` or when `responseSchema` is set). Populated via strict `JSON.parse(content)` — no jsonrepair, no LLM-assisted repair. Provider-native enforcement (`output_config.format` for Anthropic, `responseMimeType` / `responseSchema` for Gemini) guarantees the output is valid JSON. A parse failure means the provider violated its contract and the endpoint returns **502**.
+- `json` — parsed JSON object (present when `responseFormat: "json"` or when `responseSchema` is set). Populated by a strict `JSON.parse(content)` fast path, with a **first-complete-value recovery** for two provider quirks: a value wrapped in a markdown ```` ``` ```` fence, or a complete value followed by trailing prose (Gemini 3 thinking models leak trailing content despite JSON-mode metadata). Recovery is a balanced, string-aware scan only — no jsonrepair, no LLM-assisted repair. Genuinely broken output (empty, leading non-fence prose, truncated/unbalanced JSON) still returns **502**.
 - `tokensInput` / `tokensOutput` — token usage
 - `model` — the versioned model ID that was actually used (resolved from the provider + alias)
 
@@ -523,7 +523,7 @@ Determinism: Gemini `gemini-embedding-001` is deterministic for identical input 
 | **Anthropic** | **Rejected (400)** — Anthropic has no native standalone JSON mode. Supply `responseSchema`. | Passed to Anthropic as `output_config.format = { type: "json_schema", schema }`. Anthropic enforces server-side. |
 | **Google (Gemini)** | Native — passed as `generationConfig.responseMimeType: "application/json"`. | Both passed as `responseMimeType` + `responseSchema` in `generationConfig`. |
 
-When `jsonMode` is set, the service runs strict `JSON.parse(content)` on the model output to populate `response.json`. A parse failure means the provider violated its enforcement contract and is surfaced as a 502.
+When `jsonMode` is set, the service populates `response.json` from the model output: a strict `JSON.parse(content)` fast path, falling back to recovery of the **first complete JSON value** when the provider wraps it in a markdown fence or appends trailing prose (Gemini 3 thinking models do this despite JSON-mode metadata). Recovery is a balanced, string-aware scan — no jsonrepair, no LLM repair rounds. If no complete JSON value is extractable (empty response, leading non-fence prose, truncated/unbalanced JSON), the provider violated its enforcement contract and it is surfaced as a 502 with a classified `detail`.
 
 **Output budget.** Both providers receive an explicit **64k** output-token budget (Gemini `generationConfig.maxOutputTokens`, Anthropic `max_tokens`) — matching the worst-case hold provisioned/authorized for the call. Without an explicit budget Gemini falls back to a lower per-model default and truncates long responses, so it is always set. If the model still stops at the budget (`finishReason: "MAX_TOKENS"`) in JSON mode, the partial output is truncated JSON; the service **fails loud** with `[gemini] Output truncated (MAX_TOKENS)` → 502 (a clear cause, not a cryptic `JSON.parse` error). In text mode the partial content is returned with a warning.
 

--- a/src/lib/json-output.ts
+++ b/src/lib/json-output.ts
@@ -1,20 +1,125 @@
 /**
  * Parse model JSON output for /complete surfaces.
  *
- * JSON mode / structured output asks the provider for one raw JSON value.
- * Accept only that contract plus surrounding whitespace. Markdown fences,
- * preambles, trailing prose, and malformed JSON are provider-contract
- * violations and must fail loudly.
+ * JSON mode / structured output asks the provider for one raw JSON value. The
+ * clean contract is exactly that value plus surrounding whitespace, and the
+ * fast path enforces it verbatim.
+ *
+ * Reality check: Gemini 3 thinking models (google/flash-pro) intermittently
+ * emit a COMPLETE valid JSON value FOLLOWED BY trailing non-JSON content
+ * (thinking-leak prose, a stray closing fence) even in JSON mode — despite the
+ * responseMimeType/responseSchema enforcement metadata. They also sometimes
+ * wrap the value in a markdown ```json fence. So we recover the FIRST complete
+ * JSON value in those two cases (fence + trailing prose) instead of 502-ing.
+ *
+ * Recovery is a balanced-delimiter, string-aware SCAN only — no jsonrepair, no
+ * LLM-repair round (that pipeline was removed in #155 and must not return).
+ * We still fail loud on genuinely broken output: empty responses, LEADING
+ * non-fence prose (a prose sentence with a stray brace risks mis-extraction),
+ * and truncated/unbalanced JSON. This is exactly the behavior index.ts's
+ * handler comment already promised.
+ *
+ * NOTE to a future "strictly validate JSON completions" hotfix: do NOT revert
+ * this to a rigid `JSON.parse(content.trim())`. The premise "provider-side
+ * enforcement guarantees valid JSON" is empirically FALSE for Gemini 3
+ * thinking (the position-N trailing leak) — that reversion re-introduces the
+ * ~2/8-segments 502 drop in apollo-service /audiences/suggest-from-segment.
  */
 export function parseModelJsonOutput(content: string): unknown {
   const trimmed = content.trim();
 
+  // Fast path: clean, single JSON value (zero-risk for the compliant case).
   try {
     return JSON.parse(trimmed);
   } catch (err) {
     const parseMessage = err instanceof Error ? err.message : String(err);
-    throw new ModelJsonOutputError(formatJsonOutputError(trimmed, parseMessage));
+    return recoverJsonValue(trimmed, parseMessage);
   }
+}
+
+/**
+ * Recover the first complete JSON value from a fenced or trailing-prose
+ * payload. Only two shapes are eligible for recovery:
+ *   1. A leading markdown fence (```/```json) wrapping the value.
+ *   2. A payload that STARTS with a JSON structural char ({ or [) but has
+ *      trailing content after the first complete value.
+ * Anything else (empty, leading non-fence prose, unbalanced/truncated) throws
+ * with the existing classification.
+ */
+function recoverJsonValue(trimmed: string, parseMessage: string): unknown {
+  const scanFrom = trimmed.startsWith("```") ? stripLeadingFence(trimmed) : trimmed;
+
+  const start = scanFrom.search(/[{[]/);
+  // Recovery is only attempted when the (post-fence) payload begins with a JSON
+  // structural char — a fence was stripped, or the raw value already led with
+  // { / [. Leading non-fence prose keeps the first structural char buried after
+  // text, so `start > 0` there and we reject rather than risk mis-extraction.
+  if (start === 0) {
+    const candidate = extractBalancedJson(scanFrom, start);
+    if (candidate !== null) {
+      try {
+        return JSON.parse(candidate);
+      } catch {
+        // Fall through to the classified throw below.
+      }
+    }
+  }
+
+  throw new ModelJsonOutputError(formatJsonOutputError(trimmed, parseMessage));
+}
+
+/**
+ * Strip a leading ``` or ```json fence line so the balanced scan can start on
+ * the JSON value. The closing fence (if any) is ignored by the balanced scan.
+ */
+function stripLeadingFence(value: string): string {
+  const firstNewline = value.indexOf("\n");
+  if (firstNewline === -1) {
+    return "";
+  }
+  return value.slice(firstNewline + 1).trimStart();
+}
+
+/**
+ * String-aware, balanced-delimiter scan from `start` (a `{` or `[`) to its
+ * matching close. Respects double-quoted strings and backslash escapes so
+ * braces/brackets inside string values do not miscount. Returns the substring
+ * of the first complete value, or null if it never balances (truncated).
+ */
+function extractBalancedJson(value: string, start: number): string | null {
+  const open = value[start];
+  const close = open === "{" ? "}" : "]";
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let i = start; i < value.length; i++) {
+    const ch = value[i];
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = true;
+    } else if (ch === open) {
+      depth += 1;
+    } else if (ch === close) {
+      depth -= 1;
+      if (depth === 0) {
+        return value.slice(start, i + 1);
+      }
+    }
+  }
+
+  return null;
 }
 
 export class ModelJsonOutputError extends Error {

--- a/tests/integration/complete-cost.test.ts
+++ b/tests/integration/complete-cost.test.ts
@@ -285,7 +285,7 @@ describe("POST /complete — cost provision → authorize → execute → reconc
     ]);
   });
 
-  it("fails with a clear 502 when the provider appends prose after a complete JSON object", async () => {
+  it("recovers the JSON value (200) when the provider appends prose after a complete JSON object", async () => {
     const cap = { postedItems: [] as Array<Array<{ costName: string; quantity: number; status?: string }>>, patchedStatuses: [] as string[] };
     const gemini = { calls: 0 };
     routes.push(mockRunsCreate(), mockKeyDecrypt(), mockBilling(), mockGeminiJsonWithTrailingText(gemini), ...mockRunsCostRoutes(cap), mockRunsStatusPatch());
@@ -295,10 +295,16 @@ describe("POST /complete — cost provision → authorize → execute → reconc
       .set(AUTH)
       .send({ message: "extract", systemPrompt: "return json", provider: "google", model: "flash", responseFormat: "json" });
 
-    expect(res.status).toBe(502);
+    expect(res.status).toBe(200);
     expect(gemini.calls).toBe(1);
-    expect(res.body.error).toBe("LLM returned invalid JSON.");
-    expect(res.body.detail).toContain("trailing non-JSON content");
+    // Trailing "Parsed successfully." is dropped; the first complete value is returned.
+    expect(res.body.json).toEqual({ subject: "ok", emails: [] });
+
+    // The recovered path is a SUCCESS, so it actualizes real tokens like any 200.
+    const actual = cap.postedItems.find((items) => items.some((i) => i.status === undefined));
+    expect(actual).toBeDefined();
+    expect(actual!.find((i) => i.costName.endsWith("input"))!.quantity).toBe(10);
+    expect(actual!.find((i) => i.costName.endsWith("output"))!.quantity).toBe(5);
   });
 
   it("fails loud (502) and does NOT call the model when provision is rejected", async () => {

--- a/tests/unit/json-output.test.ts
+++ b/tests/unit/json-output.test.ts
@@ -13,16 +13,33 @@ describe("parseModelJsonOutput", () => {
     expect(parseModelJsonOutput('\n  {"ok":true}\n')).toEqual({ ok: true });
   });
 
-  it("rejects JSON wrapped in a markdown fence", () => {
-    expect(() => parseModelJsonOutput('```json\n{"ok":true}\n```')).toThrow(
-      "Model returned markdown-fenced JSON in JSON mode.",
-    );
+  it("recovers JSON wrapped in a markdown fence", () => {
+    expect(parseModelJsonOutput('```json\n{"ok":true}\n```')).toEqual({ ok: true });
   });
 
-  it("rejects trailing prose after a complete JSON value", () => {
-    expect(() => parseModelJsonOutput('{"ok":true}\n\nDone.')).toThrow(
-      "Model returned trailing non-JSON content after a JSON value.",
-    );
+  it("recovers JSON wrapped in a bare (no-lang) markdown fence", () => {
+    expect(parseModelJsonOutput('```\n{"ok":true}\n```')).toEqual({ ok: true });
+  });
+
+  it("recovers a complete JSON value with trailing prose (Gemini-3 thinking leak)", () => {
+    expect(parseModelJsonOutput('{"ok":true}\n\nDone.')).toEqual({ ok: true });
+  });
+
+  it("recovers a complete JSON array with trailing prose", () => {
+    expect(parseModelJsonOutput('[1,2,3]\n\nParsed successfully.')).toEqual([1, 2, 3]);
+  });
+
+  it("does not miscount braces inside string values during recovery", () => {
+    expect(parseModelJsonOutput('{"a":"} not a close","b":[1]}\ntrailing')).toEqual({
+      a: "} not a close",
+      b: [1],
+    });
+  });
+
+  it("recovers a fenced value that also has trailing prose after the fence", () => {
+    expect(parseModelJsonOutput('```json\n{"ok":true}\n```\n\nHope that helps!')).toEqual({
+      ok: true,
+    });
   });
 
   it("rejects prose before a JSON value", () => {
@@ -31,9 +48,21 @@ describe("parseModelJsonOutput", () => {
     );
   });
 
-  it("rejects malformed JSON", () => {
+  it("rejects truncated / unbalanced JSON", () => {
     expect(() => parseModelJsonOutput('{"ok":true')).toThrow(
       "Model returned malformed or truncated JSON.",
+    );
+  });
+
+  it("rejects truncated JSON even with trailing content it cannot balance", () => {
+    expect(() => parseModelJsonOutput('{"ok":true, "items":[1,2')).toThrow(
+      "Model returned malformed or truncated JSON.",
+    );
+  });
+
+  it("rejects an empty response", () => {
+    expect(() => parseModelJsonOutput("   ")).toThrow(
+      "Model returned an empty JSON-mode response.",
     );
   });
 });


### PR DESCRIPTION
## Problem
Gemini 3 thinking models (`google/flash-pro`) intermittently emit a **complete valid JSON value followed by trailing non-JSON content** (thinking-leak prose, a stray closing fence) even in JSON mode, despite `responseMimeType`/`responseSchema` enforcement. `parseModelJsonOutput` did a rigid `JSON.parse(content.trim())` and threw on any trailing content → `/complete` and `/internal/platform-complete` returned **502** `{"error":"LLM returned invalid JSON."}`.

Real prod impact: apollo-service `POST /audiences/suggest-from-segment` (calls chat-service `/complete`) 502'd on ~2/8 segments per human-service `/orgs/audiences/suggest` call — nondeterministic, silently dropped by caller `Promise.allSettled`.

## Fix
Implements the recover-first-value behavior `src/index.ts:497-499`'s handler comment already promised (added by #290 but never coded):
1. **Fast path** — `JSON.parse(content.trim())`, return on success (zero-risk for the compliant case).
2. **Recovery on failure** — strip a leading ```` ``` ````/```` ```json ```` fence, then string-aware/escape-aware **balanced-delimiter scan** the first complete JSON value from the first `{`/`[`. Return it; ignore anything after.
3. **Fail loud** on genuinely broken output — empty, **leading non-fence prose** (a stray brace in a sentence risks mis-extraction), truncated/unbalanced — with the existing classified `detail`.

No jsonrepair, no LLM-repair round (#155 stays removed). Recovery is a scan only.

Shared `parseModelJsonOutput` fixes **both** surfaces at once.

## Tests
- `tests/unit/json-output.test.ts` — flipped fence + trailing-prose to PARSE; added array recovery, brace-in-string, fence+trailing, empty, and two truncated/unbalanced REJECT cases.
- `tests/integration/complete-cost.test.ts` — flipped the trailing-prose case to expect **200 + parsed `json`** and asserts the recovered path **actualizes real tokens** (billing reconciliation intact).
- Full suite: 839 pass (2 unrelated DB-env-gated integration files skip locally on missing `CHAT_SERVICE_DATABASE_URL`), `tsc` clean, build green.

## Anti-revert note
`json-output.ts` header + `README.md` document that Gemini 3 thinking leaks trailing content despite JSON-mode metadata, so a future "strictly validate" hotfix does not re-revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)