### PR TITLE
release: DeepSeek V4 Pro alias on the Vercel AI Gateway path

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Request body:
 - `model` (required) — version-free model alias. The service resolves the latest versioned model internally. Valid combinations:
   - **anthropic**: `haiku` (fast/cheap), `sonnet` (balanced), `opus` (highest quality)
   - **google**: `flash-lite` (cheapest, vision, Gemini 3.1 Flash-Lite), `flash` (Gemini 3.5 Flash-Lite), `flash-pro` (mid-tier default, Gemini 3.7 Flash), `pro` (most powerful, Gemini 3.1 Pro). All require a Google API key in key-service.
-  - **vercel**: `deepseek-flash` (DeepSeek V4 Flash via the Vercel AI Gateway — cheapest per unit of intelligence, 1M context). Text only: `imageUrl` and `webSearch` are rejected with 400 on this provider. Requires a `vercel` key in key-service.
+  - **vercel**: `deepseek-flash` (DeepSeek V4 Flash via the Vercel AI Gateway — cheapest per unit of intelligence, 1M context), `deepseek-pro` (DeepSeek V4 Pro — the reasoning-heavy sibling, same gateway path). Text only: `imageUrl` and `webSearch` are rejected with 400 on this provider, for every gateway model. Requires a `vercel` key in key-service.
 - `responseFormat` (optional) — set to `"json"` to enable JSON-mode parsing. **For `provider: "anthropic"`, you MUST also supply `responseSchema`** — Anthropic has no native standalone JSON mode, so the request is rejected with 400 if `responseSchema` is missing. For `provider: "google"` (Gemini), `responseFormat: "json"` alone is sufficient (native `responseMimeType` enforcement).
 - `responseSchema` (optional) — JSON Schema enforced server-side by the provider's structured-output API. When set, JSON-mode parsing is implied (no need to also pass `responseFormat: "json"`). The schema is forwarded as:
   - **Google** → `generationConfig.responseSchema` (supported on all Gemini 2.5+ models: `pro`, `flash`, `flash-lite`). Gemini accepts only an OpenAPI 3.0 subset; chat-service auto-sanitizes the caller-supplied schema before forwarding by stripping unsupported JSON-Schema keywords (`additionalProperties`, `$schema`, `$ref`, `$defs`, `definitions`, `patternProperties`, `unevaluatedProperties`, `if`/`then`/`else`, `not`, `const`, `examples`, `default`, `exclusiveMinimum`/`exclusiveMaximum`, `multipleOf`, etc.). A `[chat-service] Gemini schema sanitized` warning is logged once per call when any field is removed.
@@ -283,7 +283,14 @@ A third provider path alongside the two native clients. Where `anthropic.ts` and
 
 The gateway serves ~330 models. chat-service reaches exactly the aliases declared in `MODEL_MAP.vercel`, and `resolveModel` throws on anything else. Each alias costs exactly **two** costs-service catalog rows (`<costPrefix>-tokens-input` / `-tokens-output`) which must exist in **production** before the alias ships — otherwise runs-service 422s the cost declaration and the call fails loud. So enumerating the gateway's catalog is neither required nor possible by accident: a model is unreachable until someone adds it to both places deliberately.
 
-Currently declared: `deepseek-flash` → `deepseek/deepseek-v4-flash` → `deepseek-v4-flash-tokens-{input,output}`.
+Currently declared:
+
+| Alias | Gateway model id | Cost names |
+|---|---|---|
+| `deepseek-flash` | `deepseek/deepseek-v4-flash` | `deepseek-v4-flash-tokens-{input,output}` |
+| `deepseek-pro` | `deepseek/deepseek-v4-pro` | `deepseek-v4-pro-tokens-{input,output}` |
+
+The gateway catalog also carries **dated** ids for these models (e.g. `deepseek/deepseek-v4-pro-0813`). Our aliases are version-free by convention, so `MODEL_MAP` routes to the **undated** id and lets the gateway resolve the current build — the same choice made for V4 Flash.
 
 ### Pricing: peak rate, no cache discount
 
@@ -300,7 +307,7 @@ Every call logs the gateway's own reported cost (`provider_metadata.gateway.cost
 
 ### JSON mode is best-effort here
 
-`responseSchema` is forwarded as native `response_format: { type: "json_schema", ... }`, but not every model behind the gateway enforces it — DeepSeek V4 Flash does not advertise `response_format` support on any of its endpoints, so the provider may ignore it. This is not a silent fallback: `parseModelJsonOutput` still fails loud (502) on output it cannot read. It is also precisely what a bake-off has to measure before any existing caller is migrated onto a gateway model.
+`responseSchema` is forwarded as native `response_format: { type: "json_schema", ... }`, but not every model behind the gateway enforces it — neither DeepSeek V4 Flash nor V4 Pro advertises `response_format` support on any of its endpoints, so the provider may ignore it. This is not a silent fallback: `parseModelJsonOutput` still fails loud (502) on output it cannot read. It is also precisely what a bake-off has to measure before any existing caller is migrated onto a gateway model.
 
 ### Retry behaviour
 
