### PR TITLE
fix(cost): Moonshot is priced now, so stop refusing its calls

### DIFF
--- a/src/lib/cost-names.ts
+++ b/src/lib/cost-names.ts
@@ -11,7 +11,8 @@
 //             tokens-{input,cached-input,output}`.
 //   Z.ai      cache-hit input priced apart from a miss, no schedule → 3 names
 //             per model, `zai-glm-5.2-tokens-{input,cached-input,output}`.
-//   Moonshot  nothing seeded yet — its prices are unconfirmed.
+//   Moonshot  cache-hit input priced apart from a miss, no schedule → 3 names
+//             per model, `moonshot-kimi-k3-tokens-{input,cached-input,output}`.
 //   Anthropic / Google  the flat `<prefix>-tokens-{input,cached-input,output}`
 //             shape they have always used. Untouched by this module's vendor
 //             logic; `flatCostNames` reproduces those strings byte-equal.

--- a/src/lib/openai-compatible.ts
+++ b/src/lib/openai-compatible.ts
@@ -193,14 +193,11 @@ export const VENDORS: Record<VendorId, VendorConfig> = {
     // the count (and with it the cache discount).
     readCachedTokens: (usage) =>
       usage.cached_tokens ?? usage.prompt_tokens_details?.cached_tokens ?? 0,
-    // costs-service carries no Moonshot rows: the vendor's prices are not
-    // confirmed. A Kimi call therefore fails loud at declaration rather than
-    // billing against a guessed or borrowed name — a wrong price is silent, a
-    // missing one is not.
-    pricing: {
-      kind: "unpriced",
-      reason: "Moonshot prices are unconfirmed, so no rows were seeded.",
-    },
+    // Priced since costs-service v0.46.0, which read the per-model pages the
+    // pricing index does not carry figures on. Cache-hit input is its own row at
+    // the vendor's own rate; Moonshot publishes no time-of-day schedule, so the
+    // names carry no regime segment — the same shape as Z.ai.
+    pricing: { kind: "priced", cachedInput: true, regime: null },
   },
 };
 

--- a/tests/unit/cost-names.test.ts
+++ b/tests/unit/cost-names.test.ts
@@ -3,7 +3,6 @@ import {
   buildLlmCostNames,
   flatCostNames,
   selectPricingRegime,
-  UnpricedModelError,
 } from "../../src/lib/cost-names.js";
 import { VENDORS } from "../../src/lib/openai-compatible.js";
 
@@ -106,22 +105,35 @@ describe("buildLlmCostNames — per-vendor dimensions", () => {
     expect(offHour).toEqual(peakHour);
   });
 
-  it("Moonshot: fails loud, naming every missing row", () => {
-    let thrown: unknown;
-    try {
-      buildLlmCostNames({ provider: "moonshot", costPrefix: "moonshot-kimi-k3", at: at("2026-08-20T02:00:00Z") });
-    } catch (err) {
-      thrown = err;
-    }
-    expect(thrown).toBeInstanceOf(UnpricedModelError);
-    const err = thrown as UnpricedModelError;
-    expect(err.missingCostNames).toEqual([
-      "moonshot-kimi-k3-tokens-input",
-      "moonshot-kimi-k3-tokens-cached-input",
-      "moonshot-kimi-k3-tokens-output",
-    ]);
-    expect(err.message).toContain("moonshot-kimi-k3-tokens-input");
-    expect(err.message).toContain("costs-service");
+  // Moonshot was unpriced until costs-service v0.46.0 read its per-model pages.
+  // It prices a cache hit apart from a miss and publishes no time-of-day
+  // schedule, so it takes the same three-name shape as Z.ai — no regime segment.
+  it("Moonshot: cached input priced apart, and no regime in the name", () => {
+    const names = buildLlmCostNames({
+      provider: "moonshot",
+      costPrefix: "moonshot-kimi-k3",
+      at: at("2026-08-20T02:00:00Z"),
+    });
+    expect(names).toEqual({
+      input: "moonshot-kimi-k3-tokens-input",
+      cachedInput: "moonshot-kimi-k3-tokens-cached-input",
+      output: "moonshot-kimi-k3-tokens-output",
+    });
+  });
+
+  it("Moonshot: the same names at every hour, because it has no peak schedule", () => {
+    const peakHour = buildLlmCostNames({
+      provider: "moonshot",
+      costPrefix: "moonshot-kimi-k2.6",
+      at: at("2026-08-20T02:00:00Z"),
+    });
+    const offPeakHour = buildLlmCostNames({
+      provider: "moonshot",
+      costPrefix: "moonshot-kimi-k2.6",
+      at: at("2026-08-20T14:00:00Z"),
+    });
+    expect(peakHour).toEqual(offPeakHour);
+    expect(peakHour.input).not.toContain("peak");
   });
 
   it("Anthropic and Google keep the flat names, unchanged", () => {


### PR DESCRIPTION
costs-service **v0.46.0** seeded the six Moonshot rows — it found the figures on the per-model pages that the pricing index does not carry. This service still held the marker saying they did not exist, so both Kimi models failed at declaration with an error telling someone to seed rows that were already there.

Verified in production just now:

```
kimi-flash  502  [cost] Moonshot (Kimi) model "moonshot-kimi-k2.6" has no price ...
kimi-pro    502  [cost] Moonshot (Kimi) model "moonshot-kimi-k3"   has no price ...
```

…while `SELECT count(*) FROM providers_costs WHERE name LIKE 'moonshot%'` returns **6**.

The guard did its job — it refused to bill against a name it could not price, and named exactly what was missing. It was just asserting a fact that had stopped being true.

## Shape

Moonshot prices a cache hit apart from a miss and publishes no time-of-day schedule, so it takes the same three-name shape as Z.ai, with **no regime segment**. The cost prefixes already matched what costs-service seeded, so nothing else moves.

The stale test (`Moonshot: fails loud, naming every missing row`) is replaced by two that pin the new shape, including that the names are identical at a peak hour and an off-peak one — Moonshot has no schedule and must not acquire one by copy-paste from DeepSeek.

## ⚠️ Tests not run locally

`pnpm install` fails in this environment (`ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING` from corepack) and neither the clone nor the worktree has `node_modules`. `tsc --noEmit` is clean; **CI is the gate for the unit tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)