### PR TITLE
fix(audience-editor): verbatim user wording, confirm before spending, no auto-activate

### DIFF
--- a/README.md
+++ b/README.md
@@ -961,6 +961,8 @@ Read-only and supporting workflow tools:
 | `refresh_audience_count` | Re-snapshots apollo + apify match counts via the free live dry-run. `POST /v1/orgs/audiences/:id/refresh-count` |
 | `generate_audience_avatar` | (Re)generates the audience's avatar image. Optional `prompt` steers the image; omit to derive it from the audience's descriptors. ORG-BILLED (forwards `x-user-id` like `refresh_audience_count`). Returns the updated audience with its new `avatarUrl`. `POST /v1/orgs/audiences/:id/avatar` |
 
+**Audience-editor prompt contract (self-seeded, `src/lib/seed-platform-configs.ts`):** the assistant sends the user's description to `suggest_audiences` **verbatim, in the user's own language** — no translation, no paraphrase, no added categories. The downstream audience builder reads plain natural language in any language and searches best in the market's own words (German `Drogerie` reaches Swiss drugstores that `drugstore` does not), so every rewrite is a lossy hop. It must confirm the exact search wording with the user before calling `suggest_audiences` (real spend, real audience row), and it never activates a candidate on its own — `set_audience_status` is called only when the user explicitly asks.
+
 **Funnel tools** (full end-to-end platform operation — take the brand/campaign id explicitly, so they work in a brand-less onboarding session; all route through api-service with the forwarded identity, so the underlying op is org-billed by the owning service — chat-service adds no cost of its own):
 
 | Tool | Description |

--- a/src/lib/seed-platform-configs.ts
+++ b/src/lib/seed-platform-configs.ts
@@ -93,7 +93,20 @@ Your tools:
 - refresh_audience_count — re-snapshot an audience's apollo + apify match counts when the user asks to refresh/recompute its size.
 - generate_audience_avatar — (re)generate an audience's avatar image. Use it when the user asks to create, regenerate, or change an audience's avatar / picture / image. Pass an optional prompt to steer the image; omit it to derive the image from the audience's descriptors.
 
-How to create an audience: call suggest_audiences with the user's description, show the returned candidates (name, who they target, count), and when the user picks one, call set_audience_status with its audienceId and status 'active'. Do not stop at suggest_audiences when the user clearly wants the audience created — activate it.
+How to create an audience:
+1. Restate, in the user's OWN WORDS, the exact description you are about to search for, and ask them to confirm or correct it. Searching costs the user real money and creates a real audience, so this confirmation is mandatory — never call suggest_audiences before the user has agreed to the wording.
+2. Once confirmed, call suggest_audiences with that description passed through VERBATIM.
+3. Show the returned candidates (name, who they target, count) and stop there. Do NOT activate anything on your own.
+4. Activate ONLY when the user explicitly asks for it: call set_audience_status with the chosen audienceId and status 'active'.
+
+Pass the user's description through VERBATIM (HARD RULES — never violate, even if it feels helpful):
+- Send the user's own wording, in the USER'S OWN LANGUAGE. Never translate it — not into English, not into any other language.
+- Never paraphrase, "clean up", reword, or expand it with synonyms, related categories, or example job titles.
+- NEVER add a category, industry, or business type the user did not name. Adding one is the single most damaging thing you can do here: it can dominate the resulting audience with people the user never asked for.
+- Why this matters: the downstream audience builder reads plain natural language directly, in any language, and searches best in the market's own language. Local words reach businesses their English translations do not (German "Drogerie" finds far more Swiss drugstores than "drugstore" does). Every rewrite is a lossy hop that loses reach.
+- If the request is genuinely ambiguous, ASK the user to clarify. Never resolve an ambiguity by inventing wording on their behalf.
+
+Never call the same tool twice with the same input. A tool result is final — re-read the result you already have instead of re-issuing the call to "confirm" it. This is especially true for suggest_audiences (it spends money) and set_audience_status (already applied).
 
 How to "edit" an audience's filters: filters can't be edited in place. When the user wants different targeting, suggest a new audience with the corrected description and (if they want the old one gone) archive the original with set_audience_status.
 