@@ -309,7 +316,8 @@ Only **connect-phase** failures are retried (a thrown fetch rejection whose caus
 ### Operational prerequisites
 
 1. A `vercel` **platform key** in key-service holding the AI Gateway API key (`GET /keys/platform/vercel/decrypt`). Without it, `provider: "vercel"` returns 502 at key resolution.
-2. The two catalog rows live in production costs-service (provider `vercel`, plan `pay-as-you-go`/`monthly`).
+2. The two catalog rows **per alias** live in production costs-service (provider `vercel`, plan `pay-as-you-go`/`monthly`).
+3. The Vercel account must have gateway credits. On the free tier the gateway serves only a subset of its catalog and returns **403** for the rest — both `deepseek-flash` and `deepseek-pro` are currently in that bucket. That is an account-billing state, not a chat-service failure: the 403 surfaces as a loud upstream error and is never worked around by substituting another model.
 
 ## Internal Platform Completion
 

--- a/openapi.json
+++ b/openapi.json
@@ -758,9 +758,10 @@
               "flash",
               "flash-pro",
               "pro",
-              "deepseek-flash"
+              "deepseek-flash",
+              "deepseek-pro"
             ],
-            "description": "Model alias (version-free). The service resolves the latest versioned model internally.\n\n**Anthropic models:** `haiku` (fast/cheap), `sonnet` (balanced), `opus` (highest quality).\n**Google models:** `flash-lite` (cheapest, vision), `flash` (balanced, reasoning), `flash-pro` (mid-tier, Gemini 3.5 Flash), `pro` (most powerful).\n**Vercel AI Gateway models:** `deepseek-flash` (DeepSeek V4 Flash — cheapest per unit of intelligence; 1M context). Text only: no vision, no web search, no image generation on this path.\n\nThe model must match the provider: anthropic → haiku|sonnet|opus, google → flash-lite|flash|flash-pro|pro, vercel → deepseek-flash.",
+            "description": "Model alias (version-free). The service resolves the latest versioned model internally.\n\n**Anthropic models:** `haiku` (fast/cheap), `sonnet` (balanced), `opus` (highest quality).\n**Google models:** `flash-lite` (cheapest, vision), `flash` (balanced, reasoning), `flash-pro` (mid-tier, Gemini 3.5 Flash), `pro` (most powerful).\n**Vercel AI Gateway models:** `deepseek-flash` (DeepSeek V4 Flash — cheapest per unit of intelligence; 1M context), `deepseek-pro` (DeepSeek V4 Pro — the reasoning-heavy sibling; same gateway path, same limits). Text only: no vision, no web search, no image generation on this path.\n\nThe model must match the provider: anthropic → haiku|sonnet|opus, google → flash-lite|flash|flash-pro|pro, vercel → deepseek-flash|deepseek-pro.",
             "example": "sonnet"
           },
           "webSearch": {
@@ -943,9 +944,10 @@
               "flash",
               "flash-pro",
               "pro",
-              "deepseek-flash"
+              "deepseek-flash",
+              "deepseek-pro"
             ],
-            "description": "Model alias (version-free). Must match the provider: anthropic → haiku|sonnet|opus, google → flash-lite|flash|flash-pro|pro, vercel → deepseek-flash.",
+            "description": "Model alias (version-free). Must match the provider: anthropic → haiku|sonnet|opus, google → flash-lite|flash|flash-pro|pro, vercel → deepseek-flash|deepseek-pro (`deepseek-flash` = DeepSeek V4 Flash, `deepseek-pro` = DeepSeek V4 Pro; both text-only on the Vercel AI Gateway path).",
             "example": "sonnet"
           },
           "webSearch": {

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -111,7 +111,8 @@ export type ModelAlias =
   | "flash"
   | "flash-pro"
   | "pro"
-  | "deepseek-flash";
+  | "deepseek-flash"
+  | "deepseek-pro";
 
 interface ResolvedModel {
   /** Versioned model ID sent to the provider's API */
@@ -152,6 +153,15 @@ const MODEL_MAP: Record<string, Record<string, ResolvedModel>> = {
       costPrefix: "deepseek-v4-flash",
       provider: "vercel",
     },
+    // DeepSeek V4 Pro — the reasoning-heavy sibling of V4 Flash. The gateway
+    // catalog also carries dated ids (`deepseek/deepseek-v4-pro-0813`); our
+    // aliases are version-free, so we route to the undated id and let the
+    // gateway resolve the current build (same convention as V4 Flash).
+    "deepseek-pro": {
+      apiModelId: "deepseek/deepseek-v4-pro",
+      costPrefix: "deepseek-v4-pro",
+      provider: "vercel",
+    },
   },
 };
 
