### PR TITLE
hotfix: Conform Z.ai and Moonshot cost prefixes to the costs-service catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,12 +274,12 @@ The vendors differ in exactly three things, and all three are *data* in the `VEN
 |---|---|---|---|---|
 | `deepseek` | `deepseek-flash` | `deepseek-v4-flash` | `deepseek-v4-flash` | `https://api.deepseek.com/v1` |
 | `deepseek` | `deepseek-pro` | `deepseek-v4-pro` | `deepseek-v4-pro` | `https://api.deepseek.com/v1` |
-| `zai` | `glm-flash` | `glm-4.7-flashx` | `glm-4.7-flashx` | `https://api.z.ai/api/paas/v4` |
-| `zai` | `glm-pro` | `glm-5.2` | `glm-5.2` | `https://api.z.ai/api/paas/v4` |
-| `moonshot` | `kimi-flash` | `kimi-k2.6` | `kimi-k2.6` | `https://api.moonshot.ai/v1` |
-| `moonshot` | `kimi-pro` | `kimi-k3` | `kimi-k3` | `https://api.moonshot.ai/v1` |
+| `zai` | `glm-flash` | `glm-4.7-flashx` | `zai-glm-4.7-flashx` | `https://api.z.ai/api/paas/v4` |
+| `zai` | `glm-pro` | `glm-5.2` | `zai-glm-5.2` | `https://api.z.ai/api/paas/v4` |
+| `moonshot` | `kimi-flash` | `kimi-k2.6` | `moonshot-kimi-k2.6` | `https://api.moonshot.ai/v1` |
+| `moonshot` | `kimi-pro` | `kimi-k3` | `moonshot-kimi-k3` | `https://api.moonshot.ai/v1` |
 
-Aliases follow one pattern: `<family>-flash` is the cheap tier, `<family>-pro` the strong one. The cost prefix **is** the vendor's own model id, so there is no translation table to drift. Aliases are version-free — we send the undated id and let the vendor resolve the current build (a dated echo like `deepseek-v4-pro-0813` is accepted; a different model is not).
+Aliases follow one pattern: `<family>-flash` is the cheap tier, `<family>-pro` the strong one. The cost prefix follows the costs-service catalog's own shape: the vendor's model id, prefixed with the vendor slug unless the id already names the vendor (`deepseek-v4-flash` stays bare; `glm-5.2` becomes `zai-glm-5.2`). These strings are byte-equal to the catalog rows — a prefix the catalog does not carry is 422-rejected at declaration. Aliases are version-free — we send the undated id and let the vendor resolve the current build (a dated echo like `deepseek-v4-pro-0813` is accepted; a different model is not).
 
 **Scope.** `/complete` and `/internal/platform-complete` only, non-streaming, text in / text out. Not wired: `/chat` (agentic tool-calling is unproven on these models and must be measured first), web search, image input, image generation, embeddings. `webSearch` or `imageUrl` on any of these providers returns **400** naming the vendor, rather than silently answering ungrounded or blind.
 
