### PR TITLE
feat(zai): point the glm-pro alias at GLM-5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Request body:
   - **anthropic**: `haiku` (fast/cheap), `sonnet` (balanced), `opus` (highest quality)
   - **google**: `flash-lite` (cheapest, vision, Gemini 3.1 Flash-Lite), `flash` (Gemini 3.5 Flash-Lite), `flash-pro` (mid-tier default, Gemini 3.7 Flash), `pro` (most powerful, Gemini 3.1 Pro). All require a Google API key in key-service.
   - **deepseek**: `deepseek-flash` (DeepSeek V4 Flash — cheapest per unit of intelligence, 1M context), `deepseek-pro` (DeepSeek V4 Pro — the reasoning-heavy sibling)
-  - **zai**: `glm-flash` (`glm-4.7-flashx` — fast and very cheap), `glm-pro` (`glm-5.2` — Z.ai's flagship)
+  - **zai**: `glm-flash` (`glm-4.7-flashx` — fast and very cheap), `glm-pro` (`glm-5.3` — Z.ai's flagship)
   - **moonshot**: `kimi-flash` (`kimi-k2.6` — value tier), `kimi-pro` (`kimi-k3` — flagship, 1M context)
 
   The three direct-vendor providers are **text only**: `imageUrl` and `webSearch` are rejected with 400 on every one of their models. Each needs its OWN key in key-service, stored under its provider slug.
@@ -275,11 +275,11 @@ The vendors differ in exactly four things, and all four are *data* in the `VENDO
 | `deepseek` | `deepseek-flash` | `deepseek-v4-flash` | `deepseek-v4-flash` | cache + regime | `https://api.deepseek.com/v1` |
 | `deepseek` | `deepseek-pro` | `deepseek-v4-pro` | `deepseek-v4-pro` | cache + regime | `https://api.deepseek.com/v1` |
 | `zai` | `glm-flash` | `glm-4.7-flashx` | `zai-glm-4.7-flashx` | cache | `https://api.z.ai/api/paas/v4` |
-| `zai` | `glm-pro` | `glm-5.2` | `zai-glm-5.2` | cache | `https://api.z.ai/api/paas/v4` |
+| `zai` | `glm-pro` | `glm-5.3` | `zai-glm-5.3` | cache | `https://api.z.ai/api/paas/v4` |
 | `moonshot` | `kimi-flash` | `kimi-k2.6` | `moonshot-kimi-k2.6` | none seeded → 502 | `https://api.moonshot.ai/v1` |
 | `moonshot` | `kimi-pro` | `kimi-k3` | `moonshot-kimi-k3` | none seeded → 502 | `https://api.moonshot.ai/v1` |
 
-Aliases follow one pattern: `<family>-flash` is the cheap tier, `<family>-pro` the strong one. The cost prefix follows the costs-service catalog's own shape: the vendor's model id, prefixed with the vendor slug unless the id already names the vendor (`deepseek-v4-flash` stays bare; `glm-5.2` becomes `zai-glm-5.2`). These strings are byte-equal to the catalog rows — a prefix the catalog does not carry is 422-rejected at declaration. Aliases are version-free — we send the undated id and let the vendor resolve the current build (a dated echo like `deepseek-v4-pro-0813` is accepted; a different model is not).
+Aliases follow one pattern: `<family>-flash` is the cheap tier, `<family>-pro` the strong one. The cost prefix follows the costs-service catalog's own shape: the vendor's model id, prefixed with the vendor slug unless the id already names the vendor (`deepseek-v4-flash` stays bare; `glm-5.3` becomes `zai-glm-5.3`). These strings are byte-equal to the catalog rows — a prefix the catalog does not carry is 422-rejected at declaration. Aliases are version-free — we send the undated id and let the vendor resolve the current build (a dated echo like `deepseek-v4-pro-0813` is accepted; a different model is not). `glm-pro` pointed at `glm-5.2` until 2026-08-20; Z.ai publishes GLM-5.3 as a drop-in swap at an identical list price, so the alias moved and callers saw no contract change.
 
 **Scope.** `/complete` and `/internal/platform-complete` only, non-streaming, text in / text out. Not wired: `/chat` (agentic tool-calling is unproven on these models and must be measured first), web search, image input, image generation, embeddings. `webSearch` or `imageUrl` on any of these providers returns **400** naming the vendor, rather than silently answering ungrounded or blind.
 
@@ -315,7 +315,7 @@ Each vendor reports the count in a different place, which is the entire reason `
 | Vendor | Field | Cache-hit vs miss (per 1M input) |
 |---|---|---|
 | DeepSeek | `usage.prompt_cache_hit_tokens` | $0.014 vs $0.44 (V4 Flash, peak) — 31x |
-| Z.ai | `usage.prompt_tokens_details.cached_tokens` | $0.26 vs $1.40 (`glm-5.2`) |
+| Z.ai | `usage.prompt_tokens_details.cached_tokens` | $0.26 vs $1.40 (`glm-5.3`) |
 | Moonshot | `usage.cached_tokens` | $0.30 vs $3.00 (`kimi-k3`) |
 
 A cached count larger than the prompt total is clamped: a negative fresh-token quantity would make runs-service reject the whole declaration and fail a call that actually succeeded.

--- a/openapi.json
+++ b/openapi.json
@@ -767,7 +767,7 @@
               "kimi-flash",
               "kimi-pro"
             ],
-            "description": "Model alias (version-free). The service resolves the current versioned model internally.\n\n**anthropic:** `haiku` (fast/cheap), `sonnet` (balanced), `opus` (highest quality).\n**google:** `flash-lite` (cheapest, vision), `flash` (balanced, reasoning), `flash-pro` (mid-tier, Gemini 3.7 Flash), `pro` (most powerful).\n**deepseek:** `deepseek-flash` → DeepSeek V4 Flash (cheapest per unit of intelligence; 1M context), `deepseek-pro` → DeepSeek V4 Pro (reasoning-heavy sibling).\n**zai:** `glm-flash` → `glm-4.7-flashx` (fast, very cheap), `glm-pro` → `glm-5.2` (flagship).\n**moonshot:** `kimi-flash` → `kimi-k2.6` (value tier), `kimi-pro` → `kimi-k3` (flagship, 1M context).\n\nThe three direct-vendor providers are **text only**: `imageUrl` and `webSearch` are rejected with 400.\n\nThe model must match the provider: anthropic → haiku|sonnet|opus, google → flash-lite|flash|flash-pro|pro, deepseek → deepseek-flash|deepseek-pro, zai → glm-flash|glm-pro, moonshot → kimi-flash|kimi-pro.",
+            "description": "Model alias (version-free). The service resolves the current versioned model internally.\n\n**anthropic:** `haiku` (fast/cheap), `sonnet` (balanced), `opus` (highest quality).\n**google:** `flash-lite` (cheapest, vision), `flash` (balanced, reasoning), `flash-pro` (mid-tier, Gemini 3.7 Flash), `pro` (most powerful).\n**deepseek:** `deepseek-flash` → DeepSeek V4 Flash (cheapest per unit of intelligence; 1M context), `deepseek-pro` → DeepSeek V4 Pro (reasoning-heavy sibling).\n**zai:** `glm-flash` → `glm-4.7-flashx` (fast, very cheap), `glm-pro` → `glm-5.3` (flagship).\n**moonshot:** `kimi-flash` → `kimi-k2.6` (value tier), `kimi-pro` → `kimi-k3` (flagship, 1M context).\n\nThe three direct-vendor providers are **text only**: `imageUrl` and `webSearch` are rejected with 400.\n\nThe model must match the provider: anthropic → haiku|sonnet|opus, google → flash-lite|flash|flash-pro|pro, deepseek → deepseek-flash|deepseek-pro, zai → glm-flash|glm-pro, moonshot → kimi-flash|kimi-pro.",
             "example": "sonnet"
           },
           "webSearch": {
@@ -959,7 +959,7 @@
               "kimi-flash",
               "kimi-pro"
             ],
-            "description": "Model alias (version-free). Must match the provider: anthropic → haiku|sonnet|opus, google → flash-lite|flash|flash-pro|pro, deepseek → deepseek-flash|deepseek-pro (DeepSeek V4 Flash / V4 Pro), zai → glm-flash|glm-pro (`glm-4.7-flashx` / `glm-5.2`), moonshot → kimi-flash|kimi-pro (`kimi-k2.6` / `kimi-k3`). The direct-vendor models are text-only: `webSearch` is rejected with 400.",
+            "description": "Model alias (version-free). Must match the provider: anthropic → haiku|sonnet|opus, google → flash-lite|flash|flash-pro|pro, deepseek → deepseek-flash|deepseek-pro (DeepSeek V4 Flash / V4 Pro), zai → glm-flash|glm-pro (`glm-4.7-flashx` / `glm-5.3`), moonshot → kimi-flash|kimi-pro (`kimi-k2.6` / `kimi-k3`). The direct-vendor models are text-only: `webSearch` is rejected with 400.",
             "example": "sonnet"
           },
           "webSearch": {

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -163,7 +163,7 @@ const MODEL_MAP: Record<string, Record<string, ResolvedModel>> = {
   // costPrefix follows the costs-service catalog's own shape (verified against
   // its seed, v0.44.0): the vendor's model id, prefixed with the vendor slug
   // UNLESS the id already names the vendor. So `deepseek-v4-flash` stays bare
-  // while `glm-5.2` becomes `zai-glm-5.2`. These strings are byte-equal to the
+  // while `glm-5.3` becomes `zai-glm-5.3`. These strings are byte-equal to the
   // catalog rows — a prefix the catalog does not carry is 422-rejected at
   // declaration and fails the request.
   // ---------------------------------------------------------------------
@@ -191,9 +191,14 @@ const MODEL_MAP: Record<string, Record<string, ResolvedModel>> = {
       costPrefix: "zai-glm-4.7-flashx",
       provider: "zai",
     },
+    // GLM-5.3 (released 2026-08-20) replaced GLM-5.2 here: Z.ai publishes it as
+    // a drop-in swap at an identical list price ($1.4 / $0.26 cached / $4.4 per
+    // 1M), so `glm-pro` keeps meaning "Z.ai's flagship" and callers see no
+    // contract change. GLM-5.2 is no longer reachable — reaching it again would
+    // be a deliberate fourth alias, not a fallback.
     "glm-pro": {
-      apiModelId: "glm-5.2",
-      costPrefix: "zai-glm-5.2",
+      apiModelId: "glm-5.3",
+      costPrefix: "zai-glm-5.3",
       provider: "zai",
     },
   },
@@ -270,6 +275,7 @@ export const SUPPORTED_MODELS: Record<string, string> = {
   "deepseek-v4-pro": "deepseek-v4-pro",
   "glm-4.7-flashx": "zai-glm-4.7-flashx",
   "glm-5.2": "zai-glm-5.2",
+  "glm-5.3": "zai-glm-5.3",
   "kimi-k2.6": "moonshot-kimi-k2.6",
   "kimi-k3": "moonshot-kimi-k3",
 };

--- a/src/lib/cost-names.ts
+++ b/src/lib/cost-names.ts
@@ -10,7 +10,7 @@
 //             schedule → 12 names, `deepseek-v4-{flash,pro}-{peak,off-peak}-
 //             tokens-{input,cached-input,output}`.
 //   Z.ai      cache-hit input priced apart from a miss, no schedule → 3 names
-//             per model, `zai-glm-5.2-tokens-{input,cached-input,output}`.
+//             per model, `zai-glm-5.3-tokens-{input,cached-input,output}`.
 //   Moonshot  cache-hit input priced apart from a miss, no schedule → 3 names
 //             per model, `moonshot-kimi-k3-tokens-{input,cached-input,output}`.
 //   Anthropic / Google  the flat `<prefix>-tokens-{input,cached-input,output}`

--- a/src/lib/openai-compatible.ts
+++ b/src/lib/openai-compatible.ts
@@ -222,7 +222,7 @@ export const VENDORS: Record<VendorId, VendorConfig> = {
     isOutOfCreditRefusal: (s) => s.status === 402 || EMPTY_BALANCE_PROSE.test(s.text),
   },
   // https://docs.z.ai/api-reference/llm/chat-completion — read 2026-08-15.
-  // Cached input $0.26 vs $1.4 per 1M on glm-5.2; $0.01 vs $0.07 on flashx.
+  // Cached input $0.26 vs $1.4 per 1M on glm-5.3; $0.01 vs $0.07 on flashx.
   zai: {
     id: "zai",
     label: "Z.ai",
@@ -336,7 +336,7 @@ export function vendorConfig(provider: string): VendorConfig {
 export interface VendorCompleteOptions {
   vendor: VendorId;
   apiKey: string;
-  /** Vendor model id, e.g. "deepseek-v4-flash", "glm-5.2", "kimi-k3". */
+  /** Vendor model id, e.g. "deepseek-v4-flash", "glm-5.3", "kimi-k3". */
   model: string;
   message: string;
   systemPrompt?: string;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -449,7 +449,7 @@ export const CompleteRequestSchema = z
         "**google:** `flash-lite` (cheapest, vision), `flash` (balanced, reasoning), `flash-pro` (mid-tier, Gemini 3.7 Flash), `pro` (most powerful).\n" +
         "**deepseek:** `deepseek-flash` → DeepSeek V4 Flash (cheapest per unit of intelligence; 1M context), " +
         "`deepseek-pro` → DeepSeek V4 Pro (reasoning-heavy sibling).\n" +
-        "**zai:** `glm-flash` → `glm-4.7-flashx` (fast, very cheap), `glm-pro` → `glm-5.2` (flagship).\n" +
+        "**zai:** `glm-flash` → `glm-4.7-flashx` (fast, very cheap), `glm-pro` → `glm-5.3` (flagship).\n" +
         "**moonshot:** `kimi-flash` → `kimi-k2.6` (value tier), `kimi-pro` → `kimi-k3` (flagship, 1M context).\n\n" +
         "The three direct-vendor providers are **text only**: `imageUrl` and `webSearch` are rejected with 400.\n\n" +
         "The model must match the provider: anthropic → haiku|sonnet|opus, google → flash-lite|flash|flash-pro|pro, " +
@@ -789,7 +789,7 @@ export const InternalPlatformCompleteRequestSchema = z
       description:
         "Model alias (version-free). Must match the provider: anthropic → haiku|sonnet|opus, " +
         "google → flash-lite|flash|flash-pro|pro, deepseek → deepseek-flash|deepseek-pro " +
-        "(DeepSeek V4 Flash / V4 Pro), zai → glm-flash|glm-pro (`glm-4.7-flashx` / `glm-5.2`), " +
+        "(DeepSeek V4 Flash / V4 Pro), zai → glm-flash|glm-pro (`glm-4.7-flashx` / `glm-5.3`), " +
         "moonshot → kimi-flash|kimi-pro (`kimi-k2.6` / `kimi-k3`). The direct-vendor models are " +
         "text-only: `webSearch` is rejected with 400.",
       example: "sonnet",

--- a/tests/integration/vendor-complete-cost.test.ts
+++ b/tests/integration/vendor-complete-cost.test.ts
@@ -235,7 +235,7 @@ describe("POST /complete — direct vendor routing", () => {
     { provider: "deepseek", model: "deepseek-flash", host: DEEPSEEK_URL, wire: "deepseek-v4-flash", prefix: "deepseek-v4-flash-peak" },
     { provider: "deepseek", model: "deepseek-pro", host: DEEPSEEK_URL, wire: "deepseek-v4-pro", prefix: "deepseek-v4-pro-peak" },
     { provider: "zai", model: "glm-flash", host: ZAI_URL, wire: "glm-4.7-flashx", prefix: "zai-glm-4.7-flashx" },
-    { provider: "zai", model: "glm-pro", host: ZAI_URL, wire: "glm-5.2", prefix: "zai-glm-5.2" },
+    { provider: "zai", model: "glm-pro", host: ZAI_URL, wire: "glm-5.3", prefix: "zai-glm-5.3" },
   ] as const;
 
   for (const c of CASES) {
@@ -286,7 +286,7 @@ describe("POST /complete — direct vendor routing", () => {
       mockRunsCreate(),
       mockVendorKey("zai"),
       mockBilling(),
-      mockVendor(vendor, { host: ZAI_URL, model: "glm-5.2", usage: { prompt_tokens: 10, completion_tokens: 2 } }),
+      mockVendor(vendor, { host: ZAI_URL, model: "glm-5.3", usage: { prompt_tokens: 10, completion_tokens: 2 } }),
       ...mockRunsCostRoutes(cap),
       mockRunsStatusPatch(),
     );
@@ -359,7 +359,7 @@ describe("POST /complete — direct vendor routing", () => {
       mockBilling(),
       mockVendor(vendor, {
         host: ZAI_URL,
-        model: "glm-5.2",
+        model: "glm-5.3",
         usage: { prompt_tokens: 800, completion_tokens: 15, prompt_tokens_details: { cached_tokens: 750 } },
       }),
       ...mockRunsCostRoutes(cap),
@@ -373,8 +373,8 @@ describe("POST /complete — direct vendor routing", () => {
 
     expect(res.status).toBe(200);
     const actual = actualItems(cap.postedItems);
-    expect(quantityOf(actual, "zai-glm-5.2-tokens-input")).toBe(50);
-    expect(quantityOf(actual, "zai-glm-5.2-tokens-cached-input")).toBe(750);
+    expect(quantityOf(actual, "zai-glm-5.3-tokens-input")).toBe(50);
+    expect(quantityOf(actual, "zai-glm-5.3-tokens-cached-input")).toBe(750);
   });
 
   it("declares DeepSeek against the off-peak names one minute after a peak window closes", async () => {
@@ -729,7 +729,7 @@ describe("POST /internal/platform-complete — direct vendor routing", () => {
       mockPlatformRunStatus(),
       mockVendor(vendor, {
         host: ZAI_URL,
-        model: "glm-5.2",
+        model: "glm-5.3",
         usage: { prompt_tokens: 300, completion_tokens: 8, prompt_tokens_details: { cached_tokens: 250 } },
       }),
     );
@@ -741,8 +741,8 @@ describe("POST /internal/platform-complete — direct vendor routing", () => {
 
     expect(res.status).toBe(200);
     const actual = costCap.postedItems[0];
-    expect(quantityOf(actual, "zai-glm-5.2-tokens-input")).toBe(50);
-    expect(quantityOf(actual, "zai-glm-5.2-tokens-cached-input")).toBe(250);
+    expect(quantityOf(actual, "zai-glm-5.3-tokens-input")).toBe(50);
+    expect(quantityOf(actual, "zai-glm-5.3-tokens-cached-input")).toBe(250);
     expect(actual.every((i) => !i.costName.includes("peak"))).toBe(true);
   });
 

--- a/tests/unit/cost-names.test.ts
+++ b/tests/unit/cost-names.test.ts
@@ -96,12 +96,12 @@ describe("buildLlmCostNames — per-vendor dimensions", () => {
   });
 
   it("Z.ai: cached input, no regime — the hour changes nothing", () => {
-    const peakHour = buildLlmCostNames({ provider: "zai", costPrefix: "zai-glm-5.2", at: at("2026-08-20T02:00:00Z") });
-    const offHour = buildLlmCostNames({ provider: "zai", costPrefix: "zai-glm-5.2", at: at("2026-08-20T12:00:00Z") });
+    const peakHour = buildLlmCostNames({ provider: "zai", costPrefix: "zai-glm-5.3", at: at("2026-08-20T02:00:00Z") });
+    const offHour = buildLlmCostNames({ provider: "zai", costPrefix: "zai-glm-5.3", at: at("2026-08-20T12:00:00Z") });
     expect(peakHour).toEqual({
-      input: "zai-glm-5.2-tokens-input",
-      cachedInput: "zai-glm-5.2-tokens-cached-input",
-      output: "zai-glm-5.2-tokens-output",
+      input: "zai-glm-5.3-tokens-input",
+      cachedInput: "zai-glm-5.3-tokens-cached-input",
+      output: "zai-glm-5.3-tokens-output",
     });
     expect(offHour).toEqual(peakHour);
   });
@@ -128,7 +128,7 @@ describe("buildLlmCostNames — per-vendor dimensions", () => {
       ["deepseek", "deepseek-v4-flash"],
       ["deepseek", "deepseek-v4-pro"],
       ["zai", "zai-glm-4.7-flashx"],
-      ["zai", "zai-glm-5.2"],
+      ["zai", "zai-glm-5.3"],
       ["moonshot", "moonshot-kimi-k2.6"],
       ["moonshot", "moonshot-kimi-k3"],
     ];

--- a/tests/unit/openai-compatible.test.ts
+++ b/tests/unit/openai-compatible.test.ts
@@ -26,7 +26,7 @@ const ALIASES = [
   { provider: "deepseek", alias: "deepseek-flash", modelId: "deepseek-v4-flash", prefix: "deepseek-v4-flash" },
   { provider: "deepseek", alias: "deepseek-pro", modelId: "deepseek-v4-pro", prefix: "deepseek-v4-pro" },
   { provider: "zai", alias: "glm-flash", modelId: "glm-4.7-flashx", prefix: "zai-glm-4.7-flashx" },
-  { provider: "zai", alias: "glm-pro", modelId: "glm-5.2", prefix: "zai-glm-5.2" },
+  { provider: "zai", alias: "glm-pro", modelId: "glm-5.3", prefix: "zai-glm-5.3" },
   { provider: "moonshot", alias: "kimi-flash", modelId: "kimi-k2.6", prefix: "moonshot-kimi-k2.6" },
   { provider: "moonshot", alias: "kimi-pro", modelId: "kimi-k3", prefix: "moonshot-kimi-k3" },
 ] as const;
@@ -250,7 +250,7 @@ describe("buildVendorRequestBody", () => {
 
   it("forwards the caller's systemPrompt byte-equal (no preamble, no nudge)", () => {
     const systemPrompt = "Return ONLY the value. Do not explain.";
-    const body = buildVendorRequestBody({ vendor: "zai", apiKey: "k", model: "glm-5.2", message: "m", systemPrompt });
+    const body = buildVendorRequestBody({ vendor: "zai", apiKey: "k", model: "glm-5.3", message: "m", systemPrompt });
     const messages = body.messages as Array<{ role: string; content: string }>;
     expect(messages.find((m) => m.role === "system")?.content).toBe(systemPrompt);
   });
@@ -316,7 +316,7 @@ describe("assertModelMatches", () => {
 
   it("throws when the vendor served a different model", () => {
     expect(() => assertModelMatches(MODEL, "deepseek-v4-pro")).toThrow(/Model mismatch/);
-    expect(() => assertModelMatches("glm-5.2", "glm-4.7")).toThrow(/Model mismatch/);
+    expect(() => assertModelMatches("glm-5.3", "glm-4.7")).toThrow(/Model mismatch/);
   });
 
   it("tolerates a missing model echo rather than inventing a mismatch", () => {
@@ -350,10 +350,10 @@ describe("mapVendorResponse", () => {
 
   it("carries Z.ai's nested cached_tokens", () => {
     const body = okBody({
-      model: "glm-5.2",
+      model: "glm-5.3",
       usage: { prompt_tokens: 500, completion_tokens: 10, prompt_tokens_details: { cached_tokens: 460 } },
     });
-    const r = mapVendorResponse("zai", "glm-5.2", body);
+    const r = mapVendorResponse("zai", "glm-5.3", body);
     expect(r.cachedInputTokens).toBe(460);
   });
 
@@ -422,7 +422,7 @@ describe("completeWithVendor", () => {
 
   const endpoints: Array<[VendorId, string, string]> = [
     ["deepseek", "deepseek-v4-flash", "https://api.deepseek.com/v1/chat/completions"],
-    ["zai", "glm-5.2", "https://api.z.ai/api/paas/v4/chat/completions"],
+    ["zai", "glm-5.3", "https://api.z.ai/api/paas/v4/chat/completions"],
     ["moonshot", "kimi-k3", "https://api.moonshot.ai/v1/chat/completions"],
   ];
 
@@ -482,7 +482,7 @@ describe("completeWithVendor", () => {
     globalThis.fetch = fetchMock as unknown as typeof fetch;
 
     await expect(
-      completeWithVendor({ vendor: "zai", apiKey: "k", model: "glm-5.2", message: "m" }),
+      completeWithVendor({ vendor: "zai", apiKey: "k", model: "glm-5.3", message: "m" }),
     ).rejects.toThrow(/503/);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0][0]).toBe("https://api.z.ai/api/paas/v4/chat/completions");

--- a/tests/unit/vendor-credit-alert.test.ts
+++ b/tests/unit/vendor-credit-alert.test.ts
@@ -180,7 +180,7 @@ describe("alert latch", () => {
   const context = (vendor: VendorId) => ({
     vendor,
     vendorLabel: vendor.toUpperCase(),
-    model: "glm-5.2",
+    model: "glm-5.3",
     status: 429,
     vendorMessage: "Insufficient balance",
   });
@@ -309,8 +309,8 @@ describe("completeWithVendor wiring", () => {
         ),
     );
 
-    await expect(completeWithVendor(options("zai", "glm-5.2"))).rejects.toThrow(VendorProviderError);
-    await expect(completeWithVendor(options("zai", "glm-5.2"))).rejects.toThrow(/429 from glm-5.2/);
+    await expect(completeWithVendor(options("zai", "glm-5.3"))).rejects.toThrow(VendorProviderError);
+    await expect(completeWithVendor(options("zai", "glm-5.3"))).rejects.toThrow(/429 from glm-5.3/);
 
     await vi.waitFor(() => expect(emailCalls).toHaveLength(1));
     expect(JSON.parse(emailCalls[0].body as string).metadata.vendorSlug).toBe("zai");
@@ -325,7 +325,7 @@ describe("completeWithVendor wiring", () => {
         ),
     );
 
-    await expect(completeWithVendor(options("zai", "glm-5.2"))).rejects.toThrow(VendorProviderError);
+    await expect(completeWithVendor(options("zai", "glm-5.3"))).rejects.toThrow(VendorProviderError);
     expect(emailCalls).toHaveLength(0);
     expect(isVendorCreditAlertLatched("zai")).toBe(false);
   });


### PR DESCRIPTION
## What

Points the `glm-pro` alias at **GLM-5.3** instead of GLM-5.2 on the direct Z.ai vendor path.

Z.ai released GLM-5.3 on 2026-08-20 and publishes it as a drop-in swap at an identical list price — $1.4 input / $0.26 cached input / $4.4 output per 1M tokens ([pricing](https://docs.z.ai/guides/overview/pricing), read 2026-08-20). It is text-only, which is exactly what this path serves.

## Not a contract change

No enum value is added or removed. `PROVIDER_MODELS.zai` stays `["glm-flash", "glm-pro"]`, and every caller sending `provider: "zai", model: "glm-pro"` keeps working unchanged. What moves is internal: the vendor model id (`glm-5.2` → `glm-5.3`) and the cost prefix (`zai-glm-5.2` → `zai-glm-5.3`).

GLM-5.2 becomes unreachable. Reaching it again would be a deliberate fourth alias plus its own three catalog rows, not a fallback.

## ⚠️ Deployment ordering — this PR is a DRAFT on purpose

The cost prefix is byte-equal to the costs-service catalog row. Until `zai-glm-5.3-tokens-input`, `-tokens-cached-input` and `-tokens-output` are live in **production**, runs-service 422s the declaration and every `glm-pro` call fails loud.

A costs-service workspace is seeding and promoting those rows. This PR is marked ready only once they resolve in prod.

## Tests

- `resolveModel("zai", "glm-pro")` → `glm-5.3` / `zai-glm-5.3`, and `costPrefixForModel("glm-5.3")` → `zai-glm-5.3`.
- The `/complete` cost-declaration integration suite asserts the wire model and the three `zai-glm-5.3-tokens-*` names, including the cached-input split.
- 933 unit tests green; the changed integration file (23 tests) green against a local database.