--- a/tests/unit/persona-brand-profile-configs.test.ts
+++ b/tests/unit/persona-brand-profile-configs.test.ts
@@ -120,6 +120,32 @@ describe("self-seeded platform configs", () => {
     expect(audienceTools.some((t) => /delete|destroy|remove/.test(t))).toBe(false);
   });
 
+  it("audience-editor prompt passes the user's wording through and never auto-activates", () => {
+    const prompt = AUDIENCE_EDITOR_CONFIG.systemPrompt;
+    // 1. Verbatim pass-through, in the user's own language, with the reason stated.
+    expect(prompt).toContain("VERBATIM");
+    expect(prompt).toContain("USER'S OWN LANGUAGE");
+    expect(prompt).toContain("Never translate");
+    expect(prompt).toContain("Drogerie");
+    // 2. No invented categories.
+    expect(prompt).toContain(
+      "NEVER add a category, industry, or business type the user did not name",
+    );
+    // 3. Confirmation gate before spending.
+    expect(prompt).toContain(
+      "never call suggest_audiences before the user has agreed to the wording",
+    );
+    // 4. The auto-activate instruction is GONE — activation is user-requested only.
+    expect(prompt).not.toContain("Do not stop at suggest_audiences");
+    expect(prompt).not.toContain("when the user clearly wants the audience created");
+    expect(prompt).toContain("Do NOT activate anything on your own");
+    expect(prompt).toContain(
+      "Activate ONLY when the user explicitly asks for it",
+    );
+    // 5. No redundant duplicate tool invocation.
+    expect(prompt).toContain("Never call the same tool twice with the same input");
+  });
+
   it("brand-profile-editor exposes the website refresh tool and prompt guard", () => {
     expect(BRAND_PROFILE_EDITOR_CONFIG.allowedTools).toContain(
       "refresh_brand_profile_from_website",


### PR DESCRIPTION
## Problem

A real customer session produced an audience wrong on **96% of its volume**.

Customer typed (French, verbatim):
> "Laudience cest tous les drogarian et bio shops en suisse allemande. Toutes les personnes pertinentes de ces eneignes"

Assistant sent to `suggest_audiences`:
> "Key decision makers and staff at drugstores (Drogerien), organic stores (Bio-Läden / Reformhäuser), and health shops in German-speaking Switzerland"

Translated to English and **added `pharmacy`**, never requested. Resulting 1,218-person audience:

| Keyword tag | People |
|---|---|
| `organic` | 804 |
| `pharmacy` | 432 (never requested) |
| `drugstore` | 44 ← the actual target |

In Apollo, German `drogerie` matches 429 people and `drogerien` 196; English `drugstore` matches 44. The translation dropped the only terms that reach this market. The audience then went straight to `active` without review, because the prompt told it to.

## Changes (all in `AUDIENCE_EDITOR_SYSTEM_PROMPT`)

1. **Verbatim pass-through.** The user's own wording, in the user's own language, goes to `suggest_audiences` unchanged. No translation, no paraphrase, no synonym expansion, and never a category the user did not name. The reason is stated in the prompt: the downstream builder reads plain natural language in any language and searches best in the market's own words, so every rewrite is a lossy hop. Ambiguity is resolved by asking the user.
2. **Confirm before spending.** The exact search wording is restated and confirmed with the user before `suggest_audiences` is called. Real spend, real audience row, and the only point where a divergence is catchable.
3. **Auto-activate deleted.** The sentence "Do not stop at suggest_audiences when the user clearly wants the audience created — activate it." is gone. Activation happens only on the user's explicit request.
4. **No duplicate calls.** Both `suggest_audiences` and `set_audience_status` were invoked twice with identical inputs in that session. Explicit rule added against re-issuing a call to "confirm" a result already in hand.

## Not changed

Tool list, tool schemas, model (`google`/`flash-pro`), sibling configs, downstream services. No keyword/category opinions added.

## Tests

`tests/unit/persona-brand-profile-configs.test.ts` gains one assertion per invariant, including a negative assertion that the auto-activate sentence is absent. Full unit suite green (1008 tests, 76 files); `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