@@ -339,7 +339,7 @@ Only **connect-phase** failures are retried (a thrown fetch rejection whose caus
 ### Operational prerequisites
 
 1. **One key per vendor** in key-service, stored under that vendor's slug: `deepseek`, `zai`, `moonshot`. Org-scoped calls read `GET /keys/{provider}/decrypt`; `/internal/platform-complete` reads `GET /keys/platform/{provider}/decrypt`. A missing key returns **502** naming the vendor and the slug it must live under — not a generic failure — so "which of the three is unconfigured" is answered by the error itself.
-2. The **three** catalog rows per alias live in production costs-service.
+2. The **three** catalog rows per alias live in production costs-service. As of 2026-08-15 the catalog (costs-service v0.44.0) carries the input/output rows for DeepSeek and Z.ai only: the two Moonshot models and the `-tokens-cached-input` row for **all six** are still outstanding — tracked in [costs-service#205](https://github.com/shamanic-technologies/costs-service/issues/205). Until they land, a Moonshot call and any call that gets a **cache hit** cannot declare its spend: runs-service 422s the cost, which on `/complete` leaves the provisioned hold as the fallback record (the caller still gets its answer) and on `/internal/platform-complete` is a loud 502. A call with no cache hit is unaffected.
 
 ### Replacing the Vercel AI Gateway
 

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -160,8 +160,12 @@ const MODEL_MAP: Record<string, Record<string, ResolvedModel>> = {
   // map, so a vendor's full catalog never becomes OUR catalog: a model is
   // unreachable until someone deliberately adds it here AND to costs-service.
   //
-  // costPrefix is the vendor's own model id, byte-equal — one name, no
-  // translation table to drift.
+  // costPrefix follows the costs-service catalog's own shape (verified against
+  // its seed, v0.44.0): the vendor's model id, prefixed with the vendor slug
+  // UNLESS the id already names the vendor. So `deepseek-v4-flash` stays bare
+  // while `glm-5.2` becomes `zai-glm-5.2`. These strings are byte-equal to the
+  // catalog rows — a prefix the catalog does not carry is 422-rejected at
+  // declaration and fails the request.
   // ---------------------------------------------------------------------
   deepseek: {
     // https://api-docs.deepseek.com/quick_start/pricing — read 2026-08-15.
@@ -184,12 +188,12 @@ const MODEL_MAP: Record<string, Record<string, ResolvedModel>> = {
     // https://docs.z.ai/guides/overview/pricing — read 2026-08-15.
     "glm-flash": {
       apiModelId: "glm-4.7-flashx",
-      costPrefix: "glm-4.7-flashx",
+      costPrefix: "zai-glm-4.7-flashx",
       provider: "zai",
     },
     "glm-pro": {
       apiModelId: "glm-5.2",
-      costPrefix: "glm-5.2",
+      costPrefix: "zai-glm-5.2",
       provider: "zai",
     },
   },
@@ -197,12 +201,12 @@ const MODEL_MAP: Record<string, Record<string, ResolvedModel>> = {
     // https://platform.kimi.ai/docs/pricing/chat — read 2026-08-15.
     "kimi-flash": {
       apiModelId: "kimi-k2.6",
-      costPrefix: "kimi-k2.6",
+      costPrefix: "moonshot-kimi-k2.6",
       provider: "moonshot",
     },
     "kimi-pro": {
       apiModelId: "kimi-k3",
-      costPrefix: "kimi-k3",
+      costPrefix: "moonshot-kimi-k3",
       provider: "moonshot",
     },
   },
@@ -264,10 +268,10 @@ export const SUPPORTED_MODELS: Record<string, string> = {
   // Direct-vendor models: the cost prefix IS the vendor model id.
   "deepseek-v4-flash": "deepseek-v4-flash",
   "deepseek-v4-pro": "deepseek-v4-pro",
-  "glm-4.7-flashx": "glm-4.7-flashx",
-  "glm-5.2": "glm-5.2",
-  "kimi-k2.6": "kimi-k2.6",
-  "kimi-k3": "kimi-k3",
+  "glm-4.7-flashx": "zai-glm-4.7-flashx",
+  "glm-5.2": "zai-glm-5.2",
+  "kimi-k2.6": "moonshot-kimi-k2.6",
+  "kimi-k3": "moonshot-kimi-k3",
 };
 
 /** Resolve the cost prefix for a given model ID (falls back to default). */

--- a/tests/integration/vendor-complete-cost.test.ts
+++ b/tests/integration/vendor-complete-cost.test.ts
@@ -221,10 +221,10 @@ describe("POST /complete — direct vendor routing", () => {
   const CASES = [
     { provider: "deepseek", model: "deepseek-flash", host: DEEPSEEK_URL, wire: "deepseek-v4-flash", prefix: "deepseek-v4-flash" },
     { provider: "deepseek", model: "deepseek-pro", host: DEEPSEEK_URL, wire: "deepseek-v4-pro", prefix: "deepseek-v4-pro" },
-    { provider: "zai", model: "glm-flash", host: ZAI_URL, wire: "glm-4.7-flashx", prefix: "glm-4.7-flashx" },
-    { provider: "zai", model: "glm-pro", host: ZAI_URL, wire: "glm-5.2", prefix: "glm-5.2" },
-    { provider: "moonshot", model: "kimi-flash", host: MOONSHOT_URL, wire: "kimi-k2.6", prefix: "kimi-k2.6" },
-    { provider: "moonshot", model: "kimi-pro", host: MOONSHOT_URL, wire: "kimi-k3", prefix: "kimi-k3" },
+    { provider: "zai", model: "glm-flash", host: ZAI_URL, wire: "glm-4.7-flashx", prefix: "zai-glm-4.7-flashx" },
+    { provider: "zai", model: "glm-pro", host: ZAI_URL, wire: "glm-5.2", prefix: "zai-glm-5.2" },
+    { provider: "moonshot", model: "kimi-flash", host: MOONSHOT_URL, wire: "kimi-k2.6", prefix: "moonshot-kimi-k2.6" },
+    { provider: "moonshot", model: "kimi-pro", host: MOONSHOT_URL, wire: "kimi-k3", prefix: "moonshot-kimi-k3" },
   ] as const;
 
   for (const c of CASES) {
@@ -357,8 +357,8 @@ describe("POST /complete — direct vendor routing", () => {
 
     expect(res.status).toBe(200);
     const actual = actualItems(cap.postedItems);
-    expect(quantityOf(actual, "glm-5.2-tokens-input")).toBe(50);
-    expect(quantityOf(actual, "glm-5.2-tokens-cached-input")).toBe(750);
+    expect(quantityOf(actual, "zai-glm-5.2-tokens-input")).toBe(50);
+    expect(quantityOf(actual, "zai-glm-5.2-tokens-cached-input")).toBe(750);
   });
 
   it("bills Moonshot cache hits from the flat cached_tokens field", async () => {
@@ -384,8 +384,8 @@ describe("POST /complete — direct vendor routing", () => {
 
     expect(res.status).toBe(200);
     const actual = actualItems(cap.postedItems);
-    expect(quantityOf(actual, "kimi-k3-tokens-input")).toBe(60);
-    expect(quantityOf(actual, "kimi-k3-tokens-cached-input")).toBe(540);
+    expect(quantityOf(actual, "moonshot-kimi-k3-tokens-input")).toBe(60);
+    expect(quantityOf(actual, "moonshot-kimi-k3-tokens-cached-input")).toBe(540);
   });
 
   it("declares NO cached-input row when the vendor reported no cache hit", async () => {
@@ -575,9 +575,9 @@ describe("POST /internal/platform-complete — direct vendor routing", () => {
     expect(vendor.bodies[0].model).toBe("kimi-k2.6");
 
     const actual = costCap.postedItems[0];
-    expect(quantityOf(actual, "kimi-k2.6-tokens-input")).toBe(40);
-    expect(quantityOf(actual, "kimi-k2.6-tokens-cached-input")).toBe(360);
-    expect(quantityOf(actual, "kimi-k2.6-tokens-output")).toBe(25);
+    expect(quantityOf(actual, "moonshot-kimi-k2.6-tokens-input")).toBe(40);
+    expect(quantityOf(actual, "moonshot-kimi-k2.6-tokens-cached-input")).toBe(360);
+    expect(quantityOf(actual, "moonshot-kimi-k2.6-tokens-output")).toBe(25);
     // Platform runs post actuals only — no provision, no hold.
     expect(actual.every((i) => i.status === undefined)).toBe(true);
     expect(actual.every((i) => i.costSource === "platform")).toBe(true);

--- a/tests/unit/openai-compatible.test.ts
+++ b/tests/unit/openai-compatible.test.ts
@@ -25,10 +25,10 @@ const MODEL = "deepseek-v4-flash";
 const ALIASES = [
   { provider: "deepseek", alias: "deepseek-flash", modelId: "deepseek-v4-flash", prefix: "deepseek-v4-flash" },
   { provider: "deepseek", alias: "deepseek-pro", modelId: "deepseek-v4-pro", prefix: "deepseek-v4-pro" },
-  { provider: "zai", alias: "glm-flash", modelId: "glm-4.7-flashx", prefix: "glm-4.7-flashx" },
-  { provider: "zai", alias: "glm-pro", modelId: "glm-5.2", prefix: "glm-5.2" },
-  { provider: "moonshot", alias: "kimi-flash", modelId: "kimi-k2.6", prefix: "kimi-k2.6" },
-  { provider: "moonshot", alias: "kimi-pro", modelId: "kimi-k3", prefix: "kimi-k3" },
+  { provider: "zai", alias: "glm-flash", modelId: "glm-4.7-flashx", prefix: "zai-glm-4.7-flashx" },
+  { provider: "zai", alias: "glm-pro", modelId: "glm-5.2", prefix: "zai-glm-5.2" },
+  { provider: "moonshot", alias: "kimi-flash", modelId: "kimi-k2.6", prefix: "moonshot-kimi-k2.6" },
+  { provider: "moonshot", alias: "kimi-pro", modelId: "kimi-k3", prefix: "moonshot-kimi-k3" },
 ] as const;
 
 function okBody(overrides: Record<string, unknown> = {}) {


### PR DESCRIPTION
Automated by release.sh