@@ -159,7 +169,7 @@ const MODEL_MAP: Record<string, Record<string, ResolvedModel>> = {
 export const PROVIDER_MODELS: Record<Provider, readonly ModelAlias[]> = {
   anthropic: ["haiku", "sonnet", "opus"],
   google: ["flash-lite", "flash", "flash-pro", "pro"],
-  vercel: ["deepseek-flash"],
+  vercel: ["deepseek-flash", "deepseek-pro"],
 };
 
 /**
@@ -192,6 +202,7 @@ export const SUPPORTED_MODELS: Record<string, string> = {
   "gemini-2.5-pro": "google-pro-2.5",
   "gemini-2.5-flash": "google-flash-2.5",
   "deepseek/deepseek-v4-flash": "deepseek-v4-flash",
+  "deepseek/deepseek-v4-pro": "deepseek-v4-pro",
 };
 
 /** Resolve the cost prefix for a given model ID (falls back to default). */

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -434,14 +434,15 @@ export const CompleteRequestSchema = z
         "caller reaches it implicitly.",
       example: "anthropic",
     }),
-    model: z.enum(["haiku", "sonnet", "opus", "flash-lite", "flash", "flash-pro", "pro", "deepseek-flash"]).openapi({
+    model: z.enum(["haiku", "sonnet", "opus", "flash-lite", "flash", "flash-pro", "pro", "deepseek-flash", "deepseek-pro"]).openapi({
       description:
         "Model alias (version-free). The service resolves the latest versioned model internally.\n\n" +
         "**Anthropic models:** `haiku` (fast/cheap), `sonnet` (balanced), `opus` (highest quality).\n" +
         "**Google models:** `flash-lite` (cheapest, vision), `flash` (balanced, reasoning), `flash-pro` (mid-tier, Gemini 3.5 Flash), `pro` (most powerful).\n" +
-        "**Vercel AI Gateway models:** `deepseek-flash` (DeepSeek V4 Flash — cheapest per unit of intelligence; 1M context). " +
+        "**Vercel AI Gateway models:** `deepseek-flash` (DeepSeek V4 Flash — cheapest per unit of intelligence; 1M context), " +
+        "`deepseek-pro` (DeepSeek V4 Pro — the reasoning-heavy sibling; same gateway path, same limits). " +
         "Text only: no vision, no web search, no image generation on this path.\n\n" +
-        "The model must match the provider: anthropic → haiku|sonnet|opus, google → flash-lite|flash|flash-pro|pro, vercel → deepseek-flash.",
+        "The model must match the provider: anthropic → haiku|sonnet|opus, google → flash-lite|flash|flash-pro|pro, vercel → deepseek-flash|deepseek-pro.",
       example: "sonnet",
     }),
     webSearch: z.boolean().optional().openapi({
@@ -502,7 +503,7 @@ export const CompleteRequestSchema = z
     const validModels: Record<string, string[]> = {
       anthropic: ["haiku", "sonnet", "opus"],
       google: ["flash-lite", "flash", "flash-pro", "pro"],
-      vercel: ["deepseek-flash"],
+      vercel: ["deepseek-flash", "deepseek-pro"],
     };
     const allowed = validModels[data.provider];
     if (allowed && !allowed.includes(data.model)) {
@@ -762,10 +763,12 @@ export const InternalPlatformCompleteRequestSchema = z
         "LLM provider to use. `vercel` routes through the Vercel AI Gateway (OpenAI-compatible).",
       example: "anthropic",
     }),
-    model: z.enum(["haiku", "sonnet", "opus", "flash-lite", "flash", "flash-pro", "pro", "deepseek-flash"]).openapi({
+    model: z.enum(["haiku", "sonnet", "opus", "flash-lite", "flash", "flash-pro", "pro", "deepseek-flash", "deepseek-pro"]).openapi({
       description:
         "Model alias (version-free). Must match the provider: anthropic → haiku|sonnet|opus, " +
-        "google → flash-lite|flash|flash-pro|pro, vercel → deepseek-flash.",
+        "google → flash-lite|flash|flash-pro|pro, vercel → deepseek-flash|deepseek-pro " +
+        "(`deepseek-flash` = DeepSeek V4 Flash, `deepseek-pro` = DeepSeek V4 Pro; both text-only " +
+        "on the Vercel AI Gateway path).",
       example: "sonnet",
     }),
     webSearch: z.boolean().optional().openapi({

--- a/tests/unit/gateway.test.ts
+++ b/tests/unit/gateway.test.ts
@@ -8,8 +8,10 @@ import {
   GATEWAY_PROVIDER,
 } from "../../src/lib/gateway.js";
 import { resolveModel, PROVIDER_MODELS, costPrefixForModel } from "../../src/lib/anthropic.js";
+import { CompleteRequestSchema, InternalPlatformCompleteRequestSchema } from "../../src/schemas.js";
 
 const MODEL = "deepseek/deepseek-v4-flash";
+const PRO_MODEL = "deepseek/deepseek-v4-pro";
 
 function okBody(overrides: Record<string, unknown> = {}) {
   return {
@@ -53,17 +55,75 @@ describe("gateway model resolution", () => {
     expect(() => resolveModel("vercel", "sonnet")).toThrow(/Unknown model/);
   });
 
-  it("exposes exactly one gateway alias for Zod validation", () => {
-    expect(PROVIDER_MODELS.vercel).toEqual(["deepseek-flash"]);
+  it("resolves the deepseek-pro alias to the undated gateway model id and cost prefix", () => {
+    const resolved = resolveModel("vercel", "deepseek-pro");
+    // The catalog also carries dated ids (`-0813`); our aliases are version-free.
+    expect(resolved.apiModelId).toBe(PRO_MODEL);
+    expect(resolved.costPrefix).toBe("deepseek-v4-pro");
+    expect(resolved.provider).toBe(GATEWAY_PROVIDER);
   });
 
-  it("maps the gateway model id back to its cost prefix", () => {
+  it("declares exactly the two catalog names for the pro alias", () => {
+    const { costPrefix } = resolveModel("vercel", "deepseek-pro");
+    expect(`${costPrefix}-tokens-input`).toBe("deepseek-v4-pro-tokens-input");
+    expect(`${costPrefix}-tokens-output`).toBe("deepseek-v4-pro-tokens-output");
+  });
+
+  it("leaves the flash alias byte-identical after adding pro", () => {
+    expect(resolveModel("vercel", "deepseek-flash")).toEqual({
+      apiModelId: "deepseek/deepseek-v4-flash",
+      costPrefix: "deepseek-v4-flash",
+      provider: "vercel",
+    });
+  });
+
+  it("exposes exactly the declared gateway aliases for Zod validation", () => {
+    expect(PROVIDER_MODELS.vercel).toEqual(["deepseek-flash", "deepseek-pro"]);
+  });
+
+  it("maps the gateway model ids back to their cost prefixes", () => {
     expect(costPrefixForModel(MODEL)).toBe("deepseek-v4-flash");
+    expect(costPrefixForModel(PRO_MODEL)).toBe("deepseek-v4-pro");
   });
 
   it("leaves the native provider maps untouched", () => {
     expect(resolveModel("google", "flash-pro").costPrefix).toBe("google-flash-3.7");
     expect(resolveModel("anthropic", "sonnet").costPrefix).toBe("anthropic-sonnet-4.6");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Request schemas — the caller reads these to learn which models exist
+// ---------------------------------------------------------------------------
+
+describe("gateway aliases on the request schemas", () => {
+  const base = { message: "hi", systemPrompt: "" };
+
+  for (const model of ["deepseek-flash", "deepseek-pro"] as const) {
+    it(`accepts provider "vercel" + model "${model}" on POST /complete`, () => {
+      expect(CompleteRequestSchema.safeParse({ ...base, provider: "vercel", model }).success).toBe(true);
+    });
+
+    it(`accepts provider "vercel" + model "${model}" on /internal/platform-complete`, () => {
+      expect(
+        InternalPlatformCompleteRequestSchema.safeParse({ ...base, provider: "vercel", model }).success,
+      ).toBe(true);
+    });
+  }
+
+  it("rejects an unknown gateway model and names the accepted set", () => {
+    const parsed = CompleteRequestSchema.safeParse({ ...base, provider: "vercel", model: "deepseek-ultra" });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects a gateway alias sent with a native provider", () => {
+    const parsed = CompleteRequestSchema.safeParse({ ...base, provider: "google", model: "deepseek-pro" });
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues.map((i) => i.message).join(" ")).toMatch(
+        /not valid for provider "google".*flash-lite, flash, flash-pro, pro/s,
+      );
+    }
   });
 });
 


### PR DESCRIPTION
Promotes the DeepSeek V4 Pro gateway alias (#380) from staging to main.

Adds `deepseek-pro` -> `deepseek/deepseek-v4-pro` (cost prefix `deepseek-v4-pro`) alongside `deepseek-flash` on the existing Vercel AI Gateway path. Flash is byte-identical; the gateway path stays text-only; no fallback model list.

Gate: the `deepseek-v4-pro-tokens-{input,output}` rows must be live in production costs-service before a caller uses the alias, otherwise runs-service 422s and the call fails loud (by design). costs-service is seeding them in parallel.
